### PR TITLE
Fix the span cannot stop when forward request

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/tomcat78x/ForwardInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/tomcat78x/ForwardInterceptor.java
@@ -46,7 +46,7 @@ public class ForwardInterceptor implements InstanceMethodsAroundInterceptor, Ins
     @Override
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         Object ret) throws Throwable {
-
+        ContextManager.getRuntimeContext().remove(Constants.FORWARD_REQUEST_FLAG);
         return ret;
     }
 


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#2637
___
### Bug fix
- Bug description.
This bug caused by the forward flag not clearing in time and it reasoned that the span that spring plugin generated could not finish,  and here are the steps of issue #2637 
1. Create entry span of tomcat (Tomcat plugin)
2. Create entry span of spring controller (Spring plugin)
3. Invoke forward method and set forward flag and forward event (Tomcat plugin)
4. Create entry span but DO NOTHING, because the forward flag has set[1] (Spring plugin)
5. Finish entry span but Do NOTHING, because the forward flag has set[1] (Spring plugin)
6. Finish forward method (Tomcat plugin)
7. Finish entry span, but Do NOTHING, because the forward flag has set[1] (Spring plugin)
8. Finish entry span (Tomcat plugin)

- How to fix?
Remove the `SW_FORWARD_REQUEST_FLAG` flag when finished `forward` method.

[1]: https://github.com/apache/skywalking/pull/1325