### PR TITLE
Remove the worker id, and add worker name for remote handler only.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
@@ -19,12 +19,11 @@
 
 package org.apache.skywalking.apm.agent.core.conf;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
 import org.apache.skywalking.apm.agent.core.logging.core.LogLevel;
 import org.apache.skywalking.apm.agent.core.logging.core.WriterFactory;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * This is the core config in sniffer agent.
@@ -40,14 +39,14 @@ public class Config {
         public static String NAMESPACE = "";
 
         /**
-         * Service name is showed in skywalking-ui. Suggestion: set a unique name for each service,
-         * service instance nodes share the same code
+         * Service name is showed in skywalking-ui. Suggestion: set a unique name for each service, service instance
+         * nodes share the same code
          */
         public static String SERVICE_NAME = "";
 
         /**
-         * Authentication active is based on backend setting, see application.yml for more details.
-         * For most scenarios, this needs backend extensions, only basic match auth provided in default implementation.
+         * Authentication active is based on backend setting, see application.yml for more details. For most scenarios,
+         * this needs backend extensions, only basic match auth provided in default implementation.
          */
         public static String AUTHENTICATION = "";
 
@@ -69,8 +68,8 @@ public class Config {
         public static int SPAN_LIMIT_PER_SEGMENT = 300;
 
         /**
-         * If true, skywalking agent will save all instrumented classes files in `/debugging` folder.
-         * Skywalking team may ask for these files in order to resolve compatible problem.
+         * If true, skywalking agent will save all instrumented classes files in `/debugging` folder. Skywalking team
+         * may ask for these files in order to resolve compatible problem.
          */
         public static boolean IS_OPEN_DEBUGGING_CLASS = false;
 
@@ -115,6 +114,16 @@ public class Config {
          * The buffer size of collected JVM info.
          */
         public static int BUFFER_SIZE = 60 * 10;
+
+        /**
+         * The period of JVM data collect OP.
+         */
+        public static int COLLECT_PERIOD = 5;
+
+        /**
+         * The period of JVM report
+         */
+        public static int REPORT_PERIOD = 5;
     }
 
     public static class Buffer {
@@ -160,7 +169,8 @@ public class Config {
     public static class Plugin {
         public static class MongoDB {
             /**
-             * If true, trace all the parameters in MongoDB access, default is false. Only trace the operation, not include parameters.
+             * If true, trace all the parameters in MongoDB access, default is false. Only trace the operation, not
+             * include parameters.
              */
             public static boolean TRACE_PARAM = false;
         }
@@ -187,27 +197,29 @@ public class Config {
 
         public static class SpringMVC {
             /**
-             * If true, the fully qualified method name will be used as the endpoint name instead of the request URL, default is false.
+             * If true, the fully qualified method name will be used as the endpoint name instead of the request URL,
+             * default is false.
              */
             public static boolean USE_QUALIFIED_NAME_AS_ENDPOINT_NAME = false;
         }
 
         public static class Toolkit {
             /**
-             * If true, the fully qualified method name will be used as the operation name instead of the given operation name, default is false.
+             * If true, the fully qualified method name will be used as the operation name instead of the given
+             * operation name, default is false.
              */
             public static boolean USE_QUALIFIED_NAME_AS_OPERATION_NAME = false;
         }
 
         public static class MySQL {
             /**
-             * If set to true, the parameters of the sql (typically {@link java.sql.PreparedStatement})
-             * would be collected.
+             * If set to true, the parameters of the sql (typically {@link java.sql.PreparedStatement}) would be
+             * collected.
              */
             public static boolean TRACE_SQL_PARAMETERS = false;
             /**
-             * For the sake of performance, SkyWalking won't save the entire parameters string into the tag,
-             * but only the first {@code SQL_PARAMETERS_MAX_LENGTH} characters.
+             * For the sake of performance, SkyWalking won't save the entire parameters string into the tag, but only
+             * the first {@code SQL_PARAMETERS_MAX_LENGTH} characters.
              *
              * Set a negative number to save the complete parameter string to the tag.
              */
@@ -216,7 +228,8 @@ public class Config {
 
         public static class SolrJ {
             /**
-             * If true, trace all the query parameters(include deleteByIds and deleteByQuery) in Solr query request, default is false.
+             * If true, trace all the query parameters(include deleteByIds and deleteByQuery) in Solr query request,
+             * default is false.
              */
             public static boolean TRACE_STATEMENT = false;
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/jvm/JVMService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/jvm/JVMService.java
@@ -74,7 +74,7 @@ public class JVMService implements BootService, Runnable {
                 @Override public void handle(Throwable t) {
                     logger.error("JVMService produces metrics failure.", t);
                 }
-            }), 0, 1, TimeUnit.SECONDS);
+            }), 0, Config.Jvm.COLLECT_PERIOD, TimeUnit.SECONDS);
         sendMetricFuture = Executors
             .newSingleThreadScheduledExecutor(new DefaultNamedThreadFactory("JVMService-consume"))
             .scheduleAtFixedRate(new RunnableWithExceptionProtection(sender, new RunnableWithExceptionProtection.CallbackWhenException() {
@@ -82,7 +82,7 @@ public class JVMService implements BootService, Runnable {
                     logger.error("JVMService consumes and upload failure.", t);
                 }
             }
-            ), 0, 1, TimeUnit.SECONDS);
+            ), 0, Config.Jvm.REPORT_PERIOD, TimeUnit.SECONDS);
     }
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsRemoteWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsRemoteWorker.java
@@ -33,21 +33,18 @@ public class MetricsRemoteWorker extends AbstractWorker<Metrics> {
 
     private static final Logger logger = LoggerFactory.getLogger(MetricsRemoteWorker.class);
 
-    private final AbstractWorker<Metrics> nextWorker;
     private final RemoteSenderService remoteSender;
-    private final String modelName;
+    private final String remoteReceiverWorkerName;
 
-    MetricsRemoteWorker(ModuleDefineHolder moduleDefineHolder, AbstractWorker<Metrics> nextWorker,
-        String modelName) {
+    MetricsRemoteWorker(ModuleDefineHolder moduleDefineHolder, String remoteReceiverWorkerName) {
         super(moduleDefineHolder);
         this.remoteSender = moduleDefineHolder.find(CoreModule.NAME).provider().getService(RemoteSenderService.class);
-        this.nextWorker = nextWorker;
-        this.modelName = modelName;
+        this.remoteReceiverWorkerName = remoteReceiverWorkerName;
     }
 
     @Override public final void in(Metrics metrics) {
         try {
-            remoteSender.send(nextWorker.getWorkerId(), metrics, Selector.HashCode);
+            remoteSender.send(remoteReceiverWorkerName, metrics, Selector.HashCode);
         } catch (Throwable e) {
             logger.error(e.getMessage(), e);
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/worker/InventoryStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/worker/InventoryStreamProcessor.java
@@ -26,6 +26,7 @@ import org.apache.skywalking.oap.server.core.remote.define.StreamDataMappingSett
 import org.apache.skywalking.oap.server.core.storage.*;
 import org.apache.skywalking.oap.server.core.storage.annotation.Storage;
 import org.apache.skywalking.oap.server.core.storage.model.*;
+import org.apache.skywalking.oap.server.core.worker.IWorkerInstanceSetter;
 import org.apache.skywalking.oap.server.library.module.ModuleDefineHolder;
 
 /**
@@ -63,7 +64,11 @@ public class InventoryStreamProcessor implements StreamProcessor<RegisterSource>
 
         RegisterPersistentWorker persistentWorker = new RegisterPersistentWorker(moduleDefineHolder, model.getName(), registerDAO, stream.scopeId());
 
-        RegisterRemoteWorker remoteWorker = new RegisterRemoteWorker(moduleDefineHolder, persistentWorker);
+        String remoteReceiverWorkerName = stream.name() + "_rec";
+        IWorkerInstanceSetter workerInstanceSetter = moduleDefineHolder.find(CoreModule.NAME).provider().getService(IWorkerInstanceSetter.class);
+        workerInstanceSetter.put(remoteReceiverWorkerName, persistentWorker);
+
+        RegisterRemoteWorker remoteWorker = new RegisterRemoteWorker(moduleDefineHolder, remoteReceiverWorkerName);
 
         RegisterDistinctWorker distinctWorker = new RegisterDistinctWorker(moduleDefineHolder, remoteWorker);
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/worker/RegisterRemoteWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/worker/RegisterRemoteWorker.java
@@ -33,18 +33,18 @@ public class RegisterRemoteWorker extends AbstractWorker<RegisterSource> {
 
     private static final Logger logger = LoggerFactory.getLogger(RegisterRemoteWorker.class);
 
-    private final AbstractWorker<RegisterSource> nextWorker;
+    private final String remoteReceiverWorkerName;
     private final RemoteSenderService remoteSender;
 
-    RegisterRemoteWorker(ModuleDefineHolder moduleDefineHolder, AbstractWorker<RegisterSource> nextWorker) {
+    RegisterRemoteWorker(ModuleDefineHolder moduleDefineHolder, String remoteReceiverWorkerName) {
         super(moduleDefineHolder);
         this.remoteSender = moduleDefineHolder.find(CoreModule.NAME).provider().getService(RemoteSenderService.class);
-        this.nextWorker = nextWorker;
+        this.remoteReceiverWorkerName = remoteReceiverWorkerName;
     }
 
     @Override public final void in(RegisterSource registerSource) {
         try {
-            remoteSender.send(nextWorker.getWorkerId(), registerSource, Selector.ForeverFirst);
+            remoteSender.send(remoteReceiverWorkerName, registerSource, Selector.ForeverFirst);
         } catch (Throwable e) {
             logger.error(e.getMessage(), e);
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/RemoteSenderService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/RemoteSenderService.java
@@ -41,22 +41,22 @@ public class RemoteSenderService implements Service {
         this.rollingSelector = new RollingSelector();
     }
 
-    public void send(int nextWorkId, StreamData streamData, Selector selector) {
+    public void send(String nextWorkName, StreamData streamData, Selector selector) {
         RemoteClientManager clientManager = moduleManager.find(CoreModule.NAME).provider().getService(RemoteClientManager.class);
 
         RemoteClient remoteClient;
         switch (selector) {
             case HashCode:
                 remoteClient = hashCodeSelector.select(clientManager.getRemoteClient(), streamData);
-                remoteClient.push(nextWorkId, streamData);
+                remoteClient.push(nextWorkName, streamData);
                 break;
             case Rolling:
                 remoteClient = rollingSelector.select(clientManager.getRemoteClient(), streamData);
-                remoteClient.push(nextWorkId, streamData);
+                remoteClient.push(nextWorkName, streamData);
                 break;
             case ForeverFirst:
                 remoteClient = foreverFirstSelector.select(clientManager.getRemoteClient(), streamData);
-                remoteClient.push(nextWorkId, streamData);
+                remoteClient.push(nextWorkName, streamData);
                 break;
         }
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/client/GRPCRemoteClient.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/client/GRPCRemoteClient.java
@@ -119,13 +119,13 @@ public class GRPCRemoteClient implements RemoteClient {
     /**
      * Push stream data which need to send to another OAP server.
      *
-     * @param nextWorkerId the id of a worker which will process this stream data.
+     * @param nextWorkerName the name of a worker which will process this stream data.
      * @param streamData the entity contains the values.
      */
-    @Override public void push(int nextWorkerId, StreamData streamData) {
+    @Override public void push(String nextWorkerName, StreamData streamData) {
         int streamDataId = streamDataMappingGetter.findIdByClass(streamData.getClass());
         RemoteMessage.Builder builder = RemoteMessage.newBuilder();
-        builder.setNextWorkerId(nextWorkerId);
+        builder.setNextWorkName(nextWorkerName);
         builder.setStreamDataId(streamDataId);
         builder.setRemoteData(streamData.serialize());
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/client/RemoteClient.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/client/RemoteClient.java
@@ -31,5 +31,5 @@ public interface RemoteClient extends Comparable<RemoteClient> {
 
     void close();
 
-    void push(int nextWorkerId, StreamData streamData);
+    void push(String nextWorkerName, StreamData streamData);
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/client/SelfRemoteClient.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/client/SelfRemoteClient.java
@@ -53,8 +53,8 @@ public class SelfRemoteClient implements RemoteClient {
         throw new UnexpectedException("Self remote client invoked to close.");
     }
 
-    @Override public void push(int nextWorkerId, StreamData streamData) {
-        workerInstanceGetter.get(nextWorkerId).in(streamData);
+    @Override public void push(String nextWorkerName, StreamData streamData) {
+        workerInstanceGetter.get(nextWorkerName).in(streamData);
     }
 
     @Override public int compareTo(RemoteClient o) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/worker/AbstractWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/worker/AbstractWorker.java
@@ -19,21 +19,16 @@
 package org.apache.skywalking.oap.server.core.worker;
 
 import lombok.Getter;
-import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.library.module.ModuleDefineHolder;
 
 /**
  * @author peng-yongsheng
  */
 public abstract class AbstractWorker<INPUT> {
-
-    @Getter private final int workerId;
     @Getter private final ModuleDefineHolder moduleDefineHolder;
 
     public AbstractWorker(ModuleDefineHolder moduleDefineHolder) {
         this.moduleDefineHolder = moduleDefineHolder;
-        IWorkerInstanceSetter workerInstanceSetter = moduleDefineHolder.find(CoreModule.NAME).provider().getService(IWorkerInstanceSetter.class);
-        this.workerId = workerInstanceSetter.put(this);
     }
 
     public abstract void in(INPUT input);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/worker/IWorkerInstanceGetter.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/worker/IWorkerInstanceGetter.java
@@ -25,5 +25,5 @@ import org.apache.skywalking.oap.server.library.module.Service;
  */
 public interface IWorkerInstanceGetter extends Service {
 
-    AbstractWorker get(int workerId);
+    AbstractWorker get(String nextWorkerName);
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/worker/IWorkerInstanceSetter.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/worker/IWorkerInstanceSetter.java
@@ -24,6 +24,5 @@ import org.apache.skywalking.oap.server.library.module.Service;
  * @author peng-yongsheng
  */
 public interface IWorkerInstanceSetter extends Service {
-
-    int put(AbstractWorker instance);
+    void put(String remoteReceiverWorkName, AbstractWorker instance);
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/worker/WorkerInstancesService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/worker/WorkerInstancesService.java
@@ -18,28 +18,33 @@
 
 package org.apache.skywalking.oap.server.core.worker;
 
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.skywalking.oap.server.core.UnexpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author peng-yongsheng
  */
 public class WorkerInstancesService implements IWorkerInstanceSetter, IWorkerInstanceGetter {
+    private static final Logger logger = LoggerFactory.getLogger(WorkerInstancesService.class);
 
-    private final AtomicInteger generator = new AtomicInteger(1);
-    private final Map<Integer, AbstractWorker> instances;
+    private final Map<String, AbstractWorker> instances;
 
     public WorkerInstancesService() {
         this.instances = new HashMap<>();
     }
 
-    @Override public AbstractWorker get(int workerId) {
-        return instances.get(workerId);
+    @Override public AbstractWorker get(String nextWorkerName) {
+        return instances.get(nextWorkerName);
     }
 
-    @Override public int put(AbstractWorker instance) {
-        int workerId = generator.getAndIncrement();
-        instances.put(workerId, instance);
-        return workerId;
+    @Override public void put(String remoteReceiverWorkName, AbstractWorker instance) {
+        if (instances.containsKey(remoteReceiverWorkName)) {
+            throw new UnexpectedException("Duplicate worker name:" + remoteReceiverWorkName);
+        }
+        instances.put(remoteReceiverWorkName, instance);
+        logger.debug("Worker {} has been registered as {}", instance.toString(), remoteReceiverWorkName);
     }
 }

--- a/oap-server/server-core/src/main/proto/RemoteService.proto
+++ b/oap-server/server-core/src/main/proto/RemoteService.proto
@@ -27,7 +27,7 @@ service RemoteService {
 }
 
 message RemoteMessage {
-    int32 nextWorkerId = 1;
+    string nextWorkName = 1;
     int32 streamDataId = 2;
     RemoteData remoteData = 3;
 }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/remote/RemoteServiceHandlerTestCase.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/remote/RemoteServiceHandlerTestCase.java
@@ -46,7 +46,7 @@ public class RemoteServiceHandlerTestCase {
     @Test
     public void callTest() throws DuplicateProviderException, ProviderNotFoundException, IOException {
         final int streamDataClassId = 1;
-        final int testWorkerId = 1;
+        final String testWorkerId = "mock-worker";
 
         ModuleManagerTesting moduleManager = new ModuleManagerTesting();
         ModuleDefineTesting moduleDefine = new ModuleDefineTesting();
@@ -102,7 +102,7 @@ public class RemoteServiceHandlerTestCase {
 
         RemoteMessage.Builder remoteMessage = RemoteMessage.newBuilder();
         remoteMessage.setStreamDataId(streamDataClassId);
-        remoteMessage.setNextWorkerId(testWorkerId);
+        remoteMessage.setNextWorkName(testWorkerId);
 
         RemoteData.Builder remoteData = RemoteData.newBuilder();
         remoteData.addDataStrings("test1");

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/remote/client/GRPCRemoteClientRealClient.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/remote/client/GRPCRemoteClientRealClient.java
@@ -57,7 +57,7 @@ public class GRPCRemoteClientRealClient {
         remoteClient.connect();
 
         for (int i = 0; i < 10000; i++) {
-            remoteClient.push(1, new TestStreamData());
+            remoteClient.push("mock_remote", new TestStreamData());
             TimeUnit.SECONDS.sleep(1);
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/remote/client/GRPCRemoteClientTestCase.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/remote/client/GRPCRemoteClientTestCase.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.*;
  */
 public class GRPCRemoteClientTestCase {
 
-    private final int nextWorkerId = 1;
+    private final String nextWorkerId = "mock-worker";
     private ModuleManagerTesting moduleManager;
     private StreamDataMappingGetter classGetter;
     @Rule public final GrpcServerRule grpcServerRule = new GrpcServerRule().directExecutor();

--- a/test/e2e/e2e-cluster/test-runner/pom.xml
+++ b/test/e2e/e2e-cluster/test-runner/pom.xml
@@ -120,6 +120,8 @@
                                     <INSTRUMENTED_SERVICE_1_OPTS>
                                         -DSW_AGENT_COLLECTOR_BACKEND_SERVICES=127.0.0.1:11800
                                         -DSW_AGENT_NAME=${service0.name}
+                                        -Dskywalking.jvm.collect_period=40
+                                        -Dskywalking.jvm.report_period=40
                                     </INSTRUMENTED_SERVICE_1_OPTS>
                                     <INSTRUMENTED_SERVICE_1_ARGS>
                                         --server.port=9090
@@ -131,6 +133,8 @@
                                     <INSTRUMENTED_SERVICE_2_OPTS>
                                         -DSW_AGENT_COLLECTOR_BACKEND_SERVICES=127.0.0.1:11801
                                         -DSW_AGENT_NAME=${service1.name}
+                                        -Dskywalking.jvm.collect_period=40
+                                        -Dskywalking.jvm.report_period=40
                                     </INSTRUMENTED_SERVICE_2_OPTS>
                                     <INSTRUMENTED_SERVICE_2_ARGS>
                                         --server.port=9091

--- a/test/e2e/e2e-cluster/test-runner/src/test/java/org/apache/skywalking/e2e/ClusterVerificationITCase.java
+++ b/test/e2e/e2e-cluster/test-runner/src/test/java/org/apache/skywalking/e2e/ClusterVerificationITCase.java
@@ -119,7 +119,6 @@ public class ClusterVerificationITCase {
                     user,
                     String.class
                 );
-                Thread.sleep(1000L);
             } catch (Throwable ignored) {
             }
         }
@@ -133,6 +132,17 @@ public class ClusterVerificationITCase {
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         verifyTraces(startTime);
+
+        for (int i = 0; i < 20; i++) {
+            try {
+                restTemplate.postForEntity(
+                    instrumentedServiceUrl + "/e2e/users",
+                    user,
+                    String.class
+                );
+            } catch (Throwable ignored) {
+            }
+        }
 
         verifyServices(startTime);
 

--- a/test/e2e/e2e-cluster/test-runner/src/test/java/org/apache/skywalking/e2e/ClusterVerificationITCase.java
+++ b/test/e2e/e2e-cluster/test-runner/src/test/java/org/apache/skywalking/e2e/ClusterVerificationITCase.java
@@ -98,18 +98,28 @@ public class ClusterVerificationITCase {
         final Map<String, String> user = new HashMap<>();
         user.put("name", "SkyWalking");
         List<Service> services = Collections.emptyList();
+
         while (services.size() < 2) {
+            try {
+                services = queryClient.services(
+                    new ServicesQuery()
+                        .start(startTime)
+                        .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
+                );
+
+                Thread.sleep(2000L);
+            } catch (Throwable ignored) {
+            }
+        }
+
+        for (int i = 0; i < 20; i++) {
             try {
                 restTemplate.postForEntity(
                     instrumentedServiceUrl + "/e2e/users",
                     user,
                     String.class
                 );
-                services = queryClient.services(
-                    new ServicesQuery()
-                        .start(startTime)
-                        .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
-                );
+                Thread.sleep(1000L);
             } catch (Throwable ignored) {
             }
         }
@@ -232,13 +242,13 @@ public class ClusterVerificationITCase {
                 while (!matched) {
                     LOGGER.warn("instanceRespTime is null, will retry to query");
                     Metrics instanceRespTime = queryClient.metrics(
-                            new MetricsQuery()
-                                .stepByMinute()
-                                .metricsName(metricsName)
-                                .start(minutesAgo)
-                                .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
-                                .id(instance.getKey())
-                        );
+                        new MetricsQuery()
+                            .stepByMinute()
+                            .metricsName(metricsName)
+                            .start(minutesAgo)
+                            .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
+                            .id(instance.getKey())
+                    );
                     AtLeastOneOfMetricsMatcher instanceRespTimeMatcher = new AtLeastOneOfMetricsMatcher();
                     MetricsValueMatcher greaterThanZero = new MetricsValueMatcher();
                     greaterThanZero.setValue("gt 0");


### PR DESCRIPTION
Considering OAL has moved out of compile/package stage, now it is at runtime. I have to change the OAP remote worker ID from Int to String. 

Maybe it will cost a little more CPU, but @peng-yongsheng or I will try to optimize the internal distributed aggregation w/ better batch mechanism(TBD)