### PR TITLE
Init need not return.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
@@ -89,10 +89,9 @@ public class AgentClassLoader extends ClassLoader {
     /**
      * Init the default
      *
-     * @return
      * @throws AgentPackageNotFoundException
      */
-    public static AgentClassLoader initDefaultLoader() throws AgentPackageNotFoundException {
+    public static void initDefaultLoader() throws AgentPackageNotFoundException {
         if (DEFAULT_LOADER == null) {
             synchronized (AgentClassLoader.class) {
                 if (DEFAULT_LOADER == null) {
@@ -100,7 +99,6 @@ public class AgentClassLoader extends ClassLoader {
                 }
             }
         }
-        return getDefault();
     }
 
     public AgentClassLoader(ClassLoader parent) throws AgentPackageNotFoundException {


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

I think the init function need not return the agentClassLoader, because the getDefault does this. also this funciton not used by any other places. what about your idea?