### PR TITLE
Using PowerMockito to mock System.getent;

### DIFF
--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/EnvUtilTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/EnvUtilTest.java
@@ -18,37 +18,33 @@
 
 package org.apache.skywalking.apm.commons.datacarrier;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.lang.reflect.Field;
-import java.util.Map;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 /**
  * @author dengming
  * 2019-04-20
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(EnvUtil.class)
 public class EnvUtilTest {
 
-    private Map<String, String> writableEnv;
     @Before
     public void before() {
-        try {
-            Map<String, String> env = System.getenv();
-            Class<?> cl = env.getClass();
-            Field field = cl.getDeclaredField("m");
-            field.setAccessible(true);
-            writableEnv = (Map<String, String>) field.get(env);
-            writableEnv.put("myInt", "123");
-            writableEnv.put("wrongInt", "wrong123");
-            writableEnv.put("myLong", "12345678901234567");
-            writableEnv.put("wrongLong", "wrong123");
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to set environment variable", e);
-        }
+
+        PowerMockito.mockStatic(System.class);
+
+        when(System.getenv("myInt")).thenReturn("123");
+        when(System.getenv("wrongInt")).thenReturn("wrong123");
+        when(System.getenv("myLong")).thenReturn("12345678901234567");
+        when(System.getenv("wrongLong")).thenReturn("wrong123");
     }
 
     @Test
@@ -62,15 +58,5 @@ public class EnvUtilTest {
         assertEquals(12345678901234567L, EnvUtil.getLong("myLong", 123L));
         assertEquals(987654321987654321L, EnvUtil.getLong("wrongLong", 987654321987654321L));
     }
-
-    @After
-    public void after() {
-        writableEnv.remove("myInt");
-        writableEnv.remove("wrongInt");
-        writableEnv.remove("myLong");
-        writableEnv.remove("wrongLong");
-        assertNull(System.getenv("myInt"));
-    }
-
 
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,9 +37,9 @@ skip_commits:
     - Jenkinsfile
     # - appveyor.yml
 
-branches:
-  only:
-    - master
+# branches:
+#   only:
+#     - master
 
 install:
 - ps: $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
@@ -53,8 +53,8 @@ build_script:
 # after_build:
 # - mvnw.cmd javadoc:javadoc -Dmaven.test.skip=true
 
-# test_script:
-# - mvnw.cmd test
+test_script:
+- mvnw.cmd test
 
 cache:
   - C:\Users\appveyor\.m2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,9 +37,9 @@ skip_commits:
     - Jenkinsfile
     # - appveyor.yml
 
-# branches:
-#   only:
-#     - master
+branches:
+  only:
+    - master
 
 install:
 - ps: $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")


### PR DESCRIPTION
Now, I read the document of PowerMockito and find the way to mock system class's static method.
So I remove the reflection code. I think it would be better to use PowerMockito and it can avoid the problem of compatability between difference OS and platform.

see [EnvUtilsTest failed](https://github.com/apache/skywalking/pull/2570)

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
