### PR TITLE
Make the documents matching Top Level Project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,14 +22,14 @@ for us to fix.
 
 ## How to report a bug?
 
-* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/apache/incubator-skywalking/issues).
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/apache/skywalking/issues).
 
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/apache/incubator-skywalking/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/apache/skywalking/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
 
 ## How to add a new feature or change an existing one
 
-_Before making any significant changes, please [open an issue](https://github.com/apache/incubator-skywalking/issues)._ Discussing your proposed changes ahead of time will make the contribution process smooth for everyone.
+_Before making any significant changes, please [open an issue](https://github.com/apache/skywalking/issues)._ Discussing your proposed changes ahead of time will make the contribution process smooth for everyone.
 
 Once we've discussed your changes and you've got your code ready, make sure that tests are passing and open your pull request. Your PR is most likely to be accepted if it:
 
@@ -40,4 +40,4 @@ Once we've discussed your changes and you've got your code ready, make sure that
 
 ## Do you have questions about the source code?
 
-Ask any question about how to use SkyWalking in the [Gitter](https://gitter.im/OpenSkywalking/Lobby).
+* Join `#skywalking` channel at [Apache Slack](https://join.slack.com/t/the-asf/shared_invite/enQtNDQ3OTEwNzE1MDg5LWY2NjkwMTEzMGI2ZTI1NzUzMDk0MzJmMWM1NWVmODg0MzBjNjAxYzUwMjIwNDI3MjlhZWRjNmNhOTM5NmIxNDk)

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,5 +1,0 @@
-Apache SkyWalking (incubating) is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-Incubation is required of all newly accepted projects until a further review indicates 
-that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. 
-While incubation status is not necessarily a reflection of the completeness or stability of the code, 
-it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ microservices, cloud native and container-based (Docker, Kubernetes, Mesos) arch
 
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.skywalking/apache-skywalking-apm-incubating.svg)](http://skywalking.apache.org/downloads/)
-[![Build Status](https://travis-ci.org/apache/incubator-skywalking.svg?branch=master)](https://travis-ci.org/apache/incubator-skywalking)
-[![Join the chat at https://gitter.im/sky-walking/Lobby](https://badges.gitter.im/openskywalking/Lobby.svg)](https://gitter.im/openskywalking/Lobby)
-[![OpenTracing-1.x Badge](https://img.shields.io/badge/OpenTracing--1.x-enabled-blue.svg)](http://opentracing.io)
+[![Build Status](https://travis-ci.org/apache/skywalking.svg?branch=master)](https://travis-ci.org/apache/incubator-skywalking)
 
 # Abstract
 **SkyWalking** is an open source APM system, including monitoring, tracing, diagnosing capabilities for distributed system
@@ -108,9 +106,6 @@ SkyWalking enriches the <a href="https://landscape.cncf.io/landscape=observabili
 <a href="https://openapm.io"><img src="https://openapm.io/static/media/openapm_logo.svg" width="100"/></a>
   <br/>Our project enriches the <a href="https://openapm.io">OpenAPM Landscape!</a>
 </p>
-
-# Stargazers over time
-[![Stargazers over time](https://starcharts.herokuapp.com/apache/incubator-skywalking.svg)](https://starcharts.herokuapp.com/apache/incubator-skywalking)
 
 # License
 [Apache 2.0 License.](/LICENSE)

--- a/apm-dist/pom.xml
+++ b/apm-dist/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>apache-skywalking-apm-incubating</artifactId>
+    <artifactId>apache-skywalking-apm</artifactId>
     <packaging>pom</packaging>
 
     <profiles>
@@ -72,7 +72,7 @@
     </profiles>
 
     <build>
-        <finalName>apache-skywalking-apm-incubating-bin</finalName>
+        <finalName>apache-skywalking-apm-bin</finalName>
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -105,11 +105,11 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <copy file="${project.build.directory}/apache-skywalking-apm-incubating-bin.tar.gz"
-                                      tofile="${project.basedir}/../dist/apache-skywalking-apm-incubating-bin.tar.gz"
+                                <copy file="${project.build.directory}/apache-skywalking-apm-bin.tar.gz"
+                                      tofile="${project.basedir}/../dist/apache-skywalking-apm-bin.tar.gz"
                                       overwrite="true"/>
-                                <copy file="${project.build.directory}/apache-skywalking-apm-incubating-bin.zip"
-                                      tofile="${project.basedir}/../dist/apache-skywalking-apm-incubating-bin.zip"
+                                <copy file="${project.build.directory}/apache-skywalking-apm-bin.zip"
+                                      tofile="${project.basedir}/../dist/apache-skywalking-apm-bin.zip"
                                       overwrite="true"/>
                             </tasks>
                         </configuration>

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -18,12 +18,12 @@ export DOCKER_ROOT := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 oap: 
 	cd $(DOCKER_ROOT)/oap; \
-	cp ../../dist/apache-skywalking-apm-incubating-bin.tar.gz ./ ; \
+	cp ../../dist/apache-skywalking-apm-bin.tar.gz ./ ; \
 	docker build -t skywalking/oap:latest .
 
 ui:
 	cd $(DOCKER_ROOT)/ui; \
-	cp ../../dist/apache-skywalking-apm-incubating-bin.tar.gz ./ ; \
+	cp ../../dist/apache-skywalking-apm-bin.tar.gz ./ ; \
 	docker build -t skywalking/ui:latest .
 
 build: oap ui

--- a/docker/oap/Dockerfile
+++ b/docker/oap/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM openjdk:8u181-jdk-stretch
 
-ENV DIST_NAME=apache-skywalking-apm-incubating-bin \
+ENV DIST_NAME=apache-skywalking-apm-bin \
     JAVA_OPTS=" -Xms256M "
 
 COPY "$DIST_NAME.tar.gz" /

--- a/docs/en/guides/How-to-release.md
+++ b/docs/en/guides/How-to-release.md
@@ -32,7 +32,7 @@ Use the following block as a template and place it in ~/.m2/settings.xml
 ```
 
 ## Add your GPG public key
-1. Add your GPG public key into [SkyWalking GPG KEYS](https://dist.apache.org/repos/dist/release/incubator/skywalking/KEYS) file,
+1. Add your GPG public key into [SkyWalking GPG KEYS](https://dist.apache.org/repos/dist/release/skywalking/KEYS) file,
 only if you are a committer, use your Apache id and password login this svn, and update file. **Don't override the existing file.**
 1. Upload your GPG public key to public GPG site. Such as [MIT's site](http://pgp.mit.edu:11371/). This site should be in 
 Apache maven staging repository check list.
@@ -77,7 +77,7 @@ This scripts should do following things
 1. Do `gpg` and `shasum 512`. 
 
 
-The `apache-skywalking-apm-incubating-x.y.z-src.tgz` should be found in `tools/releasing` folder,
+The `apache-skywalking-apm-x.y.z-src.tgz` should be found in `tools/releasing` folder,
 with .asc, .sha512.
 
 ## Find and download distribution in Apache Nexus Staging repositories
@@ -86,18 +86,18 @@ with .asc, .sha512.
 1. Search `skywalking` and find your staging repository
 1. Close the repository and wait for all checks pass. In this step, your GPG KEYS will be checked. See [set PGP document](#add-your-gpg-public-key),
 if you haven't done it before.
-1. Go to `{REPO_URL}/org/apache/skywalking/apache-skywalking-apm-incubating/x.y.z`
+1. Go to `{REPO_URL}/org/apache/skywalking/apache-skywalking-apm/x.y.z`
 1. Download `.tar.gz` and `.zip` with .asc and .sha1
 
 
 ## Upload to Apache svn
-1. Use ApacheId to login `https://dist.apache.org/repos/dist/dev/incubator/skywalking/`
+1. Use ApacheId to login `https://dist.apache.org/repos/dist/dev/skywalking/`
 1. Create folder, named by release version and round, such as: x.y.z
 1. Upload Source code package to the folder with .asc, .sha512
-    * Package name: apache-skywalking-incubating-x.y.z-src.tar.gz
+    * Package name: apache-skywalking-x.y.z-src.tar.gz
     * See Section "Build and sign the source code package" for more details 
 1. Upload distribution package to the folder with .asc, .sha512
-    * Package name: apache-skywalking-incubating-bin-x.y.z.tar.gz, apache-skywalking-incubating-bin-x.y.z.zip
+    * Package name: apache-skywalking-bin-x.y.z.tar.gz, apache-skywalking-bin-x.y.z.zip
     * See Section "Find and download distribution in Apache Nexus Staging repositories" for more details
     * Create .sha512 package: `shasum -a 512 file > file.sha512`
 
@@ -116,15 +116,15 @@ account if a quality vote is called for this build.
 
 Release notes:
 
- * https://github.com/apache/incubator-skywalking/blob/master/CHANGES.md
+ * https://github.com/apache/skywalking/blob/master/CHANGES.md
 
 Release Candidate:
 
- * https://dist.apache.org/repos/dist/dev/incubator/skywalking/xxxx
+ * https://dist.apache.org/repos/dist/dev/skywalking/xxxx
  * sha512 checksums
-   - sha512xxxxyyyzzz apache-skywalking-apm-incubating-x.x.x-src.tgz
-   - sha512xxxxyyyzzz apache-skywalking-apm-incubating-bin-x.x.x.tar.gz
-   - sha512xxxxyyyzzz apache-skywalking-apm-incubating-bin-x.x.x.zip
+   - sha512xxxxyyyzzz apache-skywalking-apm-x.x.x-src.tgz
+   - sha512xxxxyyyzzz apache-skywalking-apm-bin-x.x.x.tar.gz
+   - sha512xxxxyyyzzz apache-skywalking-apm-bin-x.x.x.zip
 
 Maven 2 staging repository:
 
@@ -136,11 +136,11 @@ Release Tag :
 
 Release CommitID :
 
- * https://github.com/apache/incubator-skywalking/tree/(Git Commit ID)
+ * https://github.com/apache/skywalking/tree/(Git Commit ID)
  * Git submodule
-   * skywalking-ui: https://github.com/apache/incubator-skywalking-ui/tree/(Git Commit ID)
-   * apm-protocol/apm-network/src/main/proto: https://github.com/apache/incubator-skywalking-data-collect-protocol/tree/(Git Commit ID)
-   * oap-server/server-query-plugin/query-graphql-plugin/src/main/resources/query-protocol https://github.com/apache/incubator-skywalking-query-protocol/tree/(Git Commit ID)
+   * skywalking-ui: https://github.com/apache/skywalking-ui/tree/(Git Commit ID)
+   * apm-protocol/apm-network/src/main/proto: https://github.com/apache/skywalking-data-collect-protocol/tree/(Git Commit ID)
+   * oap-server/server-query-plugin/query-graphql-plugin/src/main/resources/query-protocol https://github.com/apache/skywalking-query-protocol/tree/(Git Commit ID)
 
 Keys to verify the Release Candidate :
 
@@ -148,37 +148,37 @@ Keys to verify the Release Candidate :
 
 Guide to build the release from source :
 
- * https://github.com/apache/incubator-skywalking/blob/x.y.z/docs/en/guides/How-to-build.md
+ * https://github.com/apache/skywalking/blob/x.y.z/docs/en/guides/How-to-build.md
 
 A vote regarding the quality of this test build will be initiated
 within the next couple of days.
 ```
 
 ## Wait at least 48 hours for test responses
-Any PPMC, committer or contributor can test features for releasing, and feedback.
-Based on that, PPMC will decide whether start a vote.
+Any PMC, committer or contributor can test features for releasing, and feedback.
+Based on that, PMC will decide whether start a vote.
 
 ## Call a vote in dev
 Call a vote in `dev@skywalking.apache.org`
 
 ```
-Mail title: [VOTE] Release Apache SkyWalking (incubating) version x.y.z
+Mail title: [VOTE] Release Apache SkyWalking version x.y.z
 
 Mail content:
 Hi All,
-This is a call for vote to release Apache SkyWalking (Incubating) version x.y.z.
+This is a call for vote to release Apache SkyWalking version x.y.z.
 
 Release notes:
 
- * https://github.com/apache/incubator-skywalking/blob/x.y.z/CHANGES.md
+ * https://github.com/apache/skywalking/blob/x.y.z/CHANGES.md
 
 Release Candidate:
 
- * https://dist.apache.org/repos/dist/dev/incubator/skywalking/xxxx
+ * https://dist.apache.org/repos/dist/dev/skywalking/xxxx
  * sha512 checksums
-   - sha512xxxxyyyzzz apache-skywalking-apm-incubating-x.x.x-src.tgz
-   - sha512xxxxyyyzzz apache-skywalking-apm-incubating-bin-x.x.x.tar.gz
-   - sha512xxxxyyyzzz apache-skywalking-apm-incubating-bin-x.x.x.zip
+   - sha512xxxxyyyzzz apache-skywalking-apm-x.x.x-src.tgz
+   - sha512xxxxyyyzzz apache-skywalking-apm-bin-x.x.x.tar.gz
+   - sha512xxxxyyyzzz apache-skywalking-apm-bin-x.x.x.zip
 
 Maven 2 staging repository:
 
@@ -190,11 +190,11 @@ Release Tag :
 
 Release CommitID :
 
- * https://github.com/apache/incubator-skywalking/tree/(Git Commit ID)
+ * https://github.com/apache/skywalking/tree/(Git Commit ID)
  * Git submodule
-   * skywalking-ui: https://github.com/apache/incubator-skywalking-ui/tree/(Git Commit ID)
-   * apm-protocol/apm-network/src/main/proto: https://github.com/apache/incubator-skywalking-data-collect-protocol/tree/(Git Commit ID)
-   * oap-server/server-query-plugin/query-graphql-plugin/src/main/resources/query-protocol https://github.com/apache/incubator-skywalking-query-protocol/tree/(Git Commit ID)
+   * skywalking-ui: https://github.com/apache/skywalking-ui/tree/(Git Commit ID)
+   * apm-protocol/apm-network/src/main/proto: https://github.com/apache/skywalking-data-collect-protocol/tree/(Git Commit ID)
+   * oap-server/server-query-plugin/query-graphql-plugin/src/main/resources/query-protocol https://github.com/apache/skywalking-query-protocol/tree/(Git Commit ID)
 
 Keys to verify the Release Candidate :
 
@@ -202,148 +202,55 @@ Keys to verify the Release Candidate :
 
 Guide to build the release from source :
 
- * https://github.com/apache/incubator-skywalking/blob/x.y.z/docs/en/guides/How-to-build.md
+ * https://github.com/apache/skywalking/blob/x.y.z/docs/en/guides/How-to-build.md
 
-Voting will start now (xxxx date) and will remain open for at least 72 hours, Request all PPMC members to give their vote.
+Voting will start now (xxxx date) and will remain open for at least 72 hours, Request all PMC members to give their vote.
 [ ] +1 Release this package.
 [ ] +0 No opinion.
 [ ] -1 Do not release this package because....
 ```
 
 ## Vote Check
-All PPMC members and committers should check these before vote +1.
+All PMC members and committers should check these before vote +1.
 
 1. Features test.
 1. All artifacts in staging repository are published with .asc, .md5, *sha1 files
-1. Source code and distribution package (apache-skywalking-incubating-x.y.z-src.tar.gz, apache-skywalking-incubating-bin-x.y.z.tar.gz, apache-skywalking-incubating-bin-x.y.z.zip)
-are in `https://dist.apache.org/repos/dist/dev/incubator/skywalking/x.y.z` with .asc, .sha512
+1. Source code and distribution package (apache-skywalking-x.y.z-src.tar.gz, apache-skywalking-bin-x.y.z.tar.gz, apache-skywalking-bin-x.y.z.zip)
+are in `https://dist.apache.org/repos/dist/dev/skywalking/x.y.z` with .asc, .sha512
 1. `LICENSE` and `NOTICE` are in Source code and distribution package.
-1. Check `shasum -c apache-skywalking-apm-incubating-x.y.z-src.tgz.sha512`
-1. Build distribution from source code package (apache-skywalking-incubating-x.y.z-src.tar.gz) by following this [doc](https://github.com/apache/incubator-skywalking/blob/master/docs/en/guides/How-to-build.md#build-from-apache-source-code-release).
+1. Check `shasum -c apache-skywalking-apm-x.y.z-src.tgz.sha512`
+1. Build distribution from source code package (apache-skywalking-x.y.z-src.tar.gz) by following this [doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/How-to-build.md#build-from-apache-source-code-release).
 1. Apache RAT check. Run `./mvnw apache-rat:check`. (No binary in source codes)
-1. DISCLAIMER exists
+
 
 Vote result should follow these.
-1. PPMC vote is +1 binding, all others is +1 no binding.
+1. PMC vote is +1 binding, all others is +1 no binding.
 1. In 72 hours, you get at least 3 (+1 binding), and have more +1 than -1. Vote pass. 
 
-## Call for a vote in Apache IPMC
-Call a vote in `general@incubator.apache.org`
-
-```
-Mail title: [VOTE] Release Apache SkyWalking (incubating) version x.y.z
-
-Mail content:
-Hi All,
-This is a call for vote to release Apache SkyWalking (Incubating) version x.y.z.
-
-The Apache SkyWalking community has tested, voted and approved the proposed
-release of Apache SkyWalking (Incubating) x.y.z
-
-We now kindly request the Incubator PMC members review and vote on this
-incubator release.
-
-SkyWalking: APM (application performance monitor) tool for distributed systems, 
-especially designed for microservices, cloud native and container-based (Docker, Kubernetes, Mesos) architectures. 
-Underlying technology is a distributed tracing system.
-
-Vote Thread:
-
- * From `list.apache.org`
-
-Result Thread:
-
- * From the vote thread.
-
-Release notes:
-
- * https://github.com/apache/incubator-skywalking/blob/x.y.z/CHANGES.md
-
-Release Candidate:
-
- * https://dist.apache.org/repos/dist/dev/incubator/skywalking/xxxx
- * sha512 checksums
-   - sha512xxxxyyyzzz apache-skywalking-apm-incubating-x.x.x-src.tgz
-   - sha512xxxxyyyzzz apache-skywalking-apm-incubating-bin-x.x.x.tar.gz
-   - sha512xxxxyyyzzz apache-skywalking-apm-incubating-bin-x.x.x.zip
-
-Maven 2 staging repository:
-
- * https://repository.apache.org/content/repositories/xxxx/org/apache/skywalking/
-
-Release Tag :
-
- * (Git Tag) x.y.z
-
-Release CommitID :
-
- * https://github.com/apache/incubator-skywalking/tree/(Git Commit ID)
- * Git submodule
-   * skywalking-ui: https://github.com/apache/incubator-skywalking-ui/tree/(Git Commit ID)
-   * apm-protocol/apm-network/src/main/proto: https://github.com/apache/incubator-skywalking-data-collect-protocol/tree/(Git Commit ID)
-   * oap-server/server-query-plugin/query-graphql-plugin/src/main/resources/query-protocol https://github.com/apache/incubator-skywalking-query-protocol/tree/(Git Commit ID)
-
-Keys to verify the Release Candidate :
-
- * http://pgp.mit.edu:11371/pks/lookup?op=get&search=0x2EF5026E70A55777 corresponding to pengys@apache.org
-
-Guide to build the release from source :
-
- * https://github.com/apache/incubator-skywalking/blob/x.y.z/docs/en/guides/How-to-build.md
-
-Voting will start now (xxxx date) and will remain open for at least 72 hours, Request IPMC to give their vote.
-[ ] +1 Release this package.
-[ ] +0 No opinion.
-[ ] -1 Do not release this package because....
-```
-
-## Vote result mail
-Close the vote, if
-1. In 72 hours, you got at least 3 (+1 binding), and have more +1 than -1. Vote pass. In IPMC vote, only Incubator project PMC
-vote would be considered as +1 binding.
-1. Some reviewers found some serious mistakes in this release, the team could decide to cancel vote and prepare a new RC.
-
-Send a mail to `general@incubator.apache.org` about vote result and status.
-```
-Mail title: [Result][VOTE] Release Apache SkyWalking (incubating) version x.y.z
-
-Mail content:
-Hi all,
-
-The vote for releasing Apache SkyWalking x.y.z (incubating) is closed, now.
-
-Vote result:
-x (+1 binding) (Names of voters)
-y -1.
-
-Thank you everyone for taking the time to review the release and help us. 
-
-I will process to publish the release and send ANNOUNCE.
-```
 
 ## Publish release
-1. Move source codes tar balls and distributions to `https://dist.apache.org/repos/dist/release/incubator/skywalking/`.
+1. Move source codes tar balls and distributions to `https://dist.apache.org/repos/dist/release/skywalking/`.
 ```
 > export SVN_EDITOR=vim
-> svn mv https://dist.apache.org/repos/dist/dev/incubator/skywalking/x.y.z https://dist.apache.org/repos/dist/release/incubator/skywalking
+> svn mv https://dist.apache.org/repos/dist/dev/skywalking/x.y.z https://dist.apache.org/repos/dist/release/skywalking
 ....
 enter your apache password
 ....
 
 ```
 2. Do release in nexus staging repo.
-3. Public download source and distribution tar/zip locate in `http://www.apache.org/dyn/closer.cgi/incubator/skywalking/x.y.z/xxx`.
+3. Public download source and distribution tar/zip locate in `http://www.apache.org/dyn/closer.cgi/skywalking/x.y.z/xxx`.
 We only publish Apache mirror path as release info.
-4. Public asc and sha512 locate in `https://www.apache.org/dist/incubator/skywalking/x.y.z/xxx`
-5. Public KEYS pointing to  `https://www.apache.org/dist/incubator/skywalking/KEYS`
-6. Send ANNOUNCE mail to `general@incubator.apache.org` and `dev@skywalking.apache.org`.
+4. Public asc and sha512 locate in `https://www.apache.org/dist/skywalking/x.y.z/xxx`
+5. Public KEYS pointing to  `https://www.apache.org/dist/skywalking/KEYS`
+6. Send ANNOUNCE mail to `dev@skywalking.apache.org`.
 ```
-Mail title: [ANNOUNCE] Release Apache SkyWalking (incubating) version x.y.z
+Mail title: [ANNOUNCE] Release Apache SkyWalking version x.y.z
 
 Mail content:
 Hi all,
 
-Apache SkyWalking (incubating) Team is glad to announce the first release of Apache SkyWalking Incubating x.y.z.
+Apache SkyWalking  Team is glad to announce the first release of Apache SkyWalking Incubating x.y.z.
 
 SkyWalking: APM (application performance monitor) tool for distributed systems, 
 especially designed for microservices, cloud native and container-based (Docker, Kubernetes, Mesos) architectures. 
@@ -352,30 +259,17 @@ Vote Thread:
 
 Download Links : http://skywalking.apache.org/downloads/
 
-Release Notes : https://github.com/apache/incubator-skywalking/blob/x.y.z/CHANGES.md
+Release Notes : https://github.com/apache/skywalking/blob/x.y.z/CHANGES.md
 
 Website: http://skywalking.apache.org/
 
 SkyWalking Resources:
-- Issue: https://github.com/apache/incubator-skywalking/issues
-- Mailing list: dev@skywalkiing.incubator.apache.org
-- Documents: https://github.com/apache/incubator-skywalking/blob/x.y.z/docs/README.md
+- Issue: https://github.com/apache/skywalking/issues
+- Mailing list: dev@skywalkiing.apache.org
+- Documents: https://github.com/apache/skywalking/blob/x.y.z/docs/README.md
 
 
-- Apache SkyWalking (incubating) Team
-
-=====
-*Disclaimer*
-
-Apache SkyWalking (incubating) is an effort undergoing incubation at The
-Apache Software Foundation (ASF), sponsored by the name of Apache
-Incubator PMC. Incubation is required of all newly accepted
-projects until a further review indicates that the
-infrastructure, communications, and decision making process have
-stabilized in a manner consistent with other successful ASF
-projects. While incubation status is not necessarily a reflection
-of the completeness or stability of the code, it does indicate
-that the project has yet to be fully endorsed by the ASF.
+- Apache SkyWalking  Team
 ```
 
 7. Update website download page. http://skywalking.apache.org/downloads/ . Include new download source, distribution, sha512, asc and document

--- a/pom.xml
+++ b/pom.xml
@@ -40,18 +40,18 @@
     <packaging>pom</packaging>
 
     <name>apm</name>
-    <url>https://github.com/apache/incubator-skywalking</url>
+    <url>https://github.com/apache/skywalking</url>
 
     <scm>
-        <url>https://github.com/apache/incubator-skywalking</url>
-        <connection>scm:git:https://github.com/apache/incubator-skywalking.git</connection>
-        <developerConnection>scm:git:https://github.com/apache/incubator-skywalking.git</developerConnection>
+        <url>https://github.com/apache/skywalking</url>
+        <connection>scm:git:https://github.com/apache/skywalking.git</connection>
+        <developerConnection>scm:git:https://github.com/apache/skywalking.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/apache/incubator-skywalking/issues</url>
+        <url>https://github.com/apache/skywalking/issues</url>
     </issueManagement>
 
     <licenses>
@@ -64,15 +64,15 @@
     <mailingLists>
         <mailingList>
             <name>SkyWalking Developer List</name>
-            <post>dev@skywalking.incubator.apache.org</post>
-            <subscribe>dev-subscribe@skywalking.incubator.apache.org</subscribe>
-            <unsubscribe>dev-unsubscribe@skywalking.incubator.apache.org</unsubscribe>
+            <post>dev@skywalking.apache.org</post>
+            <subscribe>dev-subscribe@skywalking.apache.org</subscribe>
+            <unsubscribe>dev-unsubscribe@skywalking.apache.org</unsubscribe>
         </mailingList>
         <mailingList>
             <name>SkyWalking Commits</name>
-            <post>commits@skywalking.incubator.apache.org</post>
-            <subscribe>commits-subscribe@skywalking.incubator.apache.org</subscribe>
-            <unsubscribe>commits-unsubscribe@skywalking.incubator.apache.org</unsubscribe>
+            <post>commits@skywalking.apache.org</post>
+            <subscribe>commits-subscribe@skywalking.apache.org</subscribe>
+            <unsubscribe>commits-unsubscribe@skywalking.apache.org</unsubscribe>
         </mailingList>
     </mailingLists>
 
@@ -304,7 +304,6 @@
                 <configuration>
                     <excludes>
                         <exclude>**/target/**</exclude>
-                        <exclude>**/DISCLAIMER</exclude>
                         <exclude>**/licenses/**</exclude>
                         <exclude>**/ui-licenses/**</exclude>
                         <exclude>**/codeStyle.xml</exclude>
@@ -463,7 +462,7 @@
                     <dependency>
                         <groupId>org.apache.skywalking</groupId>
                         <artifactId>apm-checkstyle</artifactId>
-                        <version>5.0.0-beta</version>
+                        <version>6.0.0-GA</version>
                     </dependency>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -25,7 +25,7 @@
 
 RELEASE_VERSION=${RELEASE_VERSION}
 TAG_NAME=v${RELEASE_VERSION}
-PRODUCT_NAME="apache-skywalking-apm-incubating"
+PRODUCT_NAME="apache-skywalking-apm"
 
 echo "Release version "${RELEASE_VERSION}
 echo "Source tag "${TAG_NAME}


### PR DESCRIPTION
In this pull request, I am making sure all things matching Top Level Project, including
- Remove incubator process
- Remove `incubating`/`incubator` prefix and suffix
- Change svn path
- KEYS file has been uploaded in new svn path. https://dist.apache.org/repos/dist/release/skywalking/KEYS