### PR TITLE
Fix query all scope alarm message in MySQL and H2 storage.

### DIFF
--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2AlarmQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2AlarmQueryDAO.java
@@ -45,8 +45,8 @@ public class H2AlarmQueryDAO implements IAlarmQueryDAO {
         List<Object> parameters = new ArrayList<>(10);
         sql.append("from ").append(AlarmRecord.INDEX_NAME).append(" where ");
         sql.append(" 1=1 ");
-        sql.append(" and ").append(AlarmRecord.SCOPE).append(" = ?");
         if (Objects.nonNull(scopeId)) {
+            sql.append(" and ").append(AlarmRecord.SCOPE).append(" = ?");
             parameters.add(scopeId.intValue());
         }
         if (startTB != 0 && endTB != 0) {

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/mysql/MySQLAlarmQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/mysql/MySQLAlarmQueryDAO.java
@@ -45,8 +45,8 @@ public class MySQLAlarmQueryDAO implements IAlarmQueryDAO {
         List<Object> parameters = new ArrayList<>(10);
         sql.append("from ").append(AlarmRecord.INDEX_NAME).append(" where ");
         sql.append(" 1=1 ");
-        sql.append(" and ").append(AlarmRecord.SCOPE).append(" = ?");
         if (Objects.nonNull(scopeId)) {
+            sql.append(" and ").append(AlarmRecord.SCOPE).append(" = ?");
             parameters.add(scopeId.intValue());
         }
         if (startTB != 0 && endTB != 0) {


### PR DESCRIPTION
I miss this when I fixed query all scope in ElasticSearch storage. Luckily, this is not a widely used feature, so I put this fix in 6.2, instead of keeping breaking 6.1 release.