### PR TITLE
Use ids query method instead of get method for metrics persistence.

### DIFF
--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
@@ -218,6 +218,15 @@ public class ElasticSearchClient implements Client {
         return client.get(request);
     }
 
+    public SearchResponse idQuery(String indexName, String id) throws IOException {
+        indexName = formatIndexName(indexName);
+
+        SearchRequest searchRequest = new SearchRequest(indexName);
+        searchRequest.types(TYPE);
+        searchRequest.source().query(QueryBuilders.idsQuery().addIds(id));
+        return client.search(searchRequest);
+    }
+
     public Map<String, Map<String, Object>> ids(String indexName, String... ids) throws IOException {
         indexName = formatIndexName(indexName);
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
@@ -41,8 +41,7 @@ public class MetricsEsDAO extends EsDAO implements IMetricsDAO<IndexRequest, Upd
     }
 
     @Override public Metrics get(Model model, Metrics metrics) throws IOException {
-        String modelName = TimeSeriesUtils.timeSeries(model, metrics.getTimeBucket());
-        SearchResponse response = getClient().idQuery(modelName, metrics.id());
+        SearchResponse response = getClient().idQuery(model.getName(), metrics.id());
         if (response.getHits().totalHits > 0) {
             return storageBuilder.map2Data(response.getHits().getAt(0).getSourceAsMap());
         } else {

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
@@ -23,8 +23,8 @@ import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
 import org.apache.skywalking.oap.server.core.storage.*;
 import org.apache.skywalking.oap.server.core.storage.model.Model;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
-import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -42,9 +42,9 @@ public class MetricsEsDAO extends EsDAO implements IMetricsDAO<IndexRequest, Upd
 
     @Override public Metrics get(Model model, Metrics metrics) throws IOException {
         String modelName = TimeSeriesUtils.timeSeries(model, metrics.getTimeBucket());
-        GetResponse response = getClient().get(modelName, metrics.id());
-        if (response.isExists()) {
-            return storageBuilder.map2Data(response.getSource());
+        SearchResponse response = getClient().idQuery(modelName, metrics.id());
+        if (response.getHits().totalHits > 0) {
+            return storageBuilder.map2Data(response.getHits().getAt(0).getSourceAsMap());
         } else {
             return null;
         }


### PR DESCRIPTION
**Performance test report:**

4 million rows in the index, those two methods executed 200 thousand times each.
- The total duration of the get method:  42737 million seconds.
- The total duration of the ids query method: 103436 million seconds.

**Conclusion**
Although the ids query method is slower than the get method, but it's not too much. So, I think it's acceptable.

#2933