### PR TITLE
improve MethodsAroundInterceptor API:add MethodAroundContext over the Interceptor …

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/AbstractInstanceMethodsAroundInterceptor.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/AbstractInstanceMethodsAroundInterceptor.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance;
+
+import java.lang.reflect.Method;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+
+/**
+ * Abstract InstanceMethodsAroundInterceptor
+ * 
+ * @author qxo
+ *
+ */
+public abstract class AbstractInstanceMethodsAroundInterceptor implements InstanceMethodsAroundInterceptor {
+
+    @Override
+    @Deprecated
+    public final Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+            Object ret) throws Throwable {
+        throw new IllegalAccessError("This method should be invoked!");
+    }
+
+    public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+            Object ret, MethodAroundContext context) throws Throwable {
+        final AbstractSpan span = context.getCurrentSpan();
+        if (span != null) {
+            ContextManager.stopSpan(span);
+        }
+        return ret;
+    }
+
+
+    @Override
+    @Deprecated
+   public final void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
+        Class<?>[] argumentsTypes,Throwable t) {
+        throw new IllegalAccessError("This method should be invoked!");
+    }
+    
+    public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
+        Class<?>[] argumentsTypes,Throwable t, MethodAroundContext context) {
+        final AbstractSpan span = context.getCurrentSpan();
+        if (span != null) {
+            span.errorOccurred().log(t);
+        }
+    }
+}

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/MethodAroundContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/MethodAroundContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance;
+
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+
+/**
+ * A context for method around Interceptor, so we can pass current span ...
+ * @author qxo
+ *
+ */
+public class MethodAroundContext {
+    
+    private AbstractSpan currentSpan;
+
+    /**
+     * @return the current span
+     */
+    public AbstractSpan getCurrentSpan() {
+        return currentSpan;
+    }
+
+    /**
+     * @param currentSpan -  the current span
+     */
+    public void setCurrentSpan(AbstractSpan currentSpan) {
+        this.currentSpan = currentSpan;
+    }
+}

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/MethodInterceptResult.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/MethodInterceptResult.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Method;
  *
  * @author wusheng
  */
-public class MethodInterceptResult {
+public class MethodInterceptResult extends MethodAroundContext {
     private boolean isContinue = true;
 
     private Object ret = null;
@@ -45,7 +45,7 @@ public class MethodInterceptResult {
     }
 
     /**
-     * @return true, will trigger method interceptor({@link InstMethodsInter} and {@link StaticMethodsInter}) to invoke
+     * @return true, will trigger method interceptor({@link InstMethodsInterNew} and {@link StaticMethodsInter}) to invoke
      * the origin method. Otherwise, not.
      */
     public boolean isContinue() {


### PR DESCRIPTION
Please answer these questions before submitting pull request

## Why submit this pull request?
- New feature provided
- Improve performance

## Related issues
___
### New feature or improvement
-  MethodsAroundInterceptor should have MethodAroundContext  over the Interceptor 
so we can pass current span,then we change `ContextManager#stopSpan` to `ContextManager#stopSpan(span)` -- for speed up and fail-fast
ref: https://github.com/apache/skywalking/pull/3068


static MethodsAroundInterceptor also need to be support

