### PR TITLE
fixed for #3135:createEntrySpan should get SamplingService only if it required ( carrier is valid)

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManager.java
@@ -87,10 +87,10 @@ public class ContextManager implements BootService {
     }
 
     public static AbstractSpan createEntrySpan(String operationName, ContextCarrier carrier) {
-        SamplingService samplingService = ServiceManager.INSTANCE.findService(SamplingService.class);
         AbstractSpan span;
         AbstractTracerContext context;
         if (carrier != null && carrier.isValid()) {
+            SamplingService samplingService = ServiceManager.INSTANCE.findService(SamplingService.class);
             samplingService.forceSampled();
             context = getOrCreate(operationName, true);
             span = context.createEntrySpan(operationName);


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

- Related issues

___
### New feature or improvement
- Describe the details and related test reports.
fixed for #3135:createEntrySpan should get SamplingService only if it required ( carrier is valid)