### PR TITLE
Add agentUUID in ApplicationInstance

### DIFF
--- a/apm-network/src/main/proto/DiscoveryService.proto
+++ b/apm-network/src/main/proto/DiscoveryService.proto
@@ -20,7 +20,8 @@ service InstanceDiscoveryService {
 
 message ApplicationInstance {
     int32 applicationId = 1;
-    int64 registerTime = 2;
+    string agentUUID = 2;
+    int64 registerTime = 3;
 }
 
 message ApplicationInstanceMapping {


### PR DESCRIPTION
**agentUUID** is generated by agent mechanism, right now which is `UUID()`.

To allow that applicationInstanceId generation mechanism returns the ID asynchronous.

cc @ascrutae 