### PR TITLE
Fix wrong logger names

### DIFF
--- a/apm-sniffer/optional-plugins/customize-enhance-plugin/src/main/java/org/apache/skywalking/apm/plugin/customize/loader/CustomizeInstrumentationLoader.java
+++ b/apm-sniffer/optional-plugins/customize-enhance-plugin/src/main/java/org/apache/skywalking/apm/plugin/customize/loader/CustomizeInstrumentationLoader.java
@@ -41,7 +41,7 @@ import java.util.Set;
 
 public class CustomizeInstrumentationLoader implements InstrumentationLoader {
 
-    private static final ILog logger = LogManager.getLogger(CustomizeConfiguration.class);
+    private static final ILog logger = LogManager.getLogger(CustomizeInstrumentationLoader.class);
 
     @Override
     public List<AbstractClassEnhancePluginDefine> load(AgentClassLoader classLoader) {

--- a/oap-server/server-configuration/configuration-nacos/src/test/java/org/apache/skywalking/oap/server/configuration/nacos/NacosConfigurationTestProvider.java
+++ b/oap-server/server-configuration/configuration-nacos/src/test/java/org/apache/skywalking/oap/server/configuration/nacos/NacosConfigurationTestProvider.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * @author kezhenxu94
  */
 public class NacosConfigurationTestProvider extends ModuleProvider {
-    private static final Logger LOGGER = LoggerFactory.getLogger(NacosConfigurationProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NacosConfigurationTestProvider.class);
 
     ConfigChangeWatcher watcher;
 

--- a/oap-server/server-library/library-server/src/main/java/org/apache/skywalking/oap/server/library/server/jetty/JettyJsonHandler.java
+++ b/oap-server/server-library/library-server/src/main/java/org/apache/skywalking/oap/server/library/server/jetty/JettyJsonHandler.java
@@ -31,7 +31,7 @@ import static java.util.Objects.nonNull;
  * @author wusheng
  */
 public abstract class JettyJsonHandler extends JettyHandler {
-    private static final Logger logger = LoggerFactory.getLogger(JettyHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(JettyJsonHandler.class);
 
     @Override
     protected final void doGet(HttpServletRequest req, HttpServletResponse resp) {

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanV1JettyHandler.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanV1JettyHandler.java
@@ -29,7 +29,7 @@ import org.slf4j.*;
 import zipkin2.codec.SpanBytesDecoder;
 
 public class SpanV1JettyHandler extends JettyHandler {
-    private static final Logger logger = LoggerFactory.getLogger(SpanV2JettyHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(SpanV1JettyHandler.class);
 
     private ZipkinReceiverConfig config;
     private SourceReceiver sourceReceiver;

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/mysql/MySQLStorageProvider.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/mysql/MySQLStorageProvider.java
@@ -44,7 +44,7 @@ import org.slf4j.*;
  */
 public class MySQLStorageProvider extends ModuleProvider {
 
-    private static final Logger logger = LoggerFactory.getLogger(H2StorageProvider.class);
+    private static final Logger logger = LoggerFactory.getLogger(MySQLStorageProvider.class);
 
     private H2StorageConfig config;
     private JDBCHikariCPClient mysqlClient;


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

Logger name differentiate from the real class may be troublesome when debugging, and we have several pull requests that try to correct some of them (#3054), but not all of them.

So I just wrote [a simple shell](https://gist.github.com/kezhenxu94/806af6bbc944b93f7aa6e0b18ce5f3f5) script to find out all such cases and fix them once and for all.

Since we are using `lombok`, to avoid such problem in the future, I'd recommend using `@Slf4j` annotation in future PRs when possible.