### PR TITLE
The stream observer not call the onCompleted method when transform throw exception. 

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/TraceSegmentServiceClient.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/TraceSegmentServiceClient.java
@@ -113,13 +113,14 @@ public class TraceSegmentServiceClient implements BootService, IConsumer<TraceSe
                     UpstreamSegment upstreamSegment = segment.transform();
                     upstreamSegmentStreamObserver.onNext(upstreamSegment);
                 }
-                upstreamSegmentStreamObserver.onCompleted();
-
-                status.wait4Finish();
-                segmentUplinkedCounter += data.size();
             } catch (Throwable t) {
                 logger.error(t, "Transform and send UpstreamSegment to collector fail.");
             }
+
+            upstreamSegmentStreamObserver.onCompleted();
+
+            status.wait4Finish();
+            segmentUplinkedCounter += data.size();
         } else {
             segmentAbandonedCounter += data.size();
         }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

If transform throw exception, the stream observer won't call the onCompleted method, then the stream observer will wait until it finishes or timeout.

**Stream observer Timeout**
```
WARN 2019-07-24 15:31:47:446 GRPCStreamServiceStatus :  Collector traceSegment service doesn't response in 370955 seconds.
```

**Exception**
```
ERROR 2019-07-24 14:22:56:203 TraceSegmentServiceClient :  Transform and send UpstreamSegment to collector fail. 
java.lang.NullPointerException
	at java.util.LinkedList$ListItr.next(LinkedList.java:893)
	at org.apache.skywalking.apm.agent.core.context.trace.TraceSegment.transform(TraceSegment.java:174)
	at org.apache.skywalking.apm.agent.core.remote.TraceSegmentServiceClient.consume(TraceSegmentServiceClient.java:110)
	at org.apache.skywalking.apm.commons.datacarrier.consumer.ConsumerThread.consume(ConsumerThread.java:101)
	at org.apache.skywalking.apm.commons.datacarrier.consumer.ConsumerThread.run(ConsumerThread.java:68)
```

**Root Exception**
```
ERROR 2019-07-24 14:42:58:007 InstMethodsInter :  class[class com.alibaba.dubbo.monitor.support.MonitorFilter] before method[invoke] intercept failure 
java.lang.IllegalStateException: Inject can be done only in Exit Span
	at org.apache.skywalking.apm.agent.core.context.TracingContext.inject(TracingContext.java:99)
	at org.apache.skywalking.apm.agent.core.context.ContextManager.createExitSpan(ContextManager.java:134)
	at org.apache.skywalking.apm.plugin.dubbo.DubboInterceptor.beforeMethod(DubboInterceptor.java:74)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:82)
	at com.alibaba.dubbo.monitor.support.MonitorFilter.invoke(MonitorFilter.java)
	at com.alibaba.dubbo.rpc.protocol.ProtocolFilterWrapper$1.invoke(ProtocolFilterWrapper.java:69)
	at com.alibaba.dubbo.rpc.protocol.dubbo.filter.FutureFilter.invoke(FutureFilter.java:54)
	at com.alibaba.dubbo.rpc.protocol.ProtocolFilterWrapper$1.invoke(ProtocolFilterWrapper.java:69)
	at com.alibaba.dubbo.rpc.filter.ConsumerContextFilter.invoke(ConsumerContextFilter.java:48)
	at com.alibaba.dubbo.rpc.protocol.ProtocolFilterWrapper$1.invoke(ProtocolFilterWrapper.java:69)
	at com.alibaba.dubbo.rpc.listener.ListenerInvokerWrapper.invoke(ListenerInvokerWrapper.java:74)
	at com.alibaba.dubbo.rpc.protocol.InvokerWrapper.invoke(InvokerWrapper.java:53)
	at com.alibaba.dubbo.rpc.cluster.support.FailoverClusterInvoker.doInvoke(FailoverClusterInvoker.java:77)
	at com.alibaba.dubbo.rpc.cluster.support.AbstractClusterInvoker.invoke(AbstractClusterInvoker.java:229)
	at com.alibaba.dubbo.rpc.cluster.support.wrapper.MockClusterInvoker.invoke(MockClusterInvoker.java:72)
	at com.alibaba.dubbo.rpc.proxy.InvokerInvocationHandler.invoke(InvokerInvocationHandler.java:52)
	at com.alibaba.dubbo.common.bytecode.proxy10.getSkuVendor(proxy10.java)
	at 
```