### PR TITLE
Inventory cache update and new attribute last_update_time for all inventories.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/Const.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/Const.java
@@ -36,5 +36,6 @@ public class Const {
     public static final String SEGMENT_SPAN_SPLIT = "S";
     public static final String UNKNOWN = "Unknown";
     public static final String EMPTY_STRING = "";
+    public static final String EMPTY_JSON_OBJECT_STRING = "{}";
     public static final String DOMAIN_OPERATION_NAME = "{domain}";
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/EndpointInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/EndpointInventory.java
@@ -91,6 +91,7 @@ public class EndpointInventory extends RegisterSource {
 
         remoteBuilder.addDataLongs(getRegisterTime());
         remoteBuilder.addDataLongs(getHeartbeatTime());
+        remoteBuilder.addDataLongs(getLastUpdateTime());
 
         remoteBuilder.addDataStrings(Strings.isNullOrEmpty(name) ? Const.EMPTY_STRING : name);
         return remoteBuilder;
@@ -103,6 +104,7 @@ public class EndpointInventory extends RegisterSource {
 
         setRegisterTime(remoteData.getDataLongs(0));
         setHeartbeatTime(remoteData.getDataLongs(1));
+        setLastUpdateTime(remoteData.getDataLongs(2));
 
         setName(remoteData.getDataStrings(0));
     }
@@ -115,12 +117,13 @@ public class EndpointInventory extends RegisterSource {
 
         @Override public EndpointInventory map2Data(Map<String, Object> dbMap) {
             EndpointInventory inventory = new EndpointInventory();
-            inventory.setSequence((Integer)dbMap.get(SEQUENCE));
-            inventory.setServiceId((Integer)dbMap.get(SERVICE_ID));
+            inventory.setSequence(((Number)dbMap.get(SEQUENCE)).intValue());
+            inventory.setServiceId(((Number)dbMap.get(SERVICE_ID)).intValue());
             inventory.setName((String)dbMap.get(NAME));
-            inventory.setDetectPoint((Integer)dbMap.get(DETECT_POINT));
-            inventory.setRegisterTime((Long)dbMap.get(REGISTER_TIME));
-            inventory.setHeartbeatTime((Long)dbMap.get(HEARTBEAT_TIME));
+            inventory.setDetectPoint(((Number)dbMap.get(DETECT_POINT)).intValue());
+            inventory.setRegisterTime(((Number)dbMap.get(REGISTER_TIME)).longValue());
+            inventory.setHeartbeatTime(((Number)dbMap.get(HEARTBEAT_TIME)).longValue());
+            inventory.setLastUpdateTime(((Number)dbMap.get(LAST_UPDATE_TIME)).longValue());
             return inventory;
         }
 
@@ -132,6 +135,7 @@ public class EndpointInventory extends RegisterSource {
             map.put(DETECT_POINT, storageData.getDetectPoint());
             map.put(REGISTER_TIME, storageData.getRegisterTime());
             map.put(HEARTBEAT_TIME, storageData.getHeartbeatTime());
+            map.put(LAST_UPDATE_TIME, storageData.getLastUpdateTime());
             return map;
         }
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NetworkAddressInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NetworkAddressInventory.java
@@ -88,6 +88,7 @@ public class NetworkAddressInventory extends RegisterSource {
         inventory.setSequence(getSequence());
         inventory.setRegisterTime(getRegisterTime());
         inventory.setHeartbeatTime(getHeartbeatTime());
+        inventory.setLastUpdateTime(getLastUpdateTime());
         inventory.setName(name);
         inventory.setNodeType(nodeType);
 
@@ -95,14 +96,14 @@ public class NetworkAddressInventory extends RegisterSource {
     }
 
     @Override public boolean combine(RegisterSource registerSource) {
-        boolean isCombine = super.combine(registerSource);
+        boolean isChanged = super.combine(registerSource);
         NetworkAddressInventory inventory = (NetworkAddressInventory)registerSource;
 
-        if (nodeType != inventory.nodeType) {
-            setNodeType(inventory.nodeType);
+        if (this.nodeType != inventory.getNodeType() && inventory.getLastUpdateTime() >= this.getLastUpdateTime()) {
+            setNodeType(inventory.getNodeType());
             return true;
         } else {
-            return isCombine;
+            return isChanged;
         }
     }
 
@@ -113,6 +114,7 @@ public class NetworkAddressInventory extends RegisterSource {
 
         remoteBuilder.addDataLongs(getRegisterTime());
         remoteBuilder.addDataLongs(getHeartbeatTime());
+        remoteBuilder.addDataLongs(getLastUpdateTime());
 
         remoteBuilder.addDataStrings(Strings.isNullOrEmpty(name) ? Const.EMPTY_STRING : name);
         return remoteBuilder;
@@ -124,6 +126,7 @@ public class NetworkAddressInventory extends RegisterSource {
 
         setRegisterTime(remoteData.getDataLongs(0));
         setHeartbeatTime(remoteData.getDataLongs(1));
+        setLastUpdateTime(remoteData.getDataLongs(2));
 
         setName(remoteData.getDataStrings(0));
     }
@@ -136,11 +139,12 @@ public class NetworkAddressInventory extends RegisterSource {
 
         @Override public NetworkAddressInventory map2Data(Map<String, Object> dbMap) {
             NetworkAddressInventory inventory = new NetworkAddressInventory();
-            inventory.setSequence((Integer)dbMap.get(SEQUENCE));
+            inventory.setSequence(((Number)dbMap.get(SEQUENCE)).intValue());
             inventory.setName((String)dbMap.get(NAME));
-            inventory.setNodeType((Integer)dbMap.get(NODE_TYPE));
-            inventory.setRegisterTime((Long)dbMap.get(REGISTER_TIME));
-            inventory.setHeartbeatTime((Long)dbMap.get(HEARTBEAT_TIME));
+            inventory.setNodeType(((Number)dbMap.get(NODE_TYPE)).intValue());
+            inventory.setRegisterTime(((Number)dbMap.get(REGISTER_TIME)).longValue());
+            inventory.setHeartbeatTime(((Number)dbMap.get(HEARTBEAT_TIME)).longValue());
+            inventory.setLastUpdateTime(((Number)dbMap.get(LAST_UPDATE_TIME)).longValue());
             return inventory;
         }
 
@@ -151,6 +155,7 @@ public class NetworkAddressInventory extends RegisterSource {
             map.put(NODE_TYPE, storageData.getNodeType());
             map.put(REGISTER_TIME, storageData.getRegisterTime());
             map.put(HEARTBEAT_TIME, storageData.getHeartbeatTime());
+            map.put(LAST_UPDATE_TIME, storageData.getLastUpdateTime());
             return map;
         }
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/RegisterSource.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/RegisterSource.java
@@ -31,17 +31,24 @@ public abstract class RegisterSource extends StreamData implements StorageData {
     public static final String SEQUENCE = "sequence";
     public static final String REGISTER_TIME = "register_time";
     public static final String HEARTBEAT_TIME = "heartbeat_time";
+    public static final String LAST_UPDATE_TIME = "last_update_time";
 
     @Getter @Setter @Column(columnName = SEQUENCE) private int sequence;
-    @Getter @Setter @Column(columnName = REGISTER_TIME) private long registerTime;
-    @Getter @Setter @Column(columnName = HEARTBEAT_TIME) private long heartbeatTime;
+    @Getter @Setter @Column(columnName = REGISTER_TIME) private long registerTime = 0L;
+    @Getter @Setter @Column(columnName = HEARTBEAT_TIME) private long heartbeatTime = 0L;
+    @Setter @Getter @Column(columnName = LAST_UPDATE_TIME) private long lastUpdateTime = 0L;
 
     public boolean combine(RegisterSource registerSource) {
+        boolean isChanged = false;
         if (heartbeatTime < registerSource.getHeartbeatTime()) {
             heartbeatTime = registerSource.getHeartbeatTime();
-            return true;
-        } else {
-            return false;
+            isChanged = true;
         }
+
+        if (lastUpdateTime < registerSource.getLastUpdateTime()) {
+            lastUpdateTime = registerSource.getLastUpdateTime();
+            isChanged = true;
+        }
+        return isChanged;
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInstanceInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInstanceInventory.java
@@ -51,8 +51,7 @@ public class ServiceInstanceInventory extends RegisterSource {
     public static final String PROPERTIES = "properties";
     private static final Gson GSON = new Gson();
 
-    @Setter @Getter @Column(columnName = INSTANCE_UUID, matchQuery = true)
-    private String instanceUUID = Const.EMPTY_STRING;
+    @Setter @Getter @Column(columnName = INSTANCE_UUID, matchQuery = true) private String instanceUUID = Const.EMPTY_STRING;
     @Setter @Getter @Column(columnName = NAME) private String name = Const.EMPTY_STRING;
     @Setter @Getter @Column(columnName = SERVICE_ID) private int serviceId;
     @Setter @Getter @Column(columnName = IS_ADDRESS) private int isAddress;
@@ -133,6 +132,7 @@ public class ServiceInstanceInventory extends RegisterSource {
 
         remoteBuilder.addDataLongs(getRegisterTime());
         remoteBuilder.addDataLongs(getHeartbeatTime());
+        remoteBuilder.addDataLongs(getLastUpdateTime());
 
         remoteBuilder.addDataStrings(Strings.isNullOrEmpty(name) ? Const.EMPTY_STRING : name);
         remoteBuilder.addDataStrings(Strings.isNullOrEmpty(instanceUUID) ? Const.EMPTY_STRING : instanceUUID);
@@ -148,6 +148,7 @@ public class ServiceInstanceInventory extends RegisterSource {
 
         setRegisterTime(remoteData.getDataLongs(0));
         setHeartbeatTime(remoteData.getDataLongs(1));
+        setLastUpdateTime(remoteData.getDataLongs(2));
 
         setName(remoteData.getDataStrings(0));
         setInstanceUUID(remoteData.getDataStrings(1));
@@ -162,13 +163,14 @@ public class ServiceInstanceInventory extends RegisterSource {
 
         @Override public ServiceInstanceInventory map2Data(Map<String, Object> dbMap) {
             ServiceInstanceInventory inventory = new ServiceInstanceInventory();
-            inventory.setSequence((Integer)dbMap.get(SEQUENCE));
-            inventory.setServiceId((Integer)dbMap.get(SERVICE_ID));
-            inventory.setIsAddress((Integer)dbMap.get(IS_ADDRESS));
-            inventory.setAddressId((Integer)dbMap.get(ADDRESS_ID));
+            inventory.setSequence(((Number)dbMap.get(SEQUENCE)).intValue());
+            inventory.setServiceId(((Number)dbMap.get(SERVICE_ID)).intValue());
+            inventory.setIsAddress(((Number)dbMap.get(IS_ADDRESS)).intValue());
+            inventory.setAddressId(((Number)dbMap.get(ADDRESS_ID)).intValue());
 
-            inventory.setRegisterTime((Long)dbMap.get(REGISTER_TIME));
-            inventory.setHeartbeatTime((Long)dbMap.get(HEARTBEAT_TIME));
+            inventory.setRegisterTime(((Number)dbMap.get(REGISTER_TIME)).longValue());
+            inventory.setHeartbeatTime(((Number)dbMap.get(HEARTBEAT_TIME)).longValue());
+            inventory.setLastUpdateTime(((Number)dbMap.get(LAST_UPDATE_TIME)).longValue());
 
             inventory.setName((String)dbMap.get(NAME));
             inventory.setInstanceUUID((String)dbMap.get(INSTANCE_UUID));
@@ -185,6 +187,7 @@ public class ServiceInstanceInventory extends RegisterSource {
 
             map.put(REGISTER_TIME, storageData.getRegisterTime());
             map.put(HEARTBEAT_TIME, storageData.getHeartbeatTime());
+            map.put(LAST_UPDATE_TIME, storageData.getLastUpdateTime());
 
             map.put(NAME, storageData.getName());
             map.put(INSTANCE_UUID, storageData.getInstanceUUID());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/NetworkAddressInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/NetworkAddressInventoryRegister.java
@@ -115,7 +115,7 @@ public class NetworkAddressInventoryRegister implements INetworkAddressInventory
         if (!this.compare(networkAddress, nodeType)) {
             NetworkAddressInventory newNetworkAddress = networkAddress.getClone();
             newNetworkAddress.setNetworkAddressNodeType(nodeType);
-            newNetworkAddress.setHeartbeatTime(System.currentTimeMillis());
+            newNetworkAddress.setLastUpdateTime(System.currentTimeMillis());
 
             InventoryStreamProcessor.getInstance().in(newNetworkAddress);
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/ServiceInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/ServiceInventoryRegister.java
@@ -64,7 +64,7 @@ public class ServiceInventoryRegister implements IServiceInventoryRegister {
             serviceInventory.setRegisterTime(now);
             serviceInventory.setHeartbeatTime(now);
             serviceInventory.setMappingServiceId(Const.NONE);
-            serviceInventory.setMappingLastUpdateTime(now);
+            serviceInventory.setLastUpdateTime(now);
             serviceInventory.setProperties(properties);
 
             InventoryStreamProcessor.getInstance().in(serviceInventory);
@@ -84,7 +84,7 @@ public class ServiceInventoryRegister implements IServiceInventoryRegister {
             long now = System.currentTimeMillis();
             serviceInventory.setRegisterTime(now);
             serviceInventory.setHeartbeatTime(now);
-            serviceInventory.setMappingLastUpdateTime(now);
+            serviceInventory.setLastUpdateTime(now);
 
             InventoryStreamProcessor.getInstance().in(serviceInventory);
         }
@@ -98,7 +98,7 @@ public class ServiceInventoryRegister implements IServiceInventoryRegister {
                 serviceInventory = serviceInventory.getClone();
                 serviceInventory.setServiceNodeType(nodeType);
                 serviceInventory.setProperties(properties);
-                serviceInventory.setMappingLastUpdateTime(System.currentTimeMillis());
+                serviceInventory.setLastUpdateTime(System.currentTimeMillis());
 
                 InventoryStreamProcessor.getInstance().in(serviceInventory);
             }
@@ -124,7 +124,7 @@ public class ServiceInventoryRegister implements IServiceInventoryRegister {
         if (Objects.nonNull(serviceInventory)) {
             serviceInventory = serviceInventory.getClone();
             serviceInventory.setMappingServiceId(mappingServiceId);
-            serviceInventory.setMappingLastUpdateTime(System.currentTimeMillis());
+            serviceInventory.setLastUpdateTime(System.currentTimeMillis());
 
             InventoryStreamProcessor.getInstance().in(serviceInventory);
         } else {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/cache/INetworkAddressInventoryCacheDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/cache/INetworkAddressInventoryCacheDAO.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.storage.cache;
 
+import java.util.List;
 import org.apache.skywalking.oap.server.core.register.NetworkAddressInventory;
 import org.apache.skywalking.oap.server.core.storage.DAO;
 
@@ -29,4 +30,6 @@ public interface INetworkAddressInventoryCacheDAO extends DAO {
     int getAddressId(String networkAddress);
 
     NetworkAddressInventory get(int addressId);
+
+    List<NetworkAddressInventory> loadLastUpdate(long lastUpdateTime);
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/cache/IServiceInventoryCacheDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/cache/IServiceInventoryCacheDAO.java
@@ -33,5 +33,5 @@ public interface IServiceInventoryCacheDAO extends DAO {
 
     ServiceInventory get(int serviceId);
 
-    List<ServiceInventory> loadLastMappingUpdate();
+    List<ServiceInventory> loadLastUpdate(long lastUpdateTime);
 }

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/ReferenceIdExchanger.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/ReferenceIdExchanger.java
@@ -116,10 +116,6 @@ public class ReferenceIdExchanger implements IdExchanger<ReferenceDecorator> {
      * Need to try to get the id by assuming the endpoint name is detected at server, local or client.
      *
      * If agent does the exchange, then always use endpoint id.
-     *
-     * @param serviceId
-     * @param endpointName
-     * @return
      */
     private int getEndpointId(int serviceId, String endpointName) {
         int endpointId = endpointInventoryRegister.get(serviceId, endpointName, DetectPoint.SERVER.ordinal());

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
@@ -103,12 +103,11 @@ public class SpanIdExchanger implements IdExchanger<SpanDecorator> {
             NodeType nodeType = NodeType.fromSpanLayerValue(spanLayerValue);
             networkAddressInventoryRegister.update(peerId, nodeType);
 
-            /**
+            /*
              * In some case, conjecture node, such as Database node, could be registered by agents.
              * At here, if the target service properties need to be updated,
              * it will only be updated at the first time for now.
              */
-
             JsonObject properties = null;
             ServiceInventory newServiceInventory = serviceInventoryCacheDAO.get(serviceInventoryCacheDAO.getServiceId(peerId));
             if (SpanLayer.Database.equals(standardBuilder.getSpanLayer())) {

--- a/oap-server/server-starter/src/main/resources/log4j2.xml
+++ b/oap-server/server-starter/src/main/resources/log4j2.xml
@@ -36,7 +36,7 @@
         <logger name="org.apache.skywalking.oap.server.core.remote.client" level="DEBUG"/>
         <logger name="org.apache.skywalking.oap.server.library.buffer" level="INFO"/>
         <logger name="org.apache.skywalking.oap.server.receiver.so11y" level="DEBUG" />
-        <Root level="ERROR">
+        <Root level="DEBUG">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInventoryCacheEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInventoryCacheEsDAO.java
@@ -88,7 +88,7 @@ public class ServiceInventoryCacheEsDAO extends EsDAO implements IServiceInvento
         }
     }
 
-    @Override public List<ServiceInventory> loadLastMappingUpdate() {
+    @Override public List<ServiceInventory> loadLastUpdate(long lastUpdateTime) {
         List<ServiceInventory> serviceInventories = new ArrayList<>();
 
         try {
@@ -96,10 +96,10 @@ public class ServiceInventoryCacheEsDAO extends EsDAO implements IServiceInvento
 
             BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
             boolQuery.must().add(QueryBuilders.termQuery(ServiceInventory.IS_ADDRESS, BooleanUtils.TRUE));
-            boolQuery.must().add(QueryBuilders.rangeQuery(ServiceInventory.MAPPING_LAST_UPDATE_TIME).gte(System.currentTimeMillis() - 30 * 60 * 1000));
+            boolQuery.must().add(QueryBuilders.rangeQuery(ServiceInventory.LAST_UPDATE_TIME).gte(lastUpdateTime));
 
             searchSourceBuilder.query(boolQuery);
-            searchSourceBuilder.size(50);
+            searchSourceBuilder.size(500);
 
             SearchResponse response = getClient().search(ServiceInventory.INDEX_NAME, searchSourceBuilder);
 

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2ServiceInventoryCacheDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2ServiceInventoryCacheDAO.java
@@ -57,17 +57,17 @@ public class H2ServiceInventoryCacheDAO extends H2SQLExecutor implements IServic
         }
     }
 
-    @Override public List<ServiceInventory> loadLastMappingUpdate() {
+    @Override public List<ServiceInventory> loadLastUpdate(long lastUpdateTime) {
         List<ServiceInventory> serviceInventories = new ArrayList<>();
 
         try {
             StringBuilder sql = new StringBuilder("select * from ");
             sql.append(ServiceInventory.INDEX_NAME);
             sql.append(" where ").append(ServiceInventory.IS_ADDRESS).append("=? ");
-            sql.append(" and ").append(ServiceInventory.MAPPING_LAST_UPDATE_TIME).append(">?");
+            sql.append(" and ").append(ServiceInventory.LAST_UPDATE_TIME).append(">?");
 
             try (Connection connection = h2Client.getConnection()) {
-                try (ResultSet resultSet = h2Client.executeQuery(connection, sql.toString(), BooleanUtils.TRUE, System.currentTimeMillis() - 30 * 60 * 1000)) {
+                try (ResultSet resultSet = h2Client.executeQuery(connection, sql.toString(), BooleanUtils.TRUE, lastUpdateTime)) {
                     ServiceInventory serviceInventory;
                     do {
                         serviceInventory = (ServiceInventory)toStorageData(resultSet, ServiceInventory.INDEX_NAME, new ServiceInventory.Builder());


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [X] Bugfix
- [ ] New feature provided
- [ ] Improve performance

1. All the inventories add the last_update_time attribute,  delete the mapping_last_update_time attribute in the service inventory.
* register_time: unmodifiable, fill it when inventory creates. 
* heartbeat_time: modifiable, only for the heartbeat.
* last_update_time: modifiable, fill it when other columns changed, and it will trigger the cache update timer to refresh the inventory data from the database to the OAP server's cache.
2. Fixed the service inventory and net address inventory update bugs, 
* the node type and properties column not update from database to OAP server's cache.
* the netaddress node type column not update.