### PR TITLE
Make the step just to be the graphql java object.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/Const.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/Const.java
@@ -24,18 +24,16 @@ package org.apache.skywalking.oap.server.core;
 public class Const {
     public static final int NONE = 0;
     public static final String ID_SPLIT = "_";
+    public static final String SPACE = " ";
     public static final String KEY_VALUE_SPLIT = ",";
     public static final String ARRAY_SPLIT = "|";
     public static final String ARRAY_PARSER_SPLIT = "\\|";
     public static final int USER_SERVICE_ID = 1;
     public static final int USER_INSTANCE_ID = 1;
     public static final int USER_ENDPOINT_ID = 1;
-    public static final String NONE_ENDPOINT_NAME = "None";
     public static final String USER_CODE = "User";
     public static final String SEGMENT_SPAN_SPLIT = "S";
     public static final String UNKNOWN = "Unknown";
-    public static final String EXCEPTION = "Exception";
     public static final String EMPTY_STRING = "";
-    public static final int SPAN_TYPE_VIRTUAL = 9;
     public static final String DOMAIN_OPERATION_NAME = "{domain}";
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/Const.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/Const.java
@@ -24,6 +24,7 @@ package org.apache.skywalking.oap.server.core;
 public class Const {
     public static final int NONE = 0;
     public static final String ID_SPLIT = "_";
+    public static final String LINE = "-";
     public static final String SPACE = " ";
     public static final String KEY_VALUE_SPLIT = ",";
     public static final String ARRAY_SPLIT = "|";

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Downsampling.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Downsampling.java
@@ -13,10 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.skywalking.oap.server.core.storage;
+package org.apache.skywalking.oap.server.core.analysis;
 
 /**
  * @author peng-yongsheng

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/DownsamplingConfigService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/DownsamplingConfigService.java
@@ -19,7 +19,7 @@
 package org.apache.skywalking.oap.server.core.config;
 
 import java.util.List;
-import org.apache.skywalking.oap.server.core.storage.Downsampling;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.library.module.Service;
 
 /**

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/AggregationQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/AggregationQueryService.java
@@ -21,14 +21,15 @@ package org.apache.skywalking.oap.server.core.query;
 import java.io.IOException;
 import java.util.List;
 import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.cache.*;
 import org.apache.skywalking.oap.server.core.query.entity.*;
 import org.apache.skywalking.oap.server.core.register.*;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.annotation.ValueColumnIds;
 import org.apache.skywalking.oap.server.core.storage.query.IAggregationQueryDAO;
-import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.library.module.Service;
+import org.apache.skywalking.oap.server.library.module.*;
 
 /**
  * @author peng-yongsheng
@@ -49,9 +50,9 @@ public class AggregationQueryService implements Service {
         return aggregationQueryDAO;
     }
 
-    public List<TopNEntity> getServiceTopN(final String indName, final int topN, final Step step, final long startTB,
+    public List<TopNEntity> getServiceTopN(final String indName, final int topN, final Downsampling downsampling, final long startTB,
         final long endTB, final Order order) throws IOException {
-        List<TopNEntity> topNEntities = getAggregationQueryDAO().getServiceTopN(indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, step, startTB, endTB, order);
+        List<TopNEntity> topNEntities = getAggregationQueryDAO().getServiceTopN(indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, downsampling, startTB, endTB, order);
         for (TopNEntity entity : topNEntities) {
             ServiceInventory inventory = moduleManager.find(CoreModule.NAME).provider().getService(ServiceInventoryCache.class).get(Integer.valueOf(entity.getId()));
             if (inventory != null) {
@@ -61,9 +62,9 @@ public class AggregationQueryService implements Service {
         return topNEntities;
     }
 
-    public List<TopNEntity> getAllServiceInstanceTopN(final String indName, final int topN, final Step step,
+    public List<TopNEntity> getAllServiceInstanceTopN(final String indName, final int topN, final Downsampling downsampling,
         final long startTB, final long endTB, final Order order) throws IOException {
-        List<TopNEntity> topNEntities = getAggregationQueryDAO().getAllServiceInstanceTopN(indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, step, startTB, endTB, order);
+        List<TopNEntity> topNEntities = getAggregationQueryDAO().getAllServiceInstanceTopN(indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, downsampling, startTB, endTB, order);
         for (TopNEntity entity : topNEntities) {
             ServiceInstanceInventory inventory = moduleManager.find(CoreModule.NAME).provider().getService(ServiceInstanceInventoryCache.class).get(Integer.valueOf(entity.getId()));
             if (inventory != null) {
@@ -74,8 +75,8 @@ public class AggregationQueryService implements Service {
     }
 
     public List<TopNEntity> getServiceInstanceTopN(final int serviceId, final String indName, final int topN,
-        final Step step, final long startTB, final long endTB, final Order order) throws IOException {
-        List<TopNEntity> topNEntities = getAggregationQueryDAO().getServiceInstanceTopN(serviceId, indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, step, startTB, endTB, order);
+        final Downsampling downsampling, final long startTB, final long endTB, final Order order) throws IOException {
+        List<TopNEntity> topNEntities = getAggregationQueryDAO().getServiceInstanceTopN(serviceId, indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, downsampling, startTB, endTB, order);
         for (TopNEntity entity : topNEntities) {
             ServiceInstanceInventory inventory = moduleManager.find(CoreModule.NAME).provider().getService(ServiceInstanceInventoryCache.class).get(Integer.valueOf(entity.getId()));
             if (inventory != null) {
@@ -85,9 +86,9 @@ public class AggregationQueryService implements Service {
         return topNEntities;
     }
 
-    public List<TopNEntity> getAllEndpointTopN(final String indName, final int topN, final Step step,
+    public List<TopNEntity> getAllEndpointTopN(final String indName, final int topN, final Downsampling downsampling,
         final long startTB, final long endTB, final Order order) throws IOException {
-        List<TopNEntity> topNEntities = getAggregationQueryDAO().getAllEndpointTopN(indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, step, startTB, endTB, order);
+        List<TopNEntity> topNEntities = getAggregationQueryDAO().getAllEndpointTopN(indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, downsampling, startTB, endTB, order);
         for (TopNEntity entity : topNEntities) {
             EndpointInventory inventory = moduleManager.find(CoreModule.NAME).provider().getService(EndpointInventoryCache.class).get(Integer.valueOf(entity.getId()));
             if (inventory != null) {
@@ -98,8 +99,8 @@ public class AggregationQueryService implements Service {
     }
 
     public List<TopNEntity> getEndpointTopN(final int serviceId, final String indName, final int topN,
-        final Step step, final long startTB, final long endTB, final Order order) throws IOException {
-        List<TopNEntity> topNEntities = getAggregationQueryDAO().getEndpointTopN(serviceId, indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, step, startTB, endTB, order);
+        final Downsampling downsampling, final long startTB, final long endTB, final Order order) throws IOException {
+        List<TopNEntity> topNEntities = getAggregationQueryDAO().getEndpointTopN(serviceId, indName, ValueColumnIds.INSTANCE.getValueCName(indName), topN, downsampling, startTB, endTB, order);
         for (TopNEntity entity : topNEntities) {
             EndpointInventory inventory = moduleManager.find(CoreModule.NAME).provider().getService(EndpointInventoryCache.class).get(Integer.valueOf(entity.getId()));
             if (inventory != null) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/AlarmQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/AlarmQueryService.java
@@ -22,16 +22,13 @@ import java.io.IOException;
 import org.apache.skywalking.oap.server.core.query.entity.*;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.query.IAlarmQueryDAO;
-import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.library.module.Service;
-import org.slf4j.*;
+import org.apache.skywalking.oap.server.library.module.*;
 
 /**
  * @author peng-yongsheng
  */
 public class AlarmQueryService implements Service {
-
-    private static final Logger logger = LoggerFactory.getLogger(AlarmQueryService.class);
 
     private final ModuleManager moduleManager;
     private IAlarmQueryDAO alarmQueryDAO;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/DurationUtils.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/DurationUtils.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.core.query;
 import java.text.*;
 import java.util.*;
 import org.apache.skywalking.oap.server.core.*;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.query.entity.Step;
 import org.joda.time.*;
 
@@ -31,8 +32,8 @@ public enum DurationUtils {
     INSTANCE;
 
     public long exchangeToTimeBucket(String dateStr) {
-        dateStr = dateStr.replaceAll("-", Const.EMPTY_STRING);
-        dateStr = dateStr.replaceAll(" ", Const.EMPTY_STRING);
+        dateStr = dateStr.replaceAll(Const.ID_SPLIT, Const.EMPTY_STRING);
+        dateStr = dateStr.replaceAll(Const.SPACE, Const.EMPTY_STRING);
         return Long.valueOf(dateStr);
     }
 
@@ -119,17 +120,17 @@ public enum DurationUtils {
         return Minutes.minutesBetween(new DateTime(startDate), new DateTime(endDate)).getMinutes();
     }
 
-    public int minutesBetween(Step step, DateTime dateTime) {
-        switch (step) {
-            case MONTH:
+    public int minutesBetween(Downsampling downsampling, DateTime dateTime) {
+        switch (downsampling) {
+            case Month:
                 return dateTime.dayOfMonth().getMaximumValue() * 24 * 60;
-            case DAY:
+            case Day:
                 return 24 * 60;
-            case HOUR:
+            case Hour:
                 return 60;
-            case MINUTE:
+            case Minute:
                 return 1;
-            case SECOND:
+            case Second:
                 return 1;
             default:
                 return 1;
@@ -143,62 +144,62 @@ public enum DurationUtils {
         return Seconds.secondsBetween(new DateTime(startDate), new DateTime(endDate)).getSeconds();
     }
 
-    public int secondsBetween(Step step, DateTime dateTime) {
-        switch (step) {
-            case MONTH:
+    public int secondsBetween(Downsampling downsampling, DateTime dateTime) {
+        switch (downsampling) {
+            case Month:
                 return dateTime.dayOfMonth().getMaximumValue() * 24 * 60 * 60;
-            case DAY:
+            case Day:
                 return 24 * 60 * 60;
-            case HOUR:
+            case Hour:
                 return 60 * 60;
-            case MINUTE:
+            case Minute:
                 return 60;
-            case SECOND:
+            case Second:
                 return 1;
             default:
                 return 1;
         }
     }
 
-    public List<DurationPoint> getDurationPoints(Step step, long startTimeBucket,
+    public List<DurationPoint> getDurationPoints(Downsampling downsampling, long startTimeBucket,
         long endTimeBucket) throws ParseException {
-        DateTime dateTime = parseToDateTime(step, startTimeBucket);
+        DateTime dateTime = parseToDateTime(downsampling, startTimeBucket);
 
         List<DurationPoint> durations = new LinkedList<>();
-        durations.add(new DurationPoint(startTimeBucket, secondsBetween(step, dateTime), minutesBetween(step, dateTime)));
+        durations.add(new DurationPoint(startTimeBucket, secondsBetween(downsampling, dateTime), minutesBetween(downsampling, dateTime)));
 
         int i = 0;
         do {
-            switch (step) {
-                case MONTH:
+            switch (downsampling) {
+                case Month:
                     dateTime = dateTime.plusMonths(1);
                     String timeBucket = new SimpleDateFormat("yyyyMM").format(dateTime.toDate());
-                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(step, dateTime), minutesBetween(step, dateTime)));
+                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(downsampling, dateTime), minutesBetween(downsampling, dateTime)));
                     break;
-                case DAY:
+                case Day:
                     dateTime = dateTime.plusDays(1);
                     timeBucket = new SimpleDateFormat("yyyyMMdd").format(dateTime.toDate());
-                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(step, dateTime), minutesBetween(step, dateTime)));
+                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(downsampling, dateTime), minutesBetween(downsampling, dateTime)));
                     break;
-                case HOUR:
+                case Hour:
                     dateTime = dateTime.plusHours(1);
                     timeBucket = new SimpleDateFormat("yyyyMMddHH").format(dateTime.toDate());
-                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(step, dateTime), minutesBetween(step, dateTime)));
+                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(downsampling, dateTime), minutesBetween(downsampling, dateTime)));
                     break;
-                case MINUTE:
+                case Minute:
                     dateTime = dateTime.plusMinutes(1);
                     timeBucket = new SimpleDateFormat("yyyyMMddHHmm").format(dateTime.toDate());
-                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(step, dateTime), minutesBetween(step, dateTime)));
+                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(downsampling, dateTime), minutesBetween(downsampling, dateTime)));
                     break;
