### PR TITLE
Optimising docker image size.

### DIFF
--- a/docker/oap/Dockerfile.oap
+++ b/docker/oap/Dockerfile.oap
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8u181-jdk-stretch
+FROM openjdk:8u181-jre-alpine AS builder
 
 ENV DIST_NAME=apache-skywalking-apm-bin \
     JAVA_OPTS=" -Xms256M " \
@@ -29,6 +29,10 @@ RUN set -ex; \
     rm -rf "$DIST_NAME/config/log4j2.xml"; \
     rm -rf "$DIST_NAME/bin"; rm -rf "$DIST_NAME/webapp"; rm -rf "$DIST_NAME/agent"; \
     mv "$DIST_NAME" skywalking;
+
+FROM openjdk:8u181-jre-alpine
+
+COPY --from=builder /skywalking /skywalking
 
 WORKDIR skywalking
 

--- a/docker/ui/Dockerfile.ui
+++ b/docker/ui/Dockerfile.ui
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8u181-jdk-stretch
+FROM openjdk:8u181-jre-alpine AS builder
 
 ENV DIST_NAME=apache-skywalking-apm-bin \
     JAVA_OPTS=" -Xms256M " \
@@ -29,6 +29,10 @@ RUN set -ex; \
     rm -rf "$DIST_NAME/config"; \
     rm -rf "$DIST_NAME/bin"; rm -rf "$DIST_NAME/oap-libs"; rm -rf "$DIST_NAME/agent"; \
     mv "$DIST_NAME" skywalking;
+
+FROM openjdk:8u181-jre-alpine
+
+COPY --from=builder /skywalking /skywalking
 
 WORKDIR skywalking
 


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

In my opinion, I think the final image is too big.
If there are no special requirements for the docker image, we can optimize it in some way.

Before:
```bash
skywalking/ui                               latest      733MB
skywalking/oap                              latest     834MB
```

After:
```bash
skywalking/ui                               latest     83.4MB
skywalking/oap                              latest    184MB
```
