### PR TITLE
Add unit test for ConsumerPoolFactory, EnvUtil

### DIFF
--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/EnvUtil.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/EnvUtil.java
@@ -42,7 +42,7 @@ public class EnvUtil {
         String envValue = System.getenv(envName);
         if (envValue != null) {
             try {
-                value = Integer.parseInt(envValue);
+                value = Long.parseLong(envValue);
             } catch (NumberFormatException e) {
 
             }

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/EnvUtilTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/EnvUtilTest.java
@@ -1,0 +1,58 @@
+package org.apache.skywalking.apm.commons.datacarrier;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author flycash
+ * 2019-04-20
+ */
+public class EnvUtilTest {
+
+    private Map<String, String> writableEnv;
+    @Before
+    public void before() {
+        try {
+            Map<String, String> env = System.getenv();
+            Class<?> cl = env.getClass();
+            Field field = cl.getDeclaredField("m");
+            field.setAccessible(true);
+            writableEnv = (Map<String, String>) field.get(env);
+            writableEnv.put("myInt", "123");
+            writableEnv.put("wrongInt", "wrong123");
+            writableEnv.put("myLong", "12345678901234567");
+            writableEnv.put("wrongLong", "wrong123");
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to set environment variable", e);
+        }
+    }
+
+    @Test
+    public void getInt() {
+        assertEquals(123, EnvUtil.getInt("myInt", 234));
+        assertEquals(234, EnvUtil.getLong("wrongInt", 234));
+    }
+
+    @Test
+    public void getLong() {
+        assertEquals(12345678901234567L, EnvUtil.getLong("myLong", 123L));
+        assertEquals(987654321987654321L, EnvUtil.getLong("wrongLong", 987654321987654321L));
+    }
+
+    @After
+    public void after() {
+        writableEnv.remove("myInt");
+        writableEnv.remove("wrongInt");
+        writableEnv.remove("myLong");
+        writableEnv.remove("wrongLong");
+        assertNull(System.getenv("myInt"));
+    }
+
+
+}

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/EnvUtilTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/EnvUtilTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.apache.skywalking.apm.commons.datacarrier;
 
 import org.junit.After;
@@ -10,7 +28,7 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 /**
- * @author flycash
+ * @author dengming
  * 2019-04-20
  */
 public class EnvUtilTest {

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerPoolFactoryTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerPoolFactoryTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.apache.skywalking.apm.commons.datacarrier.consumer;
 
 import org.junit.Before;
@@ -6,7 +24,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
- * @author flycash
+ * @author dengming
  * 2019-04-20
  */
 public class ConsumerPoolFactoryTest {

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerPoolFactoryTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerPoolFactoryTest.java
@@ -1,0 +1,32 @@
+package org.apache.skywalking.apm.commons.datacarrier.consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author flycash
+ * 2019-04-20
+ */
+public class ConsumerPoolFactoryTest {
+
+    @Before
+    public void createIfAbsent() throws Exception {
+        BulkConsumePool.Creator creator = new BulkConsumePool.Creator("my-test-pool", 10, 20);
+        boolean firstCreated = ConsumerPoolFactory.INSTANCE.createIfAbsent("my-test-pool", creator);
+        assertTrue(firstCreated);
+
+        boolean secondCreated = ConsumerPoolFactory.INSTANCE.createIfAbsent("my-test-pool", creator);
+        assertTrue(!secondCreated);
+    }
+
+    @Test
+    public void get() {
+        ConsumerPool consumerPool = ConsumerPoolFactory.INSTANCE.get("my-test-pool");
+        assertNotNull(consumerPool);
+
+        ConsumerPool notExist = ConsumerPoolFactory.INSTANCE.get("not-exists-pool");
+        assertNull(notExist);
+    }
+}


### PR DESCRIPTION
1. Add unit test for ConsumerPoolFactory, EnvUtil
2. fix the bug that Env.getLong invoking the Integer.parseInt;

Please answer these questions before submitting pull request

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance
- [X] Add Tests
- Related issues

___
### Bug fix
- Bug description.
org.apache.skywalking.apm.commons.datacarrier.EnvUtil#getLong method using Integer.parseInt to
parse the String to Integer and then return as long
- How to fix?
Using Long.parseLong
___
### New feature or improvement
- Describe the details and related test reports.
