### PR TITLE
Remove "IDs can't be null" in backend

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricQueryService.java
@@ -20,24 +20,31 @@ package org.apache.skywalking.oap.server.core.query;
 
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.skywalking.apm.util.StringUtil;
 import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.analysis.Downsampling;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
-import org.apache.skywalking.oap.server.core.query.entity.*;
-import org.apache.skywalking.oap.server.core.query.sql.*;
+import org.apache.skywalking.oap.server.core.query.entity.IntValues;
+import org.apache.skywalking.oap.server.core.query.entity.Thermodynamic;
+import org.apache.skywalking.oap.server.core.query.sql.KeyValues;
+import org.apache.skywalking.oap.server.core.query.sql.Where;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.annotation.ValueColumnIds;
 import org.apache.skywalking.oap.server.core.storage.query.IMetricsQueryDAO;
+import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.module.Service;
-import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author peng-yongsheng
  */
 public class MetricQueryService implements Service {
+
+    private static final Logger logger = LoggerFactory.getLogger(MetricQueryService.class);
 
     private final ModuleManager moduleManager;
     private IMetricsQueryDAO metricQueryDAO;
@@ -53,10 +60,17 @@ public class MetricQueryService implements Service {
         return metricQueryDAO;
     }
 
-    public IntValues getValues(final String indName, final List<String> ids, final Downsampling downsampling, final long startTB,
+    public IntValues getValues(final String indName, final List<String> ids, final Downsampling downsampling,
+        final long startTB,
         final long endTB) throws IOException {
         if (CollectionUtils.isEmpty(ids)) {
-            throw new RuntimeException("IDs can't be null");
+            /**
+             * Don't support query values w/o ID. but UI still did this(as bug),
+             * we return an empty list, and a debug level log,
+             * rather than an exception, which always being considered as a serious error from new users.
+             */
+            logger.debug("query metrics[{}] w/o IDs", indName);
+            return new IntValues();
         }
 
         Where where = new Where();
@@ -68,7 +82,8 @@ public class MetricQueryService implements Service {
         return getMetricQueryDAO().getValues(indName, downsampling, startTB, endTB, where, ValueColumnIds.INSTANCE.getValueCName(indName), ValueColumnIds.INSTANCE.getValueFunction(indName));
     }
 
-    public IntValues getLinearIntValues(final String indName, final String id, final Downsampling downsampling, final long startTB,
+    public IntValues getLinearIntValues(final String indName, final String id, final Downsampling downsampling,
+        final long startTB,
         final long endTB) throws IOException, ParseException {
         List<DurationPoint> durationPoints = DurationUtils.INSTANCE.getDurationPoints(downsampling, startTB, endTB);
         List<String> ids = new ArrayList<>();
@@ -81,7 +96,8 @@ public class MetricQueryService implements Service {
         return getMetricQueryDAO().getLinearIntValues(indName, downsampling, ids, ValueColumnIds.INSTANCE.getValueCName(indName));
     }
 
-    public Thermodynamic getThermodynamic(final String indName, final String id, final Downsampling downsampling, final long startTB,
+    public Thermodynamic getThermodynamic(final String indName, final String id, final Downsampling downsampling,
+        final long startTB,
         final long endTB) throws IOException, ParseException {
         List<DurationPoint> durationPoints = DurationUtils.INSTANCE.getDurationPoints(downsampling, startTB, endTB);
         List<String> ids = new ArrayList<>();


### PR DESCRIPTION
We still don't support query values w/o ID. but UI still did this(as a bug),
Now, I change the codes to return an empty list, and a debug level log,
rather than an exception, which always being considered as a serious error from new users.

I change this only as a tradeoff for endless explanations and @TinyAllen told me, this is hard to change from this version UI codebases.