### PR TITLE
Revert parallelism in CI IT build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,6 @@ pipeline {
                                 // separate lightweight checks that don't support parallel run
                                 sh './mvnw checkstyle:check apache-rat:check'
                                 sh './mvnw -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -P"agent,backend,ui,dist,CI-with-IT" org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent clean install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report'
-                                sh './mvnw -DskipTests -Dcheckstyle.skip -Drat.skip -T 2C javadoc:javadoc'
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,10 +27,6 @@ pipeline {
         skipStagesAfterUnstable()
     }
 
-    environment {
-        MAVEN_OPTS = '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
-    }
-
     stages {
         stage('Install & Test') {
             parallel {
@@ -63,10 +59,8 @@ pipeline {
 
                         stage('Test & Report') {
                             steps {
-                                // separate lightweight checks that don't support parallel run
-                                sh './mvnw checkstyle:check apache-rat:check'
-                                sh './mvnw -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -P"agent,backend,ui,dist,CI-with-IT" org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent clean install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report'
-                                sh './mvnw -DskipTests -Dcheckstyle.skip -Drat.skip javadoc:javadoc'
+                                sh './mvnw -P"agent,backend,ui,dist,CI-with-IT" org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent clean install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report'
+                                sh './mvnw javadoc:javadoc -Dmaven.test.skip=true'
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,7 @@ pipeline {
                                 // separate lightweight checks that don't support parallel run
                                 sh './mvnw checkstyle:check apache-rat:check'
                                 sh './mvnw -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -P"agent,backend,ui,dist,CI-with-IT" org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent clean install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report'
+                                sh './mvnw -DskipTests -Dcheckstyle.skip -Drat.skip javadoc:javadoc'
                             }
                         }
                     }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

A recent build job shows that the `javadoc:javadoc` is causing issues, we don't host JavaDoc pages and this task is a waste of time/resources, so I'm just removing it

[![image](https://user-images.githubusercontent.com/15965696/61839623-dc085c00-aec0-11e9-85da-3dc97b1959c6.png)](https://builds.apache.org/job/skywalking-ci-it/641/flowGraphTable/)
