### PR TITLE
Using ArryList instead of LinkedList

### DIFF
--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/buffer/Buffer.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/buffer/Buffer.java
@@ -18,9 +18,11 @@
 
 package org.apache.skywalking.apm.commons.datacarrier.buffer;
 
-import java.util.*;
 import org.apache.skywalking.apm.commons.datacarrier.callback.QueueBlockingCallback;
 import org.apache.skywalking.apm.commons.datacarrier.common.AtomicRangeInteger;
+
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Created by wusheng on 2016/10/25.
@@ -79,19 +81,17 @@ public class Buffer<T> {
         return buffer.length;
     }
 
-    public LinkedList<T> obtain() {
-        return this.obtain(0, buffer.length);
+    public void obtain(List<T> consumeList) {
+        this.obtain(consumeList, 0, buffer.length);
     }
 
-    public LinkedList<T> obtain(int start, int end) {
-        LinkedList<T> result = new LinkedList<T>();
+    public void obtain(List<T> consumeList, int start, int end) {
         for (int i = start; i < end; i++) {
             if (buffer[i] != null) {
-                result.add((T)buffer[i]);
+                consumeList.add((T)buffer[i]);
                 buffer[i] = null;
             }
         }
-        return result;
     }
 
 }

--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerThread.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerThread.java
@@ -19,9 +19,10 @@
 
 package org.apache.skywalking.apm.commons.datacarrier.consumer;
 
-import java.util.LinkedList;
-import java.util.List;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.Buffer;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by wusheng on 2016/10/25.
@@ -36,7 +37,7 @@ public class ConsumerThread<T> extends Thread {
         super(threadName);
         this.consumer = consumer;
         running = false;
-        dataSources = new LinkedList<DataSource>();
+        dataSources = new ArrayList<DataSource>(1);
         this.consumeCycle = consumeCycle;
     }
 
@@ -64,34 +65,30 @@ public class ConsumerThread<T> extends Thread {
     public void run() {
         running = true;
 
+        final List<T> consumeList = new ArrayList<T>();
         while (running) {
-            boolean hasData = consume();
+            boolean hasData = consume(consumeList);
 
             if (!hasData) {
                 try {
                     Thread.sleep(consumeCycle);
                 } catch (InterruptedException e) {
                 }
+            } else {
+                consumeList.clear();
             }
         }
 
         // consumer thread is going to stop
         // consume the last time
-        consume();
+        consume(consumeList);
 
         consumer.onExit();
     }
 
-    private boolean consume() {
-        boolean hasData = false;
-        LinkedList<T> consumeList = new LinkedList<T>();
+    private boolean consume(List<T> consumeList) {
         for (DataSource dataSource : dataSources) {
-            LinkedList<T> data = dataSource.obtain();
-            if (data.size() == 0) {
-                continue;
-            }
-            consumeList.addAll(data);
-            hasData = true;
+            dataSource.obtain(consumeList);
         }
 
         if (consumeList.size() > 0) {
@@ -101,7 +98,7 @@ public class ConsumerThread<T> extends Thread {
                 consumer.onError(consumeList, t);
             }
         }
-        return hasData;
+        return !consumeList.isEmpty();
     }
 
     void shutdown() {
@@ -122,8 +119,8 @@ public class ConsumerThread<T> extends Thread {
             this.end = end;
         }
 
-        LinkedList<T> obtain() {
-            return sourceBuffer.obtain(start, end);
+        void obtain(List<T> consumeList) {
+            sourceBuffer.obtain(consumeList, start, end);
         }
     }
 }

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/DataCarrierTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/DataCarrierTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.skywalking.apm.commons.datacarrier;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.Buffer;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.BufferStrategy;
@@ -65,13 +66,15 @@ public class DataCarrierTest {
 
         Channels<SampleData> channels = (Channels<SampleData>)(MemberModifier.field(DataCarrier.class, "channels").get(carrier));
         Buffer<SampleData> buffer1 = channels.getBuffer(0);
-        List result1 = buffer1.obtain(0, 100);
+
+        List result = new ArrayList();
+        buffer1.obtain(result, 0, 100);
+        Assert.assertEquals(2, result.size());
 
         Buffer<SampleData> buffer2 = channels.getBuffer(1);
-        List result2 = buffer2.obtain(0, 100);
+        buffer2.obtain(result, 0, 100);
 
-        Assert.assertEquals(2, result1.size());
-        Assert.assertEquals(4, result1.size() + result2.size());
+        Assert.assertEquals(4, result.size());
 
     }
 
@@ -86,11 +89,12 @@ public class DataCarrierTest {
 
         Channels<SampleData> channels = (Channels<SampleData>)(MemberModifier.field(DataCarrier.class, "channels").get(carrier));
         Buffer<SampleData> buffer1 = channels.getBuffer(0);
-        List result1 = buffer1.obtain(0, 100);
+        List result = new ArrayList();
+        buffer1.obtain(result, 0, 100);
 
         Buffer<SampleData> buffer2 = channels.getBuffer(1);
-        List result2 = buffer2.obtain(0, 100);
-        Assert.assertEquals(200, result1.size() + result2.size());
+        buffer2.obtain(result, 0, 100);
+        Assert.assertEquals(200, result.size());
     }
 
     @Test
@@ -108,11 +112,12 @@ public class DataCarrierTest {
 
         Channels<SampleData> channels = (Channels<SampleData>)(MemberModifier.field(DataCarrier.class, "channels").get(carrier));
         Buffer<SampleData> buffer1 = channels.getBuffer(0);
-        List result1 = buffer1.obtain(0, 100);
+        List result = new ArrayList();
+        buffer1.obtain(result, 0, 100);
 
         Buffer<SampleData> buffer2 = channels.getBuffer(1);
-        List result2 = buffer2.obtain(0, 100);
-        Assert.assertEquals(200, result1.size() + result2.size());
+        buffer2.obtain(result, 0, 100);
+        Assert.assertEquals(200, result.size());
     }
 
     @Test

--- a/apm-sniffer/pom.xml
+++ b/apm-sniffer/pom.xml
@@ -30,9 +30,10 @@
 
     <modules>
         <module>apm-agent</module>
-        <module>apm-agent-core</module>
+        <module>apm-sdk-plugin</module>
         <module>apm-toolkit-activation</module>
         <module>apm-test-tools</module>
+        <module>optional-plugins</module>
     </modules>
 
     <properties>

--- a/apm-sniffer/pom.xml
+++ b/apm-sniffer/pom.xml
@@ -31,10 +31,8 @@
     <modules>
         <module>apm-agent</module>
         <module>apm-agent-core</module>
-        <module>apm-sdk-plugin</module>
         <module>apm-toolkit-activation</module>
         <module>apm-test-tools</module>
-        <module>optional-plugins</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

___
### New feature or improvement
- Describe the details and related test reports.

Arylist has better performance than LinkedList.

Benchmark | Mode | Cnt | Score | Error | Units
---|---|---|---|---|----
DmBenchmark.testArray | thrpt | 5 | 18941.928 | ± 1594.049 | ops/s
DmBenchmark.testLinked | thrpt  |  5 | 12825.072 | ±  128.101 | ops/s

And to make ConsumerThread have one ArrayList to reduce create ArrayList Object and grow.

