### PR TITLE
Fix bug: Agent never update its Instance HeartbeatTime

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
@@ -131,7 +131,7 @@ public class AppAndServiceRegisterClient implements BootService, GRPCChannelList
                                     = instanceMapping.getApplicationInstanceId();
                             }
                         } else {
-                            if (lastSegmentTime - System.currentTimeMillis() > 60 * 1000) {
+                            if ( System.currentTimeMillis() - lastSegmentTime > 60 * 1000) {
                                 instanceDiscoveryServiceBlockingStub.heartbeat(ApplicationInstanceHeartbeat.newBuilder()
                                     .setApplicationInstanceId(RemoteDownstreamConfig.Agent.APPLICATION_INSTANCE_ID)
                                     .setHeartbeatTime(System.currentTimeMillis())


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix

- Related issues

___
### Bug fix
- Bug description.
Agent never update its Instance HeartbeatTime

Beacause the judgment statement in ```org.apache.skywalking.apm.agent.core.remote.AppAndServiceRegisterClient```that compares current timestamp with lastSegmentUpdateTime will be always negative and never works 
```java
if (lastSegmentTime - System.currentTimeMillis() > 60 * 1000) {
                                instanceDiscoveryServiceBlockingStub.heartbeat(ApplicationInstanceHeartbeat.newBuilder()
                                    .setApplicationInstanceId(RemoteDownstreamConfig.Agent.APPLICATION_INSTANCE_ID)
                                    .setHeartbeatTime(System.currentTimeMillis())
                                    .build());
                            }
```
- How to fix?
Fix the judgement sequence putting  System.currentTimeMillis() before
```java
                            if ( System.currentTimeMillis() - lastSegmentTime > 60 * 1000) {
                                instanceDiscoveryServiceBlockingStub.heartbeat(ApplicationInstanceHeartbeat.newBuilder()
                                    .setApplicationInstanceId(RemoteDownstreamConfig.Agent.APPLICATION_INSTANCE_ID)
                                    .setHeartbeatTime(System.currentTimeMillis())
                                    .build());
                            }
```
___
### New feature or improvement
- Describe the details and related test reports.
