### PR TITLE
Propose a API change : AbstractTracerContext#asyncStop and AsyncSpan#asyncFinish return boolean

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AbstractTracerContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AbstractTracerContext.java
@@ -113,6 +113,7 @@ public interface AbstractTracerContext {
      * The given span could be stopped officially.
      *
      * @param span to be stopped.
+     * @return true when finished 
      */
-    void asyncStop(AsyncSpan span);
+    boolean asyncStop(AsyncSpan span);
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AsyncSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AsyncSpan.java
@@ -50,7 +50,7 @@ public interface AsyncSpan {
      *
      * The execution times of {@link #prepareForAsync} and {@link #asyncFinish()} must match.
      *
-     * @return the current span
+     * @return true when the current span is finished
      */
-    AbstractSpan asyncFinish();
+    boolean asyncFinish();
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
@@ -97,8 +97,8 @@ public class IgnoredTracerContext implements AbstractTracerContext {
         return this;
     }
 
-    @Override public void asyncStop(AsyncSpan span) {
-
+    @Override public boolean asyncStop(AsyncSpan span) {
+        return stackDepth == 0;
     }
 
     public static class ListenerManager {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -423,12 +423,14 @@ public class TracingContext implements AbstractTracerContext {
         return this;
     }
 
-    @Override public void asyncStop(AsyncSpan span) {
+    @Override public boolean asyncStop(AsyncSpan span) {
         asyncSpanCounter.addAndGet(-1);
 
         if (checkFinishConditions()) {
             finish();
+            return true;
         }
+        return false;
     }
 
     private boolean checkFinishConditions() {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/AbstractTracingSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/AbstractTracingSpan.java
@@ -327,13 +327,12 @@ public abstract class AbstractTracingSpan implements AbstractSpan {
         return this;
     }
 
-    @Override public AbstractSpan asyncFinish() {
+    @Override public boolean asyncFinish() {
         if (!isInAsyncMode) {
             throw new RuntimeException("Span is not in async mode, please use '#prepareForAsync' to active.");
         }
 
         this.endTime = System.currentTimeMillis();
-        context.asyncStop(this);
-        return this;
+        return context.asyncStop(this);
     }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/NoopSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/NoopSpan.java
@@ -120,7 +120,7 @@ public class NoopSpan implements AbstractSpan {
         return this;
     }
 
-    @Override public AbstractSpan asyncFinish() {
-        return this;
+    @Override public boolean asyncFinish() {
+        return true;
     }
 }


### PR DESCRIPTION
    change API AbstractTracerContext#asyncStop and AsyncSpan#asyncFinish return boolean
    return true when in asyncStop do invoke finished

目的是提供能力用来判断调用是否成功调用了fishished方法

原因如下：
  在调用了prepareForAsync后，而后如果是最后代码点调用asyncStop因目前asyncStop实现法中和stopSpan方法中pop last span逻辑而致没法触发fishished方法
如此时再调用stopSpan因asyncSpanCounter==0可以触发fishished方法
但如果调用asyncStop方法内已经触发fishished方法，而后直接再调用stopSpan则会再次触发fishished方法
同时也不能直接调用stopSpan(因之前调用prepareForAsync,asyncSpanCounter不为0且isRunningInAsyncMode=true,故没法触发fishished方法）
由于实际代码存在两种情况，需要调整API返回调后的结果以后判断

之后就这样调用：
```
if (!span.asyncFinish() ){
    ContextManager.stopSpan(span);
}
```

Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
