### PR TITLE
Refactor ConfigWatcherRegister to only read interested configs

### DIFF
--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigWatcherRegister.java
@@ -64,12 +64,12 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
         logger.info("Current configurations after the bootstrap sync." + LINE_SEPARATOR + register.toString());
 
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-            new RunnableWithExceptionProtection(() -> configSync(),
+            new RunnableWithExceptionProtection(this::configSync,
                 t -> logger.error("Sync config center error.", t)), syncPeriod, syncPeriod, TimeUnit.SECONDS);
     }
 
     void configSync() {
-        ConfigTable configTable = readConfig();
+        ConfigTable configTable = readConfig(register.keys());
 
         configTable.getItems().forEach(item -> {
             String itemName = item.getName();
@@ -99,7 +99,7 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
         logger.trace("Current configurations after the sync." + LINE_SEPARATOR + register.toString());
     }
 
-    public abstract ConfigTable readConfig();
+    public abstract ConfigTable readConfig(Set<String> keys);
 
     public class Register {
         private Map<String, WatcherHolder> register = new HashMap<>();
@@ -114,6 +114,10 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
 
         public WatcherHolder get(String name) {
             return register.get(name);
+        }
+
+        public Set<String> keys() {
+            return register.keySet();
         }
 
         @Override public String toString() {


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

- Related issues
resolve #2834

___
### New feature or improvement
- Describe the details and related test reports.
Specify interested config keys and only read configs of those keys from configuration center