### PR TITLE
Update ES-Server-FAQ.md

### DIFF
--- a/docs/en/FAQ/ES-Server-FAQ.md
+++ b/docs/en/FAQ/ES-Server-FAQ.md
@@ -12,9 +12,6 @@ Some new user may face the following error in ElasticSearch storage. ERROR CODE 
 You could add following config to `elasticsearch.yml`, set the value based on your env.
 ```yml
 # In tracing scenario, consider to set more than this at least.
-thread_pool.bulk.queue_size: 1000
-
-thread_pool.bulk.size: 16
 thread_pool.index.queue_size: 500
 thread_pool.write.queuq_size: 500
 

--- a/docs/en/FAQ/ES-Server-FAQ.md
+++ b/docs/en/FAQ/ES-Server-FAQ.md
@@ -13,7 +13,7 @@ You could add following config to `elasticsearch.yml`, set the value based on yo
 ```yml
 # In tracing scenario, consider to set more than this at least.
 thread_pool.index.queue_size: 500
-thread_pool.write.queuq_size: 500
+thread_pool.write.queue_size: 500
 
 # When you face query error at trace page, remember to check this.
 index.max_result_window: 1000000


### PR DESCRIPTION
[Thread Pool Setting Document](https://www.elastic.co/guide/en/elasticsearch/reference/6.3/modules-threadpool.html?nsukey=W48pJFXgvLgtyfM%2FXI%2FQ8BhcPYE0WjNFGwKD%2Bv0cjUkocQhh1FCPQwklwVBOec541GcUkX899f%2FQv5ikjA8ckqdcrlVHpjATTKbJarNA1Gr%2BltpTiDJe%2FMuqrZGa0CAkbLfIGrYqMyc0s%2BlkxFr%2BzEo2hmWsgMaPZvK9K6f9Xugz0k0v1Wb2nfeex8ZQn0Y9SFEHwRaYV5uzw8rnH9I%2BGg%3D%3D)

From this document, we can find that the bulk thread pool setting is deleted.

write
For single-document index/delete/update and bulk requests. Thread pool type is fixed with a size of # of available processors, queue_size of 200. The maximum size for this pool is 1 + # of available processors.