### PR TITLE
Add more logs for tracking elasticsearch validation error, e.g. [Data…

### DIFF
--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
@@ -246,20 +246,35 @@ public class ElasticSearchClient implements Client {
     public void forceInsert(String indexName, String id, XContentBuilder source) throws IOException {
         IndexRequest request = prepareInsert(indexName, id, source);
         request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        client.index(request);
+        try {
+            client.index(request);
+        } catch (IOException e) {
+            logger.error("Failed to forceInsert: indexName={}, id={}", indexName, id);
+            throw e;
+        }
     }
 
     public void forceUpdate(String indexName, String id, XContentBuilder source, long version) throws IOException {
         UpdateRequest request = prepareUpdate(indexName, id, source);
         request.version(version);
         request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        client.update(request);
+        try {
+            client.update(request);
+        } catch (IOException e) {
+            logger.error("Failed to forceUpdate: indexName={}, id={}", indexName, id);
+            throw e;
+        }
     }
 
     public void forceUpdate(String indexName, String id, XContentBuilder source) throws IOException {
         UpdateRequest request = prepareUpdate(indexName, id, source);
         request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        client.update(request);
+        try {
+            client.update(request);
+        } catch (IOException e) {
+            logger.error("Failed to forceUpdate: indexName={}, id={}", indexName, id);
+            throw e;
+        }
     }
 
     public IndexRequest prepareInsert(String indexName, String id, XContentBuilder source) {


### PR DESCRIPTION
…Carrier.REGISTER_L2.BulkConsumePool.0.Thread] ERROR [] - Validation Failed: 1: id is too long, must be no longer than 512 bytes but was: 685;

Please answer these questions before submitting pull request

- Why submit this pull request?
We have got a lot of error logs like: org.elasticsearch.action.ActionRequestValidationException: Validation Failed: 1: id is too long, must be no longer than 512 bytes but was: 685;

Without the detailed log, we cannot do improvement for the endpoint names or find out whether SkyWalking has a bug or not.
