### PR TITLE
Time series ElasticSearch implementation bug of record type

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/RecordStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/RecordStreamProcessor.java
@@ -65,7 +65,7 @@ public class RecordStreamProcessor implements StreamProcessor<Record> {
         }
 
         IModelSetter modelSetter = moduleDefineHolder.find(CoreModule.NAME).provider().getService(IModelSetter.class);
-        Model model = modelSetter.putIfAbsent(recordClass, stream.scopeId(), new Storage(stream.name(), true, true, Downsampling.Minute));
+        Model model = modelSetter.putIfAbsent(recordClass, stream.scopeId(), new Storage(stream.name(), true, true, Downsampling.Second));
         RecordPersistentWorker persistentWorker = new RecordPersistentWorker(moduleDefineHolder, model, 1000, recordDAO);
 
         persistentWorkers.add(persistentWorker);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/TopNStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/TopNStreamProcessor.java
@@ -61,7 +61,7 @@ public class TopNStreamProcessor implements StreamProcessor<TopN> {
         }
 
         IModelSetter modelSetter = moduleDefineHolder.find(CoreModule.NAME).provider().getService(IModelSetter.class);
-        Model model = modelSetter.putIfAbsent(topNClass, stream.scopeId(), new Storage(stream.name(), true, true, Downsampling.Minute));
+        Model model = modelSetter.putIfAbsent(topNClass, stream.scopeId(), new Storage(stream.name(), true, true, Downsampling.Second));
 
         TopNWorker persistentWorker = new TopNWorker(moduleDefineHolder, model, 50, recordDAO);
         persistentWorkers.add(persistentWorker);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/ModelName.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/ModelName.java
@@ -33,8 +33,8 @@ public class ModelName {
                 return modelName + Const.ID_SPLIT + Downsampling.Day.getName();
             case Hour:
                 return modelName + Const.ID_SPLIT + Downsampling.Hour.getName();
-            case Second:
-                return modelName + Const.ID_SPLIT + Downsampling.Second.getName();
+//            case Second:
+//                return modelName + Const.ID_SPLIT + Downsampling.Second.getName();
             default:
                 return modelName;
         }


### PR DESCRIPTION
Fixed a time series bug about downsampling setting in processors are different from the setting in receivers.
TopN and record processor setting the downsampling value is minute, but the trace receiver setting the time bucket value to be the second, so the OAP server creates the top n and record indexes with the name of minute time bucket. But the trace receiver sets the top n and record with the second time bucket, then OAP server creates a new index with the name of the second time bucket, it out of our expectations.

#2851