### PR TITLE
Lift checkstyle config to plugin level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,29 +507,29 @@
                         <version>6.0.0-GA</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <configLocation>skywalking/checkStyle.xml</configLocation>
+                    <headerLocation>skywalking/CHECKSTYLE_HEAD</headerLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <failsOnError>true</failsOnError>
+                    <includes>org/apache/skywalking/**/*.java</includes>
+                    <excludes>
+                        org/apache/skywalking/apm/network/register/v2/**/*.java,
+                        org/apache/skywalking/apm/network/common/**/*.java,
+                        org/apache/skywalking/apm/network/servicemesh/**/*.java,
+                        org/apache/skywalking/apm/network/language/**/*.java,
+                        org/apache/skywalking/oap/server/core/remote/grpc/proto/*.java,
+                        org/apache/skywalking/oal/tool/grammar/*.java,
+                        org/apache/skywalking/oap/server/exporter/grpc/*.java,
+                        org/apache/skywalking/oap/server/configuration/service/*.java
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>validate</id>
                         <phase>process-sources</phase>
-                        <configuration>
-                            <configLocation>skywalking/checkStyle.xml</configLocation>
-                            <headerLocation>skywalking/CHECKSTYLE_HEAD</headerLocation>
-                            <encoding>UTF-8</encoding>
-                            <consoleOutput>true</consoleOutput>
-                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                            <failsOnError>true</failsOnError>
-                            <includes>org/apache/skywalking/**/*.java</includes>
-                            <excludes>
-                                org/apache/skywalking/apm/network/register/v2/**/*.java,
-                                org/apache/skywalking/apm/network/common/**/*.java,
-                                org/apache/skywalking/apm/network/servicemesh/**/*.java,
-                                org/apache/skywalking/apm/network/language/**/*.java,
-                                org/apache/skywalking/oap/server/core/remote/grpc/proto/*.java,
-                                org/apache/skywalking/oal/tool/grammar/*.java,
-                                org/apache/skywalking/oap/server/exporter/grpc/*.java,
-                                org/apache/skywalking/oap/server/configuration/service/*.java
-                            </excludes>
-                        </configuration>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

___
### Bug fix
- Bug description.

the configurations of `checkstyle` is placed in the `execution` tag, running `mvn checkstyle:check` won't take those configs and use the built-in checkstyle configs (such as Sun or Google), but `mvn process-sources` will cause other unwanted tasks (e.g. jacoco, enforcer), this patch allows running `mvn checkstyle:check` without extra efforts