-                case SECOND:
+                case Second:
                     dateTime = dateTime.plusSeconds(1);
                     timeBucket = new SimpleDateFormat("yyyyMMddHHmmss").format(dateTime.toDate());
-                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(step, dateTime), minutesBetween(step, dateTime)));
+                    durations.add(new DurationPoint(Long.valueOf(timeBucket), secondsBetween(downsampling, dateTime), minutesBetween(downsampling, dateTime)));
                     break;
             }
             i++;
             if (i > 500) {
-                throw new UnexpectedException("Duration data error, step: " + step.name() + ", start: " + startTimeBucket + ", end: " + endTimeBucket);
+                throw new UnexpectedException("Duration data error, step: " + downsampling.name() + ", start: " + startTimeBucket + ", end: " + endTimeBucket);
             }
         }
         while (endTimeBucket != durations.get(durations.size() - 1).getPoint());
@@ -228,27 +229,27 @@ public enum DurationUtils {
         return date;
     }
 
-    private DateTime parseToDateTime(Step step, long time) throws ParseException {
+    private DateTime parseToDateTime(Downsampling downsampling, long time) throws ParseException {
         DateTime dateTime = null;
 
-        switch (step) {
-            case MONTH:
+        switch (downsampling) {
+            case Month:
                 Date date = new SimpleDateFormat("yyyyMM").parse(String.valueOf(time));
                 dateTime = new DateTime(date);
                 break;
-            case DAY:
+            case Day:
                 date = new SimpleDateFormat("yyyyMMdd").parse(String.valueOf(time));
                 dateTime = new DateTime(date);
                 break;
-            case HOUR:
+            case Hour:
                 date = new SimpleDateFormat("yyyyMMddHH").parse(String.valueOf(time));
                 dateTime = new DateTime(date);
                 break;
-            case MINUTE:
+            case Minute:
                 date = new SimpleDateFormat("yyyyMMddHHmm").parse(String.valueOf(time));
                 dateTime = new DateTime(date);
                 break;
-            case SECOND:
+            case Second:
                 date = new SimpleDateFormat("yyyyMMddHHmmss").parse(String.valueOf(time));
                 dateTime = new DateTime(date);
                 break;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/DurationUtils.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/DurationUtils.java
@@ -32,7 +32,7 @@ public enum DurationUtils {
     INSTANCE;
 
     public long exchangeToTimeBucket(String dateStr) {
-        dateStr = dateStr.replaceAll(Const.ID_SPLIT, Const.EMPTY_STRING);
+        dateStr = dateStr.replaceAll(Const.LINE, Const.EMPTY_STRING);
         dateStr = dateStr.replaceAll(Const.SPACE, Const.EMPTY_STRING);
         return Long.valueOf(dateStr);
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/LogQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/LogQueryService.java
@@ -31,6 +31,7 @@ import org.apache.skywalking.oap.server.library.module.*;
  * @author wusheng
  */
 public class LogQueryService implements Service {
+    
     private final ModuleManager moduleManager;
     private ILogQueryDAO logQueryDAO;
     private ServiceInventoryCache serviceInventoryCache;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricQueryService.java
@@ -23,23 +23,21 @@ import java.text.ParseException;
 import java.util.*;
 import org.apache.skywalking.apm.util.StringUtil;
 import org.apache.skywalking.oap.server.core.Const;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
 import org.apache.skywalking.oap.server.core.query.entity.*;
 import org.apache.skywalking.oap.server.core.query.sql.*;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.annotation.ValueColumnIds;
 import org.apache.skywalking.oap.server.core.storage.query.IMetricsQueryDAO;
-import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.library.module.Service;
+import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
-import org.slf4j.*;
 
 /**
  * @author peng-yongsheng
  */
 public class MetricQueryService implements Service {
-
-    private static final Logger logger = LoggerFactory.getLogger(MetricQueryService.class);
 
     private final ModuleManager moduleManager;
     private IMetricsQueryDAO metricQueryDAO;
@@ -55,7 +53,7 @@ public class MetricQueryService implements Service {
         return metricQueryDAO;
     }
 
-    public IntValues getValues(final String indName, final List<String> ids, final Step step, final long startTB,
+    public IntValues getValues(final String indName, final List<String> ids, final Downsampling downsampling, final long startTB,
         final long endTB) throws IOException {
         if (CollectionUtils.isEmpty(ids)) {
             throw new RuntimeException("IDs can't be null");
@@ -67,12 +65,12 @@ public class MetricQueryService implements Service {
         where.getKeyValues().add(intKeyValues);
         ids.forEach(intKeyValues.getValues()::add);
 
-        return getMetricQueryDAO().getValues(indName, step, startTB, endTB, where, ValueColumnIds.INSTANCE.getValueCName(indName), ValueColumnIds.INSTANCE.getValueFunction(indName));
+        return getMetricQueryDAO().getValues(indName, downsampling, startTB, endTB, where, ValueColumnIds.INSTANCE.getValueCName(indName), ValueColumnIds.INSTANCE.getValueFunction(indName));
     }
 
-    public IntValues getLinearIntValues(final String indName, final String id, final Step step, final long startTB,
+    public IntValues getLinearIntValues(final String indName, final String id, final Downsampling downsampling, final long startTB,
         final long endTB) throws IOException, ParseException {
-        List<DurationPoint> durationPoints = DurationUtils.INSTANCE.getDurationPoints(step, startTB, endTB);
+        List<DurationPoint> durationPoints = DurationUtils.INSTANCE.getDurationPoints(downsampling, startTB, endTB);
         List<String> ids = new ArrayList<>();
         if (StringUtil.isEmpty(id)) {
             durationPoints.forEach(durationPoint -> ids.add(String.valueOf(durationPoint.getPoint())));
@@ -80,12 +78,12 @@ public class MetricQueryService implements Service {
             durationPoints.forEach(durationPoint -> ids.add(durationPoint.getPoint() + Const.ID_SPLIT + id));
         }
 
-        return getMetricQueryDAO().getLinearIntValues(indName, step, ids, ValueColumnIds.INSTANCE.getValueCName(indName));
+        return getMetricQueryDAO().getLinearIntValues(indName, downsampling, ids, ValueColumnIds.INSTANCE.getValueCName(indName));
     }
 
-    public Thermodynamic getThermodynamic(final String indName, final String id, final Step step, final long startTB,
+    public Thermodynamic getThermodynamic(final String indName, final String id, final Downsampling downsampling, final long startTB,
         final long endTB) throws IOException, ParseException {
-        List<DurationPoint> durationPoints = DurationUtils.INSTANCE.getDurationPoints(step, startTB, endTB);
+        List<DurationPoint> durationPoints = DurationUtils.INSTANCE.getDurationPoints(downsampling, startTB, endTB);
         List<String> ids = new ArrayList<>();
         durationPoints.forEach(durationPoint -> {
             if (id == null) {
@@ -95,6 +93,6 @@ public class MetricQueryService implements Service {
             }
         });
 
-        return getMetricQueryDAO().getThermodynamic(indName, step, ids, ValueColumnIds.INSTANCE.getValueCName(indName));
+        return getMetricQueryDAO().getThermodynamic(indName, downsampling, ids, ValueColumnIds.INSTANCE.getValueCName(indName));
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/StepToDownsampling.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/StepToDownsampling.java
@@ -13,21 +13,32 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.skywalking.oap.server.core.storage.model;
+package org.apache.skywalking.oap.server.core.query;
 
+import org.apache.skywalking.oap.server.core.UnexpectedException;
+import org.apache.skywalking.oap.server.core.query.entity.Step;
 import org.apache.skywalking.oap.server.core.analysis.Downsampling;
-import org.apache.skywalking.oap.server.core.storage.annotation.Storage;
-import org.apache.skywalking.oap.server.library.module.Service;
 
 /**
  * @author peng-yongsheng
  */
-public interface IModelSetter extends Service {
+public class StepToDownsampling {
 
-    Model putIfAbsent(Class aClass, String modelName, int scopeId, Storage storage);
-
-    Model putIfAbsent(Class aClass, String modelName, int scopeId, Storage storage, Downsampling downsampling);
+    public static Downsampling transform(Step step) {
+        switch (step) {
+            case SECOND:
+                return Downsampling.Second;
+            case MINUTE:
+                return Downsampling.Minute;
+            case HOUR:
+                return Downsampling.Hour;
+            case DAY:
+                return Downsampling.Day;
+            case MONTH:
+                return Downsampling.Month;
+        }
+        throw new UnexpectedException("Unknown step value.");
+    }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/Model.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/Model.java
@@ -21,7 +21,7 @@ package org.apache.skywalking.oap.server.core.storage.model;
 import java.util.List;
 import lombok.Getter;
 import org.apache.skywalking.oap.server.core.*;
-import org.apache.skywalking.oap.server.core.storage.Downsampling;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.storage.ttl.*;
 
 /**

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/ModelName.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/ModelName.java
@@ -13,34 +13,32 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.skywalking.oap.server.core.storage;
+package org.apache.skywalking.oap.server.core.storage.model;
 
 import org.apache.skywalking.oap.server.core.Const;
-import org.apache.skywalking.oap.server.core.query.entity.Step;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 
 /**
  * @author peng-yongsheng
  */
-public class DownSamplingModelNameBuilder {
+public class ModelName {
 
-    private DownSamplingModelNameBuilder() {
-    }
-
-    public static String build(Step step, String modelName) {
-        switch (step) {
-            case MONTH:
-                modelName = modelName + Const.ID_SPLIT + Downsampling.Month.getName();
-                break;
-            case DAY:
-                modelName = modelName + Const.ID_SPLIT + Downsampling.Day.getName();
-                break;
-            case HOUR:
-                modelName = modelName + Const.ID_SPLIT + Downsampling.Hour.getName();
-                break;
+    public static String build(Downsampling downsampling, String modelName) {
+        switch (downsampling) {
+            case Month:
+                return modelName + Const.ID_SPLIT + Downsampling.Month.getName();
+            case Day:
+                return modelName + Const.ID_SPLIT + Downsampling.Day.getName();
+            case Hour:
+                return modelName + Const.ID_SPLIT + Downsampling.Hour.getName();
+            case Minute:
+                return modelName + Const.ID_SPLIT + Downsampling.Minute.getName();
+            case Second:
+                return modelName + Const.ID_SPLIT + Downsampling.Second.getName();
+            default:
+                return modelName;
         }
-        return modelName;
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
@@ -21,7 +21,7 @@ import java.lang.reflect.Field;
 import java.util.*;
 import lombok.Getter;
 import org.apache.skywalking.oap.server.core.source.DefaultScopeDefine;
-import org.apache.skywalking.oap.server.core.storage.Downsampling;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.storage.annotation.*;
 import org.slf4j.*;
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IAggregationQueryDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IAggregationQueryDAO.java
@@ -20,28 +20,27 @@ package org.apache.skywalking.oap.server.core.storage.query;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.query.entity.*;
-import org.apache.skywalking.oap.server.core.storage.DAO;
+import org.apache.skywalking.oap.server.core.storage.*;
 
 /**
  * @author peng-yongsheng
  */
 public interface IAggregationQueryDAO extends DAO {
 
-    List<TopNEntity> getServiceTopN(final String indName, String valueCName, final int topN, final Step step,
-        final long startTB,
-        final long endTB, final Order order) throws IOException;
+    List<TopNEntity> getServiceTopN(final String indName, String valueCName, final int topN, final Downsampling downsampling,
+        final long startTB, final long endTB, final Order order) throws IOException;
 
-    List<TopNEntity> getAllServiceInstanceTopN(final String indName, String valueCName, final int topN, final Step step,
+    List<TopNEntity> getAllServiceInstanceTopN(final String indName, String valueCName, final int topN, final Downsampling downsampling,
         final long startTB, final long endTB, final Order order) throws IOException;
 
     List<TopNEntity> getServiceInstanceTopN(final int serviceId, final String indName, String valueCName,
-        final int topN,
-        final Step step, final long startTB, final long endTB, final Order order) throws IOException;
+        final int topN, final Downsampling downsampling, final long startTB, final long endTB, final Order order) throws IOException;
 
-    List<TopNEntity> getAllEndpointTopN(final String indName, String valueCName, final int topN, final Step step,
+    List<TopNEntity> getAllEndpointTopN(final String indName, String valueCName, final int topN, final Downsampling downsampling,
         final long startTB, final long endTB, final Order order) throws IOException;
 
     List<TopNEntity> getEndpointTopN(final int serviceId, final String indName, String valueCName, final int topN,
-        final Step step, final long startTB, final long endTB, final Order order) throws IOException;
+        final Downsampling downsampling, final long startTB, final long endTB, final Order order) throws IOException;
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IMetricsQueryDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IMetricsQueryDAO.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.oap.server.core.storage.query;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.query.entity.*;
 import org.apache.skywalking.oap.server.core.query.sql.*;
 import org.apache.skywalking.oap.server.core.storage.DAO;
@@ -29,10 +30,9 @@ import org.apache.skywalking.oap.server.core.storage.DAO;
  */
 public interface IMetricsQueryDAO extends DAO {
 
-    IntValues getValues(String indName, Step step, long startTB,
-        long endTB, Where where, String valueCName, Function function) throws IOException;
+    IntValues getValues(String indName, Downsampling downsampling, long startTB, long endTB, Where where, String valueCName, Function function) throws IOException;
 
-    IntValues getLinearIntValues(String indName, Step step, List<String> ids, String valueCName) throws IOException;
+    IntValues getLinearIntValues(String indName, Downsampling downsampling, List<String> ids, String valueCName) throws IOException;
 
-    Thermodynamic getThermodynamic(String indName, Step step, List<String> ids, String valueCName) throws IOException;
+    Thermodynamic getThermodynamic(String indName, Downsampling downsampling, List<String> ids, String valueCName) throws IOException;
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/ITopologyQueryDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/ITopologyQueryDAO.java
@@ -20,7 +20,8 @@ package org.apache.skywalking.oap.server.core.storage.query;
 
 import java.io.IOException;
 import java.util.List;
-import org.apache.skywalking.oap.server.core.query.entity.*;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
+import org.apache.skywalking.oap.server.core.query.entity.Call;
 import org.apache.skywalking.oap.server.library.module.Service;
 
 /**
@@ -28,16 +29,13 @@ import org.apache.skywalking.oap.server.library.module.Service;
  */
 public interface ITopologyQueryDAO extends Service {
 
-    List<Call.CallDetail> loadSpecifiedServerSideServiceRelations(Step step, long startTB, long endTB,
-        List<Integer> serviceIds) throws IOException;
+    List<Call.CallDetail> loadSpecifiedServerSideServiceRelations(Downsampling downsampling, long startTB, long endTB, List<Integer> serviceIds) throws IOException;
 
-    List<Call.CallDetail> loadSpecifiedClientSideServiceRelations(Step step, long startTB, long endTB,
-        List<Integer> serviceIds) throws IOException;
+    List<Call.CallDetail> loadSpecifiedClientSideServiceRelations(Downsampling downsampling, long startTB, long endTB, List<Integer> serviceIds) throws IOException;
 
-    List<Call.CallDetail> loadServerSideServiceRelations(Step step, long startTB, long endTB) throws IOException;
+    List<Call.CallDetail> loadServerSideServiceRelations(Downsampling downsampling, long startTB, long endTB) throws IOException;
 
-    List<Call.CallDetail> loadClientSideServiceRelations(Step step, long startTB, long endTB) throws IOException;
+    List<Call.CallDetail> loadClientSideServiceRelations(Downsampling downsampling, long startTB, long endTB) throws IOException;
 
-    List<Call.CallDetail> loadSpecifiedDestOfServerSideEndpointRelations(Step step, long startTB, long endTB,
-        int destEndpointId) throws IOException;
+    List<Call.CallDetail> loadSpecifiedDestOfServerSideEndpointRelations(Downsampling downsampling, long startTB, long endTB, int destEndpointId) throws IOException;
 }

--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/AggregationQuery.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/AggregationQuery.java
@@ -51,7 +51,7 @@ public class AggregationQuery implements GraphQLQueryResolver {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getQueryService().getServiceTopN(name, topN, duration.getStep(), startTimeBucket, endTimeBucket, order);
+        return getQueryService().getServiceTopN(name, topN, StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket, order);
     }
 
     public List<TopNEntity> getAllServiceInstanceTopN(final String name, final int topN, final Duration duration,
@@ -59,7 +59,7 @@ public class AggregationQuery implements GraphQLQueryResolver {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getQueryService().getAllServiceInstanceTopN(name, topN, duration.getStep(), startTimeBucket, endTimeBucket, order);
+        return getQueryService().getAllServiceInstanceTopN(name, topN, StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket, order);
     }
 
     public List<TopNEntity> getServiceInstanceTopN(final int serviceId, final String name, final int topN,
@@ -67,7 +67,7 @@ public class AggregationQuery implements GraphQLQueryResolver {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getQueryService().getServiceInstanceTopN(serviceId, name, topN, duration.getStep(), startTimeBucket, endTimeBucket, order);
+        return getQueryService().getServiceInstanceTopN(serviceId, name, topN, StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket, order);
     }
 
     public List<TopNEntity> getAllEndpointTopN(final String name, final int topN,
@@ -75,7 +75,7 @@ public class AggregationQuery implements GraphQLQueryResolver {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getQueryService().getAllEndpointTopN(name, topN, duration.getStep(), startTimeBucket, endTimeBucket, order);
+        return getQueryService().getAllEndpointTopN(name, topN, StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket, order);
     }
 
     public List<TopNEntity> getEndpointTopN(final int serviceId, final String name, final int topN,
@@ -83,6 +83,6 @@ public class AggregationQuery implements GraphQLQueryResolver {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getQueryService().getEndpointTopN(serviceId, name, topN, duration.getStep(), startTimeBucket, endTimeBucket, order);
+        return getQueryService().getEndpointTopN(serviceId, name, topN, StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket, order);
     }
 }

--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/MetricQuery.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/MetricQuery.java
@@ -50,20 +50,20 @@ public class MetricQuery implements GraphQLQueryResolver {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getMetricQueryService().getValues(metrics.getName(), metrics.getIds(), duration.getStep(), startTimeBucket, endTimeBucket);
+        return getMetricQueryService().getValues(metrics.getName(), metrics.getIds(), StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket);
     }
 
     public IntValues getLinearIntValues(final MetricCondition metrics, final Duration duration) throws IOException, ParseException {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getMetricQueryService().getLinearIntValues(metrics.getName(), metrics.getId(), duration.getStep(), startTimeBucket, endTimeBucket);
+        return getMetricQueryService().getLinearIntValues(metrics.getName(), metrics.getId(), StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket);
     }
 
     public Thermodynamic getThermodynamic(final MetricCondition metrics, final Duration duration) throws IOException, ParseException {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getMetricQueryService().getThermodynamic(metrics.getName(), metrics.getId(), duration.getStep(), startTimeBucket, endTimeBucket);
+        return getMetricQueryService().getThermodynamic(metrics.getName(), metrics.getId(), StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket);
     }
 }

--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/TopologyQuery.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/TopologyQuery.java
@@ -53,20 +53,20 @@ public class TopologyQuery implements GraphQLQueryResolver {
         long startTimestamp = DurationUtils.INSTANCE.startTimeToTimestamp(duration.getStep(), duration.getStart());
         long endTimestamp = DurationUtils.INSTANCE.endTimeToTimestamp(duration.getStep(), duration.getEnd());
 
-        return getQueryService().getGlobalTopology(duration.getStep(), startTimeBucket, endTimeBucket, startTimestamp, endTimestamp);
+        return getQueryService().getGlobalTopology(StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket, startTimestamp, endTimestamp);
     }
 
     public Topology getServiceTopology(final int serviceId, final Duration duration) throws IOException {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getQueryService().getServiceTopology(duration.getStep(), startTimeBucket, endTimeBucket, serviceId);
+        return getQueryService().getServiceTopology(StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket, serviceId);
     }
 
     public Topology getEndpointTopology(final int endpointId, final Duration duration) throws IOException {
         long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
         long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getQueryService().getEndpointTopology(duration.getStep(), startTimeBucket, endTimeBucket, endpointId);
+        return getQueryService().getEndpointTopology(StepToDownsampling.transform(duration.getStep()), startTimeBucket, endTimeBucket, endpointId);
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AggregationQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AggregationQueryEsDAO.java
@@ -20,10 +20,11 @@ package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
 
 import java.io.IOException;
 import java.util.*;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
 import org.apache.skywalking.oap.server.core.query.entity.*;
 import org.apache.skywalking.oap.server.core.register.*;
-import org.apache.skywalking.oap.server.core.storage.DownSamplingModelNameBuilder;
+import org.apache.skywalking.oap.server.core.storage.model.ModelName;
 import org.apache.skywalking.oap.server.core.storage.query.IAggregationQueryDAO;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
 import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.EsDAO;
@@ -44,18 +45,18 @@ public class AggregationQueryEsDAO extends EsDAO implements IAggregationQueryDAO
     }
 
     @Override
-    public List<TopNEntity> getServiceTopN(String indName, String valueCName, int topN, Step step, long startTB,
+    public List<TopNEntity> getServiceTopN(String indName, String valueCName, int topN, Downsampling downsampling, long startTB,
         long endTB, Order order) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, indName);
+        String indexName = ModelName.build(downsampling, indName);
 
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         sourceBuilder.query(QueryBuilders.rangeQuery(Metrics.TIME_BUCKET).lte(endTB).gte(startTB));
         return aggregation(indexName, valueCName, sourceBuilder, topN, order);
     }
 
-    @Override public List<TopNEntity> getAllServiceInstanceTopN(String indName, String valueCName, int topN, Step step,
+    @Override public List<TopNEntity> getAllServiceInstanceTopN(String indName, String valueCName, int topN, Downsampling downsampling,
         long startTB, long endTB, Order order) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, indName);
+        String indexName = ModelName.build(downsampling, indName);
 
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         sourceBuilder.query(QueryBuilders.rangeQuery(Metrics.TIME_BUCKET).lte(endTB).gte(startTB));
@@ -63,8 +64,8 @@ public class AggregationQueryEsDAO extends EsDAO implements IAggregationQueryDAO
     }
 
     @Override public List<TopNEntity> getServiceInstanceTopN(int serviceId, String indName, String valueCName, int topN,
-        Step step, long startTB, long endTB, Order order) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, indName);
+        Downsampling downsampling, long startTB, long endTB, Order order) throws IOException {
+        String indexName = ModelName.build(downsampling, indName);
 
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
 
@@ -78,9 +79,9 @@ public class AggregationQueryEsDAO extends EsDAO implements IAggregationQueryDAO
     }
 
     @Override
-    public List<TopNEntity> getAllEndpointTopN(String indName, String valueCName, int topN, Step step, long startTB,
+    public List<TopNEntity> getAllEndpointTopN(String indName, String valueCName, int topN, Downsampling downsampling, long startTB,
         long endTB, Order order) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, indName);
+        String indexName = ModelName.build(downsampling, indName);
 
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         sourceBuilder.query(QueryBuilders.rangeQuery(Metrics.TIME_BUCKET).lte(endTB).gte(startTB));
@@ -88,9 +89,9 @@ public class AggregationQueryEsDAO extends EsDAO implements IAggregationQueryDAO
     }
 
     @Override
-    public List<TopNEntity> getEndpointTopN(int serviceId, String indName, String valueCName, int topN, Step step,
+    public List<TopNEntity> getEndpointTopN(int serviceId, String indName, String valueCName, int topN, Downsampling downsampling,
         long startTB, long endTB, Order order) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, indName);
+        String indexName = ModelName.build(downsampling, indName);
 
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
 
@@ -104,8 +105,7 @@ public class AggregationQueryEsDAO extends EsDAO implements IAggregationQueryDAO
     }
 
     private List<TopNEntity> aggregation(String indexName, String valueCName, SearchSourceBuilder sourceBuilder,
-        int topN,
-        Order order) throws IOException {
+        int topN, Order order) throws IOException {
         boolean asc = false;
         if (order.equals(Order.ASC)) {
             asc = true;

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetricsQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetricsQueryEsDAO.java
@@ -20,10 +20,11 @@ package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
 
 import java.io.IOException;
 import java.util.*;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.analysis.metrics.*;
 import org.apache.skywalking.oap.server.core.query.entity.*;
 import org.apache.skywalking.oap.server.core.query.sql.*;
-import org.apache.skywalking.oap.server.core.storage.DownSamplingModelNameBuilder;
+import org.apache.skywalking.oap.server.core.storage.model.ModelName;
 import org.apache.skywalking.oap.server.core.storage.query.IMetricsQueryDAO;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
 import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.EsDAO;
@@ -44,9 +45,9 @@ public class MetricsQueryEsDAO extends EsDAO implements IMetricsQueryDAO {
         super(client);
     }
 
-    public IntValues getValues(String indName, Step step, long startTB, long endTB, Where where, String valueCName,
+    @Override public IntValues getValues(String indName, Downsampling downsampling, long startTB, long endTB, Where where, String valueCName,
         Function function) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, indName);
+        String indexName = ModelName.build(downsampling, indName);
 
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         queryBuild(sourceBuilder, where, startTB, endTB);
@@ -99,9 +100,8 @@ public class MetricsQueryEsDAO extends EsDAO implements IMetricsQueryDAO {
         }
     }
 
-    @Override public IntValues getLinearIntValues(String indName, Step step, List<String> ids,
-        String valueCName) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, indName);
+    @Override public IntValues getLinearIntValues(String indName, Downsampling downsampling, List<String> ids, String valueCName) throws IOException {
+        String indexName = ModelName.build(downsampling, indName);
 
         MultiGetResponse response = getClient().multiGet(indexName, ids);
 
@@ -120,9 +120,8 @@ public class MetricsQueryEsDAO extends EsDAO implements IMetricsQueryDAO {
         return intValues;
     }
 
-    @Override public Thermodynamic getThermodynamic(String indName, Step step, List<String> ids,
-        String valueCName) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, indName);
+    @Override public Thermodynamic getThermodynamic(String indName, Downsampling downsampling, List<String> ids, String valueCName) throws IOException {
+        String indexName = ModelName.build(downsampling, indName);
 
         MultiGetResponse response = getClient().multiGet(indexName, ids);
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TopologyQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TopologyQueryEsDAO.java
@@ -21,13 +21,14 @@ package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
 import java.io.IOException;
 import java.util.*;
 import org.apache.skywalking.oap.server.core.UnexpectedException;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.analysis.manual.RelationDefineUtil;
 import org.apache.skywalking.oap.server.core.analysis.manual.endpointrelation.EndpointRelationServerSideMetrics;
 import org.apache.skywalking.oap.server.core.analysis.manual.servicerelation.*;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
-import org.apache.skywalking.oap.server.core.query.entity.*;
+import org.apache.skywalking.oap.server.core.query.entity.Call;
 import org.apache.skywalking.oap.server.core.source.DetectPoint;
-import org.apache.skywalking.oap.server.core.storage.DownSamplingModelNameBuilder;
+import org.apache.skywalking.oap.server.core.storage.model.ModelName;
 import org.apache.skywalking.oap.server.core.storage.query.ITopologyQueryDAO;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
@@ -48,8 +49,7 @@ public class TopologyQueryEsDAO extends EsDAO implements ITopologyQueryDAO {
     }
 
     @Override
-    public List<Call.CallDetail> loadSpecifiedServerSideServiceRelations(Step step, long startTB, long endTB,
-        List<Integer> serviceIds) throws IOException {
+    public List<Call.CallDetail> loadSpecifiedServerSideServiceRelations(Downsampling downsampling, long startTB, long endTB, List<Integer> serviceIds) throws IOException {
         if (CollectionUtils.isEmpty(serviceIds)) {
             throw new UnexpectedException("Service id is empty");
         }
@@ -58,13 +58,12 @@ public class TopologyQueryEsDAO extends EsDAO implements ITopologyQueryDAO {
         sourceBuilder.size(0);
         setQueryCondition(sourceBuilder, startTB, endTB, serviceIds);
 
-        String indexName = DownSamplingModelNameBuilder.build(step, ServiceRelationServerSideMetrics.INDEX_NAME);
+        String indexName = ModelName.build(downsampling, ServiceRelationServerSideMetrics.INDEX_NAME);
         return load(sourceBuilder, indexName, DetectPoint.SERVER);
     }
 
     @Override
-    public List<Call.CallDetail> loadSpecifiedClientSideServiceRelations(Step step, long startTB, long endTB,
-        List<Integer> serviceIds) throws IOException {
+    public List<Call.CallDetail> loadSpecifiedClientSideServiceRelations(Downsampling downsampling, long startTB, long endTB, List<Integer> serviceIds) throws IOException {
         if (CollectionUtils.isEmpty(serviceIds)) {
             throw new UnexpectedException("Service id is empty");
         }
@@ -73,12 +72,11 @@ public class TopologyQueryEsDAO extends EsDAO implements ITopologyQueryDAO {
         sourceBuilder.size(0);
         setQueryCondition(sourceBuilder, startTB, endTB, serviceIds);
 
-        String indexName = DownSamplingModelNameBuilder.build(step, ServiceRelationClientSideMetrics.INDEX_NAME);
+        String indexName = ModelName.build(downsampling, ServiceRelationClientSideMetrics.INDEX_NAME);
         return load(sourceBuilder, indexName, DetectPoint.CLIENT);
     }
 
-    private void setQueryCondition(SearchSourceBuilder sourceBuilder, long startTB, long endTB,
-        List<Integer> serviceIds) {
+    private void setQueryCondition(SearchSourceBuilder sourceBuilder, long startTB, long endTB, List<Integer> serviceIds) {
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
         boolQuery.must().add(QueryBuilders.rangeQuery(ServiceRelationServerSideMetrics.TIME_BUCKET).gte(startTB).lte(endTB));
 
@@ -95,9 +93,8 @@ public class TopologyQueryEsDAO extends EsDAO implements ITopologyQueryDAO {
         sourceBuilder.query(boolQuery);
     }
 
-    @Override public List<Call.CallDetail> loadServerSideServiceRelations(Step step, long startTB,
-        long endTB) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, ServiceRelationServerSideMetrics.INDEX_NAME);
+    @Override public List<Call.CallDetail> loadServerSideServiceRelations(Downsampling downsampling, long startTB, long endTB) throws IOException {
+        String indexName = ModelName.build(downsampling, ServiceRelationServerSideMetrics.INDEX_NAME);
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         sourceBuilder.query(QueryBuilders.rangeQuery(ServiceRelationServerSideMetrics.TIME_BUCKET).gte(startTB).lte(endTB));
         sourceBuilder.size(0);
@@ -105,9 +102,8 @@ public class TopologyQueryEsDAO extends EsDAO implements ITopologyQueryDAO {
         return load(sourceBuilder, indexName, DetectPoint.SERVER);
     }
 
-    @Override public List<Call.CallDetail> loadClientSideServiceRelations(Step step, long startTB,
-        long endTB) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, ServiceRelationClientSideMetrics.INDEX_NAME);
+    @Override public List<Call.CallDetail> loadClientSideServiceRelations(Downsampling downsampling, long startTB, long endTB) throws IOException {
+        String indexName = ModelName.build(downsampling, ServiceRelationClientSideMetrics.INDEX_NAME);
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         sourceBuilder.query(QueryBuilders.rangeQuery(ServiceRelationServerSideMetrics.TIME_BUCKET).gte(startTB).lte(endTB));
         sourceBuilder.size(0);
@@ -116,9 +112,8 @@ public class TopologyQueryEsDAO extends EsDAO implements ITopologyQueryDAO {
     }
 
     @Override
-    public List<Call.CallDetail> loadSpecifiedDestOfServerSideEndpointRelations(Step step, long startTB, long endTB,
-        int destEndpointId) throws IOException {
-        String indexName = DownSamplingModelNameBuilder.build(step, EndpointRelationServerSideMetrics.INDEX_NAME);
+    public List<Call.CallDetail> loadSpecifiedDestOfServerSideEndpointRelations(Downsampling downsampling, long startTB, long endTB, int destEndpointId) throws IOException {
+        String indexName = ModelName.build(downsampling, EndpointRelationServerSideMetrics.INDEX_NAME);
 
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         sourceBuilder.size(0);

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2AggregationQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2AggregationQueryDAO.java
@@ -19,18 +19,13 @@
 package org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao;
 
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.sql.*;
+import java.util.*;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
-import org.apache.skywalking.oap.server.core.query.entity.Order;
-import org.apache.skywalking.oap.server.core.query.entity.Step;
-import org.apache.skywalking.oap.server.core.query.entity.TopNEntity;
-import org.apache.skywalking.oap.server.core.register.EndpointInventory;
-import org.apache.skywalking.oap.server.core.register.ServiceInstanceInventory;
-import org.apache.skywalking.oap.server.core.storage.DownSamplingModelNameBuilder;
+import org.apache.skywalking.oap.server.core.query.entity.*;
+import org.apache.skywalking.oap.server.core.register.*;
+import org.apache.skywalking.oap.server.core.storage.model.ModelName;
 import org.apache.skywalking.oap.server.core.storage.query.IAggregationQueryDAO;
 import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCHikariCPClient;
 
@@ -38,6 +33,7 @@ import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCHikariC
  * @author wusheng
  */
 public class H2AggregationQueryDAO implements IAggregationQueryDAO {
+
     private JDBCHikariCPClient h2Client;
 
     public H2AggregationQueryDAO(JDBCHikariCPClient h2Client) {
@@ -45,46 +41,47 @@ public class H2AggregationQueryDAO implements IAggregationQueryDAO {
     }
 
     @Override
-    public List<TopNEntity> getServiceTopN(String indName, String valueCName, int topN, Step step,
+    public List<TopNEntity> getServiceTopN(String indName, String valueCName, int topN, Downsampling downsampling,
         long startTB, long endTB, Order order) throws IOException {
-        return topNQuery(indName, valueCName, topN, step, startTB, endTB, order, null);
+        return topNQuery(indName, valueCName, topN, downsampling, startTB, endTB, order, null);
     }
 
     @Override public List<TopNEntity> getAllServiceInstanceTopN(String indName, String valueCName, int topN,
-        Step step, long startTB, long endTB, Order order) throws IOException {
-        return topNQuery(indName, valueCName, topN, step, startTB, endTB, order, null);
+        Downsampling downsampling, long startTB, long endTB, Order order) throws IOException {
+        return topNQuery(indName, valueCName, topN, downsampling, startTB, endTB, order, null);
     }
 
     @Override
     public List<TopNEntity> getServiceInstanceTopN(int serviceId, String indName, String valueCName,
-        int topN, Step step, long startTB, long endTB, Order order) throws IOException {
-        return topNQuery(indName, valueCName, topN, step, startTB, endTB, order, (sql, conditions) -> {
+        int topN, Downsampling downsampling, long startTB, long endTB, Order order) throws IOException {
+        return topNQuery(indName, valueCName, topN, downsampling, startTB, endTB, order, (sql, conditions) -> {
             sql.append(" and ").append(ServiceInstanceInventory.SERVICE_ID).append("=?");
             conditions.add(serviceId);
         });
     }
 
     @Override
-    public List<TopNEntity> getAllEndpointTopN(String indName, String valueCName, int topN, Step step,
+    public List<TopNEntity> getAllEndpointTopN(String indName, String valueCName, int topN, Downsampling downsampling,
         long startTB, long endTB, Order order) throws IOException {
-        return topNQuery(indName, valueCName, topN, step, startTB, endTB, order, null);
+        return topNQuery(indName, valueCName, topN, downsampling, startTB, endTB, order, null);
     }
 
     @Override public List<TopNEntity> getEndpointTopN(int serviceId, String indName, String valueCName,
-        int topN, Step step, long startTB, long endTB, Order order) throws IOException {
-        return topNQuery(indName, valueCName, topN, step, startTB, endTB, order, (sql, conditions) -> {
+        int topN, Downsampling downsampling, long startTB, long endTB, Order order) throws IOException {
+        return topNQuery(indName, valueCName, topN, downsampling, startTB, endTB, order, (sql, conditions) -> {
             sql.append(" and ").append(EndpointInventory.SERVICE_ID).append("=?");
             conditions.add(serviceId);
         });
     }
 
-    public List<TopNEntity> topNQuery(String indName, String valueCName, int topN, Step step,
+    public List<TopNEntity> topNQuery(String indName, String valueCName, int topN, Downsampling downsampling,
         long startTB, long endTB, Order order, AppendCondition appender) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, indName);
+        String indexName = ModelName.build(downsampling, indName);
+
         StringBuilder sql = new StringBuilder();
         List<Object> conditions = new ArrayList<>(10);
         sql.append("select * from (select avg(").append(valueCName).append(") value,").append(Metrics.ENTITY_ID).append(" from ")
-            .append(tableName).append(" where ");
+            .append(indexName).append(" where ");
         this.setTimeRangeCondition(sql, conditions, startTB, endTB);
         if (appender != null) {
             appender.append(sql, conditions);

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetricsQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetricsQueryDAO.java
@@ -19,23 +19,13 @@
 package org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao;
 
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.sql.*;
+import java.util.*;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.analysis.metrics.*;
-import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
-import org.apache.skywalking.oap.server.core.query.entity.IntValues;
-import org.apache.skywalking.oap.server.core.query.entity.KVInt;
-import org.apache.skywalking.oap.server.core.query.entity.Step;
-import org.apache.skywalking.oap.server.core.query.entity.Thermodynamic;
-import org.apache.skywalking.oap.server.core.query.sql.Function;
-import org.apache.skywalking.oap.server.core.query.sql.KeyValues;
-import org.apache.skywalking.oap.server.core.query.sql.Where;
-import org.apache.skywalking.oap.server.core.storage.DownSamplingModelNameBuilder;
+import org.apache.skywalking.oap.server.core.query.entity.*;
+import org.apache.skywalking.oap.server.core.query.sql.*;
+import org.apache.skywalking.oap.server.core.storage.model.ModelName;
 import org.apache.skywalking.oap.server.core.storage.query.IMetricsQueryDAO;
 import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCHikariCPClient;
 
@@ -50,9 +40,9 @@ public class H2MetricsQueryDAO extends H2SQLExecutor implements IMetricsQueryDAO
     }
 
     @Override
-    public IntValues getValues(String indName, Step step, long startTB, long endTB, Where where, String valueCName,
+    public IntValues getValues(String indName, Downsampling downsampling, long startTB, long endTB, Where where, String valueCName,
         Function function) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, indName);
+        String tableName = ModelName.build(downsampling, indName);
 
         List<KeyValues> whereKeyValues = where.getKeyValues();
         String op;
@@ -109,9 +99,9 @@ public class H2MetricsQueryDAO extends H2SQLExecutor implements IMetricsQueryDAO
         return orderWithDefault0(intValues, ids);
     }
 
-    @Override public IntValues getLinearIntValues(String indName, Step step, List<String> ids,
+    @Override public IntValues getLinearIntValues(String indName, Downsampling downsampling, List<String> ids,
         String valueCName) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, indName);
+        String tableName = ModelName.build(downsampling, indName);
 
         StringBuilder idValues = new StringBuilder();
         for (int valueIdx = 0; valueIdx < ids.size(); valueIdx++) {
@@ -158,9 +148,9 @@ public class H2MetricsQueryDAO extends H2SQLExecutor implements IMetricsQueryDAO
         return intValues;
     }
 
-    @Override public Thermodynamic getThermodynamic(String indName, Step step, List<String> ids,
+    @Override public Thermodynamic getThermodynamic(String indName, Downsampling downsampling, List<String> ids,
         String valueCName) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, indName);
+        String tableName = ModelName.build(downsampling, indName);
 
         StringBuilder idValues = new StringBuilder();
         for (int valueIdx = 0; valueIdx < ids.size(); valueIdx++) {
@@ -182,7 +172,6 @@ public class H2MetricsQueryDAO extends H2SQLExecutor implements IMetricsQueryDAO
                 + ThermodynamicMetrics.DETAIL_GROUP + " detail_group, "
                 + "id "
                 + " from " + tableName + " where id in (" + idValues.toString() + ")")) {
-
 
                 while (resultSet.next()) {
                     axisYStep = resultSet.getInt("step");
@@ -222,5 +211,4 @@ public class H2MetricsQueryDAO extends H2SQLExecutor implements IMetricsQueryDAO
             throw new IOException(e);
         }
     }
-
 }

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TopologyQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TopologyQueryDAO.java
@@ -21,13 +21,14 @@ package org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao;
 import java.io.IOException;
 import java.sql.*;
 import java.util.*;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.analysis.manual.RelationDefineUtil;
 import org.apache.skywalking.oap.server.core.analysis.manual.endpointrelation.EndpointRelationServerSideMetrics;
 import org.apache.skywalking.oap.server.core.analysis.manual.servicerelation.*;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
 import org.apache.skywalking.oap.server.core.query.entity.*;
 import org.apache.skywalking.oap.server.core.source.DetectPoint;
-import org.apache.skywalking.oap.server.core.storage.DownSamplingModelNameBuilder;
+import org.apache.skywalking.oap.server.core.storage.model.ModelName;
 import org.apache.skywalking.oap.server.core.storage.query.ITopologyQueryDAO;
 import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCHikariCPClient;
 
@@ -41,34 +42,31 @@ public class H2TopologyQueryDAO implements ITopologyQueryDAO {
         this.h2Client = h2Client;
     }
 
-    @Override public List<Call.CallDetail> loadSpecifiedServerSideServiceRelations(Step step, long startTB, long endTB,
+    @Override public List<Call.CallDetail> loadSpecifiedServerSideServiceRelations(Downsampling downsampling, long startTB, long endTB,
         List<Integer> serviceIds) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, ServiceRelationServerSideMetrics.INDEX_NAME);
+        String tableName = ModelName.build(downsampling, ServiceRelationServerSideMetrics.INDEX_NAME);
         return loadServiceCalls(tableName, startTB, endTB, ServiceRelationServerSideMetrics.SOURCE_SERVICE_ID, ServiceRelationServerSideMetrics.DEST_SERVICE_ID, serviceIds, true);
     }
 
-    @Override public List<Call.CallDetail> loadSpecifiedClientSideServiceRelations(Step step, long startTB, long endTB,
+    @Override public List<Call.CallDetail> loadSpecifiedClientSideServiceRelations(Downsampling downsampling, long startTB, long endTB,
         List<Integer> serviceIds) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, ServiceRelationClientSideMetrics.INDEX_NAME);
+        String tableName = ModelName.build(downsampling, ServiceRelationClientSideMetrics.INDEX_NAME);
         return loadServiceCalls(tableName, startTB, endTB, ServiceRelationServerSideMetrics.SOURCE_SERVICE_ID, ServiceRelationServerSideMetrics.DEST_SERVICE_ID, serviceIds, false);
     }
 
-    @Override public List<Call.CallDetail> loadServerSideServiceRelations(Step step, long startTB,
-        long endTB) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, ServiceRelationServerSideMetrics.INDEX_NAME);
+    @Override public List<Call.CallDetail> loadServerSideServiceRelations(Downsampling downsampling, long startTB, long endTB) throws IOException {
+        String tableName = ModelName.build(downsampling, ServiceRelationServerSideMetrics.INDEX_NAME);
         return loadServiceCalls(tableName, startTB, endTB, ServiceRelationServerSideMetrics.SOURCE_SERVICE_ID, ServiceRelationServerSideMetrics.DEST_SERVICE_ID, new ArrayList<>(0), false);
     }
 
-    @Override public List<Call.CallDetail> loadClientSideServiceRelations(Step step, long startTB,
-        long endTB) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, ServiceRelationClientSideMetrics.INDEX_NAME);
+    @Override public List<Call.CallDetail> loadClientSideServiceRelations(Downsampling downsampling, long startTB, long endTB) throws IOException {
+        String tableName = ModelName.build(downsampling, ServiceRelationClientSideMetrics.INDEX_NAME);
         return loadServiceCalls(tableName, startTB, endTB, ServiceRelationServerSideMetrics.SOURCE_SERVICE_ID, ServiceRelationServerSideMetrics.DEST_SERVICE_ID, new ArrayList<>(0), true);
     }
 
     @Override
-    public List<Call.CallDetail> loadSpecifiedDestOfServerSideEndpointRelations(Step step, long startTB, long endTB,
-        int destEndpointId) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, EndpointRelationServerSideMetrics.INDEX_NAME);
+    public List<Call.CallDetail> loadSpecifiedDestOfServerSideEndpointRelations(Downsampling downsampling, long startTB, long endTB, int destEndpointId) throws IOException {
+        String tableName = ModelName.build(downsampling, EndpointRelationServerSideMetrics.INDEX_NAME);
 
         List<Call.CallDetail> calls = loadEndpointFromSide(tableName, startTB, endTB, EndpointRelationServerSideMetrics.SOURCE_ENDPOINT_ID, EndpointRelationServerSideMetrics.DEST_ENDPOINT_ID, destEndpointId, false);
         calls.addAll(loadEndpointFromSide(tableName, startTB, endTB, EndpointRelationServerSideMetrics.SOURCE_ENDPOINT_ID, EndpointRelationServerSideMetrics.DEST_ENDPOINT_ID, destEndpointId, true));

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/mysql/MySQLAggregationQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/mysql/MySQLAggregationQueryDAO.java
@@ -19,16 +19,12 @@
 package org.apache.skywalking.oap.server.storage.plugin.jdbc.mysql;
 
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.sql.*;
+import java.util.*;
+import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
-import org.apache.skywalking.oap.server.core.query.entity.Order;
-import org.apache.skywalking.oap.server.core.query.entity.Step;
-import org.apache.skywalking.oap.server.core.query.entity.TopNEntity;
-import org.apache.skywalking.oap.server.core.storage.DownSamplingModelNameBuilder;
+import org.apache.skywalking.oap.server.core.query.entity.*;
+import org.apache.skywalking.oap.server.core.storage.model.ModelName;
 import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCHikariCPClient;
 import org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao.H2AggregationQueryDAO;
 
@@ -36,15 +32,16 @@ import org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao.H2Aggregation
  * @author wusheng
  */
 public class MySQLAggregationQueryDAO extends H2AggregationQueryDAO {
+
     public MySQLAggregationQueryDAO(
         JDBCHikariCPClient client) {
         super(client);
     }
 
     @Override
-    public List<TopNEntity> topNQuery(String indName, String valueCName, int topN, Step step,
+    public List<TopNEntity> topNQuery(String indName, String valueCName, int topN, Downsampling downsampling,
         long startTB, long endTB, Order order, AppendCondition appender) throws IOException {
-        String tableName = DownSamplingModelNameBuilder.build(step, indName);
+        String tableName = ModelName.build(downsampling, indName);
         StringBuilder sql = new StringBuilder();
         List<Object> conditions = new ArrayList<>(10);
         sql.append("select * from (select avg(").append(valueCName).append(") value,").append(Metrics.ENTITY_ID).append(" from ")


### PR DESCRIPTION
Downsampling is the core feature of the OAP backend. It used on everywhere such as model name, analysis worker, time bucket transform, time duration calculates, query service... 
For some historical reason, we define a step enum object for query service. It has the same meaning as the downsampling. But, this object is used for UI protocol. We can't replace it. 
So, I decide to make the step stay in the layer of Graphql resolvers. 