### PR TITLE
Fix NPE when ALS is off.

### DIFF
--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/EnvoyMetricReceiverConfig.java
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/EnvoyMetricReceiverConfig.java
@@ -18,18 +18,21 @@
 
 package org.apache.skywalking.oap.server.receiver.envoy;
 
+import com.google.common.base.Strings;
 import java.util.*;
 import java.util.stream.Collectors;
-
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 
 /**
- * @author wusheng,gaohongtao
+ * @author wusheng, gaohongtao
  */
 public class EnvoyMetricReceiverConfig extends ModuleConfig {
     private String alsHTTPAnalysis;
 
     public List<String> getAlsHTTPAnalysis() {
+        if (Strings.isNullOrEmpty(alsHTTPAnalysis)) {
+            return Collections.EMPTY_LIST;
+        }
         return Arrays.stream(alsHTTPAnalysis.trim().split(",")).map(String::trim).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
The `EnvoyMetricReceiverConfig#alsHTTPAnalysis` could never been set, especially in default config.

```yml
envoy-metric:
  default:
    #alsHTTPAnalysis: ${SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS:k8s-mesh}
```