### PR TITLE
Fix lettuce AsyncCommand::onComplete bug

### DIFF
--- a/apm-sniffer/optional-plugins/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/AsyncCommandMethodInterceptor.java
+++ b/apm-sniffer/optional-plugins/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/AsyncCommandMethodInterceptor.java
@@ -43,7 +43,7 @@ public class AsyncCommandMethodInterceptor implements InstanceMethodsAroundInter
         String operationName = "Lettuce/" + asyncCommand.getType().name();
         AbstractSpan span = ContextManager.createLocalSpan(operationName + "/onComplete");
         span.setComponent(ComponentsDefine.LETTUCE);
-        if(allArguments[0] instanceof Consumer){
+        if (allArguments[0] instanceof Consumer) {
             allArguments[0] = new SWConsumer((Consumer) allArguments[0], ContextManager.capture(), operationName);
         } else {
             allArguments[0] = new SWBiConsumer((BiConsumer) allArguments[0], ContextManager.capture(), operationName);

--- a/apm-sniffer/optional-plugins/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/AsyncCommandMethodInterceptor.java
+++ b/apm-sniffer/optional-plugins/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/AsyncCommandMethodInterceptor.java
@@ -27,6 +27,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 
 import java.lang.reflect.Method;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
@@ -42,7 +43,11 @@ public class AsyncCommandMethodInterceptor implements InstanceMethodsAroundInter
         String operationName = "Lettuce/" + asyncCommand.getType().name();
         AbstractSpan span = ContextManager.createLocalSpan(operationName + "/onComplete");
         span.setComponent(ComponentsDefine.LETTUCE);
-        allArguments[0] = new SWConsumer((Consumer) allArguments[0], ContextManager.capture(), operationName);
+        if(allArguments[0] instanceof Consumer){
+            allArguments[0] = new SWConsumer((Consumer) allArguments[0], ContextManager.capture(), operationName);
+        } else {
+            allArguments[0] = new SWBiConsumer((BiConsumer) allArguments[0], ContextManager.capture(), operationName);
+        }
     }
 
     @Override

--- a/apm-sniffer/optional-plugins/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/SWBiConsumer.java
+++ b/apm-sniffer/optional-plugins/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/SWBiConsumer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.lettuce.v5;
+
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+
+import java.util.function.BiConsumer;
+
+/**
+ * @author zhaoyuguang
+ */
+public class SWBiConsumer<T, U> implements BiConsumer<T, U> {
+
+    private BiConsumer<T, U> biConsumer;
+    private ContextSnapshot snapshot;
+    private String operationName;
+
+    SWBiConsumer(BiConsumer<T, U> biConsumer, ContextSnapshot snapshot, String operationName) {
+        this.biConsumer = biConsumer;
+        this.snapshot = snapshot;
+        this.operationName = operationName;
+    }
+
+    @Override
+    public void accept(T t, U u) {
+        AbstractSpan span = ContextManager.createLocalSpan(operationName + "/accept");
+        span.setComponent(ComponentsDefine.LETTUCE);
+        try {
+            ContextManager.continued(snapshot);
+            biConsumer.accept(t, u);
+        } catch (Throwable th) {
+            ContextManager.activeSpan().errorOccurred().log(th);
+        } finally {
+            ContextManager.stopSpan();
+        }
+    }
+}

--- a/apm-sniffer/optional-plugins/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/define/AsyncCommandInstrumentation.java
+++ b/apm-sniffer/optional-plugins/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/define/AsyncCommandInstrumentation.java
@@ -27,6 +27,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInst
 import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.skywalking.apm.agent.core.plugin.bytebuddy.ArgumentTypeNameMatch.takesArgumentWithType;
 import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
 
 /**
@@ -49,7 +50,8 @@ public class AsyncCommandInstrumentation extends ClassInstanceMethodsEnhancePlug
             new InstanceMethodsInterceptPoint() {
                 @Override
                 public ElementMatcher<MethodDescription> getMethodsMatcher() {
-                    return named("onComplete");
+                    return (named("onComplete").and(takesArgumentWithType(0,"java.util.function.Consumer")))
+                            .or(named("onComplete").and(takesArgumentWithType(0,"java.util.function.BiConsumer")));
                 }
 
                 @Override


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
https://github.com/apache/skywalking/issues/2790
___
### Bug fix
- Bug description.
There are three exceptions

###### 1.ClassCastException
```
ERROR 2019-05-30 19:31:32:153 lettuce-nioEventLoop-4-3 InstMethodsInterWithOverrideArgs : class[class io.lettuce.core.protocol.AsyncCommand] before method[onComplete] intercept failure
java.lang.ClassCastException: io.lettuce.core.protocol.CommandExpiryWriter$$Lambda$833/818080089 cannot be cast to java.util.function.Consumer
        At org.apache.skywalking.apm.plugin.lettuce.v5.AsyncCommandMethodInterceptor.beforeMethod(AsyncCommandMethodInterceptor.java:45)
```
![image](https://user-images.githubusercontent.com/10150229/58690296-cc3a3300-83bb-11e9-8abc-635ad2db6b95.png)
This exception is also the exception of this pr repair: because AsyncCommand::onComplete is polymorphic, it can be Consumer or BiConsumer, originally only wrote Consumer, so there is a cast exception, the repair process is that I have to divide the Consumer or BiConsumer, Logic is handled separately.

###### 2.NullPointerException
```
ERROR 2019-05-30 19:31:32:155 lettuce-nioEventLoop-4-3 InstMethodsInter : class[class io.lettuce.core.protocol.DefaultEndpoint] before method[writeToChannelAndFlush] intercept failure
java.lang.NullPointerException
        At org.apache.skywalking.apm.plugin.lettuce.v5.RedisChannelWriterInterceptor.beforeMethod(RedisChannelWriterInterceptor.java:62)
```
Because the peer will be lost in some cases, I have fixed this pr https://github.com/apache/skywalking/pull/2621
###### 3.IllegalStateException
```
ERROR 2019-05-30 19:31:32:158 lettuce-nioEventLoop-4-3 InstMethodsInter : class[class io.lettuce.core.protocol.DefaultEndpoint] after method[writeToChannelAndFlush] intercept failure
java.lang.IllegalStateException: No active span.
        At org.apache.skywalking.apm.agent.core.context.TracingContext.activeSpan(TracingContext.java:382)
        At org.apache.skywalking.apm.agent.core.context.ContextManager.activeSpan(ContextManager.java:161)
        At org.apache.skywalking.apm.agent.core.context.ContextManager.stopSpan(ContextManager.java:165)
        At org.apache.skywalking.apm.plugin.lettuce.v5.RedisChannelWriterInterceptor.afterMethod(RedisChannelWriterInterceptor.java:72)
```
       The reason is the same as 2, because before is exception, so afterMethod reporting this error
