### PR TITLE
Add changelog for 6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,77 @@ Changes by Version
 ==================
 Release Notes.
 
+6.1.0
+------------------
+
+#### Project
+**SkyWalking graduated as Apache Top Level Project**.
+- Support compiling project agent, backend, UI separately.
+
+#### Java Agent
+- Support Vert.x Core 3.x plugin.
+- Support Apache Dubbo plugin.
+- Support `use_qualified_name_as_endpoint_name` and `use_qualified_name_as_operation_name` configs in SpringMVC plugin.
+- Support span async close APIs in core. Used in Vert.x plugin.
+- Support MySQL 5,8 plugins.
+- Support set instance id manually(optional).
+- Support customize enhance trace plugin in optional list.
+- Support to set peer in Entry Span.
+- Support Zookeeper plugin.
+- Fix Webflux plugin created unexpected Entry Span. 
+- Fix Kafka plugin NPE in Kafka 1.1+
+- Fix wrong operation name in postgre 8.x plugin.
+- Fix RabbitMQ plugin NPE.
+- Fix agent can't run in JVM 6/7, remove `module-info.class`.
+- Fix agent can't work well, if there is whitespace in agent path.
+- Fix Spring annotation bug and inheritance enhance issue.
+- Fix CPU accessor bug.
+
+#### Backend
+**Performance improved, especially in CPU limited environment. 3x improvement in service mesh scenario(no trace) in 8C16G VM. 
+Significantly cost less CPU in low payload.**
+
+- Support database metric and SLOW SQL detection.
+- Support to set max size of metadata query. And change default to 5000 from 100.
+- Support ElasticSearch template for new feature in the future.
+- Support shutdown Zipkin trace analysis, because it doesn't fit production environment.
+- Support log type, scope HTTP_ACCESS_LOG and query. No feature provided, prepare for future  versions.
+- Support .NET clr receiver.
+- Support Jaeger trace format, no analysis.
+- Support group endpoint name by regax rules in mesh receiver.
+- Support `diable` statement in OAL.
+- Support basic auth in ElasticSearch connection.
+- Support metric exporter module and gRPC implementor.
+- Support `>, <, >=, <=` in OAL.
+- Support role mode in backend.
+- Support Envoy metric.
+- Support query segment by service instance.
+- Support to set host/port manually at cluster coordinator, rather than based on core settings.
+- Make sure OAP shutdown when it faces startup error.
+- Support set separated gRPC/Jetty ip:port for receiver, default still use core settings.
+- Fix JVM receiver bug.
+- Fix wrong dest service in mesh analysis.
+- Refactor `ScopeDeclaration` annotation.
+- Refactor register lock mechanism.
+- Add SmartSql component for .NET
+- Add integration tests for ElasticSearch client.
+- Add test cases for exporter.
+- Add test cases for queue consume.
+
+#### UI
+- RocketBot UI has been accepted and bind in this release.
+- Support CLR metric.
+
+#### Document
+- Documents updated, matching Top Level Project requirement.
+- UI licenses updated, according to RocketBot UI IP clearance.
+- User wall and powered-by list updated.
+- CN documents removed, only consider to provide by volunteer out of Apache.
+
+
+All issues and pull requests are [here](https://github.com/apache/incubator-skywalking/milestone/32?closed=1)
+
+
 6.0.0-GA
 ------------------
 


### PR DESCRIPTION
Because we were preparing graduation, 6.1 comes a little late :) But we are very close to it. Here is a very long changelog for SkyWalking 6.1, and no `incubating` anymore.

6.1.0
------------------

#### Project
**SkyWalking graduated as Apache Top Level Project**.
- Support compiling project agent, backend, UI separately.

#### Java Agent
- Support Vert.x Core 3.x plugin.
- Support Apache Dubbo plugin.
- Support `use_qualified_name_as_endpoint_name` and `use_qualified_name_as_operation_name` configs in SpringMVC plugin.
- Support span async close APIs in core. Used in Vert.x plugin.
- Support MySQL 5,8 plugins.
- Support set instance id manually(optional).
- Support customize enhance trace plugin in optional list.
- Support to set peer in Entry Span.
- Support Zookeeper plugin.
- Fix Webflux plugin created unexpected Entry Span. 
- Fix Kafka plugin NPE in Kafka 1.1+
- Fix wrong operation name in postgre 8.x plugin.
- Fix RabbitMQ plugin NPE.
- Fix agent can't run in JVM 6/7, remove `module-info.class`.
- Fix agent can't work well, if there is whitespace in agent path.
- Fix Spring annotation bug and inheritance enhance issue.
- Fix CPU accessor bug.

#### Backend
**Performance improved, especially in CPU limited environment. 3x improvement in service mesh scenario(no trace) in 8C16G VM. 
Significantly cost less CPU in low payload.**

- Support database metric and SLOW SQL detection.
- Support to set max size of metadata query. And change default to 5000 from 100.
- Support ElasticSearch template for new feature in the future.
- Support shutdown Zipkin trace analysis, because it doesn't fit production environment.
- Support log type, scope HTTP_ACCESS_LOG and query. No feature provided, prepare for future  versions.
- Support .NET clr receiver.
- Support Jaeger trace format, no analysis.
- Support group endpoint name by regax rules in mesh receiver.
- Support `diable` statement in OAL.
- Support basic auth in ElasticSearch connection.
- Support metric exporter module and gRPC implementor.
- Support `>, <, >=, <=` in OAL.
- Support role mode in backend.
- Support Envoy metric.
- Support query segment by service instance.
- Support to set host/port manually at cluster coordinator, rather than based on core settings.
- Make sure OAP shutdown when it faces startup error.
- Support set separated gRPC/Jetty ip:port for receiver, default still use core settings.
- Fix JVM receiver bug.
- Fix wrong dest service in mesh analysis.
- Refactor `ScopeDeclaration` annotation.
- Refactor register lock mechanism.
- Add SmartSql component for .NET
- Add integration tests for ElasticSearch client.
- Add test cases for exporter.
- Add test cases for queue consume.

#### UI
- RocketBot UI has been accepted and bind in this release.
- Support CLR metric.

#### Document
- Documents updated, matching Top Level Project requirement.
- UI licenses updated, according to RocketBot UI IP clearance.
- User wall and powered-by list updated.
- CN documents removed, only consider to provide by volunteer out of Apache.


All issues and pull requests are [here](https://github.com/apache/incubator-skywalking/milestone/32?closed=1)
