### PR TITLE
Add script to clean files created by docker

### DIFF
--- a/Jenkinsfile-E2E
+++ b/Jenkinsfile-E2E
@@ -60,6 +60,11 @@ pipeline {
 
     post {
         always {
+            // Files created by docker container in the directories that are mounted from the host to
+            // the container can not be deleted by `deleteDir()`, we need to mount it again and delete them
+            // inside the container
+            sh 'docker run -v $(pwd)/dist:/sw alpine rm -rf /sw'
+
             // "Abort old build on update" will interrupt the job completely,
             // we need to clean up when there are containers started by the e2e tests
             sh 'docker ps'

--- a/Jenkinsfile-E2E
+++ b/Jenkinsfile-E2E
@@ -60,16 +60,16 @@ pipeline {
 
     post {
         always {
-            // Files created by docker container in the directories that are mounted from the host to
-            // the container can not be deleted by `deleteDir()`, we need to mount it again and delete them
-            // inside the container
-            sh 'docker run -v $(pwd)/dist:/sw alpine rm -rf /sw'
-
             // "Abort old build on update" will interrupt the job completely,
             // we need to clean up when there are containers started by the e2e tests
             sh 'docker ps'
             sh 'docker ps | grep -e "skywalking-e2e-container-${BUILD_ID}" | awk \'{print $1}\' | xargs --no-run-if-empty docker stop'
             sh 'docker ps | grep -e "skywalking-e2e-container-${BUILD_ID}" | awk \'{print $1}\' | xargs --no-run-if-empty docker rm'
+            
+            // Files created by docker container in the directories that are mounted from the host to
+            // the container can not be deleted by `deleteDir()`, we need to mount it again and delete them
+            // inside the container
+            sh 'docker run -v $(pwd)/dist:/sw alpine rm -rf /sw'
             deleteDir()
         }
     }

--- a/Jenkinsfile-E2E
+++ b/Jenkinsfile-E2E
@@ -28,6 +28,7 @@ pipeline {
     stages {
         stage('Checkout Source Code') {
             steps {
+                sh 'docker run -v $(pwd)/dist:/sw alpine sleep 10 && rm -rf /sw'
                 deleteDir()
                 checkout scm
                 sh 'git submodule update --init'

--- a/Jenkinsfile-E2E
+++ b/Jenkinsfile-E2E
@@ -18,7 +18,7 @@
 
 pipeline {
     agent {
-        label 'xenial'
+        label 'H43'
     }
 
     tools {

--- a/Jenkinsfile-E2E
+++ b/Jenkinsfile-E2E
@@ -18,7 +18,7 @@
 
 pipeline {
     agent {
-        label 'H43'
+        label 'H14'
     }
 
     tools {
@@ -26,52 +26,10 @@ pipeline {
     }
 
     stages {
-        stage('Checkout Source Code') {
+        stage('Clean Up') {
             steps {
-                sh 'docker run -v $(pwd)/dist:/sw alpine sleep 10 && rm -rf /sw'
-                deleteDir()
-                checkout scm
-                sh 'git submodule update --init'
+                sh 'docker run -v $(pwd)/dist:/sw alpine rm -rf /sw'
             }
-        }
-
-        stage('Prepare Distribution Package') {
-            steps {
-                sh './mvnw -DskipTests clean package'
-                sh 'tar -zxf dist/apache-skywalking-apm-bin.tar.gz -C dist'
-            }
-        }
-
-        stage('Run End-to-End Tests') {
-            parallel {
-                stage('Run Single Node Tests') {
-                    steps {
-                        sh './mvnw -DskipSurefire=false -Dbuild.id=${BUILD_ID} -f test/e2e/pom.xml -pl e2e-single-service -am verify'
-                    }
-                }
-
-                stage('Run Cluster Tests (ES/ZK)') {
-                    steps {
-                        sh './mvnw -Dbuild.id=${BUILD_ID} -f test/e2e/pom.xml -pl e2e-cluster/test-runner -am verify'
-                    }
-                }
-            }
-        }
-    }
-
-    post {
-        always {
-            // "Abort old build on update" will interrupt the job completely,
-            // we need to clean up when there are containers started by the e2e tests
-            sh 'docker ps'
-            sh 'docker ps | grep -e "skywalking-e2e-container-${BUILD_ID}" | awk \'{print $1}\' | xargs --no-run-if-empty docker stop'
-            sh 'docker ps | grep -e "skywalking-e2e-container-${BUILD_ID}" | awk \'{print $1}\' | xargs --no-run-if-empty docker rm'
-            
-            // Files created by docker container in the directories that are mounted from the host to
-            // the container can not be deleted by `deleteDir()`, we need to mount it again and delete them
-            // inside the container
-            sh 'docker run -v $(pwd)/dist:/sw alpine rm -rf /sw'
-            deleteDir()
         }
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

Files created by the docker container must be delete inside the docker container, this patch add a clean up command to do the job and assign the problematic node to verify whether it works or not.

**Should remove the hardcoded node name "H43" before merging**