### PR TITLE
Filtering pods not in 'Running' phase

### DIFF
--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/als/K8sALSServiceMeshHTTPAnalysis.java
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/als/K8sALSServiceMeshHTTPAnalysis.java
@@ -100,8 +100,8 @@ public class K8sALSServiceMeshHTTPAnalysis implements ALSHTTPAnalysis {
                     continue;
                 }
                 if (item.getStatus().getPodIP().equals(item.getStatus().getHostIP())) {
-                    logger.debug("Pod {}.{} is removed because hostIP and podIP are identical ", item.getMetadata().getName()
-                            , item.getMetadata().getNamespace());
+                    logger.debug("Pod {}.{} is removed because hostIP and podIP are identical ", item.getMetadata().getName(),
+                            item.getMetadata().getNamespace());
                     continue;
                 }
                 ipMap.put(item.getStatus().getPodIP(), createServiceMetaInfo(item.getMetadata()));


### PR DESCRIPTION
As the title shows, ALS analysis will filter pods whose phase is not 'Running', that will avoid invalid pods to mess IP-mapping up.