### PR TITLE
Remove javassist from agent dependency

### DIFF
--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -38,10 +38,6 @@
         <grpc.version>1.14.0</grpc.version>
         <guava.version>20.0</guava.version>
         <bytebuddy.version>1.9.2</bytebuddy.version>
-        <!-- 3.21.0-GA is the last version w/ JDK 6 supported -->
-        <!-- We can't update this, unless JDK 6 agent is not supported. -->
-        <!-- ref discussion, https://github.com/jboss-javassist/javassist/issues/268 -->
-        <javaassist.version>3.21.0-GA</javaassist.version>
         <disruptor.version>3.3.6</disruptor.version>
         <wiremock.version>2.6.0</wiremock.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
@@ -58,8 +54,6 @@
         <shade.io.netty.target>${shade.package}.${shade.io.netty.source}</shade.io.netty.target>
         <shade.io.opencensus.source>io.opencensus</shade.io.opencensus.source>
         <shade.io.opencensus.target>${shade.package}.${shade.io.opencensus.source}</shade.io.opencensus.target>
-        <shade.javaassist.source>javassist</shade.javaassist.source>
-        <shade.javaassist.target>${shade.package}.${shade.javaassist.source}</shade.javaassist.target>
         <ststem-rules.version>1.18.0</ststem-rules.version>
     </properties>
 
@@ -103,11 +97,6 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
             <version>${netty-tcnative-boringssl-static.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>${javaassist.version}</version>
         </dependency>
         <dependency>
             <groupId>net.bytebuddy</groupId>
@@ -192,10 +181,6 @@
                                 </excludes>
                             </artifactSet>
                             <relocations>
-                                <relocation>
-                                    <pattern>${shade.javaassist.source}</pattern>
-                                    <shadedPattern>${shade.javaassist.target}</shadedPattern>
-                                </relocation>
                                 <relocation>
                                     <pattern>${shade.com.lmax.disruptor.source}</pattern>
                                     <shadedPattern>${shade.com.lmax.disruptor.target}</shadedPattern>

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/InstrumentDebuggingClass.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/InstrumentDebuggingClass.java
@@ -21,7 +21,6 @@ package org.apache.skywalking.apm.agent.core.plugin;
 
 import java.io.File;
 import java.io.IOException;
-import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
 import org.apache.skywalking.apm.agent.core.boot.AgentPackageNotFoundException;
 import org.apache.skywalking.apm.agent.core.boot.AgentPackagePath;
@@ -30,6 +29,9 @@ import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 
 /**
+ * The manipulated class output. Write the dynamic classes to the `debugging` folder, when we need to do some debug and
+ * recheck.
+ *
  * @author wu-sheng
  */
 public enum InstrumentDebuggingClass {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/InstrumentDebuggingClass.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/InstrumentDebuggingClass.java
@@ -17,7 +17,7 @@
  */
 
 
-package org.apache.skywalking.apm.agent;
+package org.apache.skywalking.apm.agent.core.plugin;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,7 +38,7 @@ public enum InstrumentDebuggingClass {
     private static final ILog logger = LogManager.getLogger(InstrumentDebuggingClass.class);
     private File debuggingClassesRootPath;
 
-    public void log(TypeDescription typeDescription, DynamicType dynamicType) {
+    public void log(DynamicType dynamicType) {
         if (!Config.Agent.IS_OPEN_DEBUGGING_CLASS) {
             return;
         }
@@ -62,7 +62,7 @@ public enum InstrumentDebuggingClass {
                 try {
                     dynamicType.saveIn(debuggingClassesRootPath);
                 } catch (IOException e) {
-                    logger.error(e, "Can't save class {} to file." + typeDescription.getActualName());
+                    logger.error(e, "Can't save class {} to file." + dynamicType.getTypeDescription().getActualName());
                 }
             } catch (Throwable t) {
                 logger.error(t, "Save debugging classes fail.");

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/BootstrapInstrumentBoost.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/BootstrapInstrumentBoost.java
@@ -26,22 +26,27 @@ import java.lang.instrument.Instrumentation;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javassist.ClassPool;
-import javassist.CtClass;
-import javassist.CtField;
+import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassInjector;
+import net.bytebuddy.pool.TypePool;
 import org.apache.skywalking.apm.agent.core.boot.AgentPackageNotFoundException;
 import org.apache.skywalking.apm.agent.core.boot.AgentPackagePath;
 import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 import org.apache.skywalking.apm.agent.core.plugin.AbstractClassEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.InstrumentDebuggingClass;
 import org.apache.skywalking.apm.agent.core.plugin.PluginException;
 import org.apache.skywalking.apm.agent.core.plugin.PluginFinder;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.StaticMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.loader.AgentClassLoader;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**
  * If there is Bootstrap instrumentation plugin declared in plugin list, BootstrapInstrumentBoost inject the necessary
@@ -51,6 +56,7 @@ import org.apache.skywalking.apm.agent.core.plugin.loader.AgentClassLoader;
  */
 public class BootstrapInstrumentBoost {
     private static final ILog logger = LogManager.getLogger(BootstrapInstrumentBoost.class);
+    private static final String SHADE_PACKAGE = "org.apache.skywalking.apm.dependencies.";
     private static final String[] HIGH_PRIORITY_CLASSES = {
         "org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance",
         "org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.BootstrapInterRuntimeAssist",
@@ -58,7 +64,14 @@ public class BootstrapInstrumentBoost {
         "org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor",
         "org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult",
         "org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.OverrideCallable",
-        "org.apache.skywalking.apm.agent.core.plugin.bootstrap.IBootstrapLog"
+        "org.apache.skywalking.apm.agent.core.plugin.bootstrap.IBootstrapLog",
+        SHADE_PACKAGE + "net.bytebuddy.implementation.bind.annotation.RuntimeType",
+        SHADE_PACKAGE + "net.bytebuddy.implementation.bind.annotation.This",
+        SHADE_PACKAGE + "net.bytebuddy.implementation.bind.annotation.AllArguments",
+        SHADE_PACKAGE + "net.bytebuddy.implementation.bind.annotation.AllArguments$Assignment",
+        SHADE_PACKAGE + "net.bytebuddy.implementation.bind.annotation.SuperCall",
+        SHADE_PACKAGE + "net.bytebuddy.implementation.bind.annotation.Origin",
+        SHADE_PACKAGE + "net.bytebuddy.implementation.bind.annotation.Morph"
     };
     private static String INSTANCE_METHOD_DELEGATE_TEMPLATE = "org.apache.skywalking.apm.agent.core.plugin.bootstrap.template.InstanceMethodInterTemplate";
     private static String INSTANCE_METHOD_WITH_OVERRIDE_ARGS_DELEGATE_TEMPLATE = "org.apache.skywalking.apm.agent.core.plugin.bootstrap.template.InstanceMethodInterWithOverrideArgsTemplate";
@@ -127,26 +140,26 @@ public class BootstrapInstrumentBoost {
      */
     private static boolean prepareJREInstrumentation(PluginFinder pluginFinder,
         Map<String, byte[]> classesTypeMap) throws PluginException {
-        ClassPool classPool = ClassPool.getDefault();
+        TypePool typePool = TypePool.Default.of(BootstrapInstrumentBoost.class.getClassLoader());
         List<AbstractClassEnhancePluginDefine> bootstrapClassMatchDefines = pluginFinder.getBootstrapClassMatchDefine();
         for (AbstractClassEnhancePluginDefine define : bootstrapClassMatchDefines) {
             for (InstanceMethodsInterceptPoint point : define.getInstanceMethodsInterceptPoints()) {
                 if (point.isOverrideArgs()) {
-                    generateDelegator(classesTypeMap, classPool, INSTANCE_METHOD_WITH_OVERRIDE_ARGS_DELEGATE_TEMPLATE, point.getMethodsInterceptor());
+                    generateDelegator(classesTypeMap, typePool, INSTANCE_METHOD_WITH_OVERRIDE_ARGS_DELEGATE_TEMPLATE, point.getMethodsInterceptor());
                 } else {
-                    generateDelegator(classesTypeMap, classPool, INSTANCE_METHOD_DELEGATE_TEMPLATE, point.getMethodsInterceptor());
+                    generateDelegator(classesTypeMap, typePool, INSTANCE_METHOD_DELEGATE_TEMPLATE, point.getMethodsInterceptor());
                 }
             }
 
             for (ConstructorInterceptPoint point : define.getConstructorsInterceptPoints()) {
-                generateDelegator(classesTypeMap, classPool, CONSTRUCTOR_DELEGATE_TEMPLATE, point.getConstructorInterceptor());
+                generateDelegator(classesTypeMap, typePool, CONSTRUCTOR_DELEGATE_TEMPLATE, point.getConstructorInterceptor());
             }
 
             for (StaticMethodsInterceptPoint point : define.getStaticMethodsInterceptPoints()) {
                 if (point.isOverrideArgs()) {
-                    generateDelegator(classesTypeMap, classPool, STATIC_METHOD_WITH_OVERRIDE_ARGS_DELEGATE_TEMPLATE, point.getMethodsInterceptor());
+                    generateDelegator(classesTypeMap, typePool, STATIC_METHOD_WITH_OVERRIDE_ARGS_DELEGATE_TEMPLATE, point.getMethodsInterceptor());
                 } else {
-                    generateDelegator(classesTypeMap, classPool, STATIC_METHOD_DELEGATE_TEMPLATE, point.getMethodsInterceptor());
+                    generateDelegator(classesTypeMap, typePool, STATIC_METHOD_DELEGATE_TEMPLATE, point.getMethodsInterceptor());
                 }
             }
         }
@@ -159,29 +172,49 @@ public class BootstrapInstrumentBoost {
      * One key step to avoid class confliction between AppClassLoader and BootstrapClassLoader
      *
      * @param classesTypeMap hosts injected binary of generated class
-     * @param classPool to generate new class
+     * @param typePool to generate new class
      * @param templateClassName represents the class as template in this generation process. The templates are
      * pre-defined in SkyWalking agent core.
      * @param methodsInterceptor
      */
-    private static void generateDelegator(Map<String, byte[]> classesTypeMap, ClassPool classPool,
+    private static void generateDelegator(Map<String, byte[]> classesTypeMap, TypePool typePool,
         String templateClassName, String methodsInterceptor) {
         String internalInterceptorName = internalDelegate(methodsInterceptor);
         try {
-            CtClass interClass = classPool.get(templateClassName);
-            interClass.setName(internalInterceptorName);
+            TypeDescription templateTypeDescription = typePool.describe(templateClassName)
+                .resolve();
 
-            CtField interceptorDefine = interClass.getField("TARGET_INTERCEPTOR");
-            interClass.removeField(interceptorDefine);
+            DynamicType.Unloaded interceptorType = new ByteBuddy()
+                .redefine(templateTypeDescription, ClassFileLocator.ForClassLoader.of(BootstrapInstrumentBoost.class.getClassLoader()))
+                .name(internalInterceptorName)
+                .field(named("TARGET_INTERCEPTOR")).value(methodsInterceptor)
+                .make();
 
-            interceptorDefine = CtField.make("private static String TARGET_INTERCEPTOR = \"" + methodsInterceptor + "\";", interClass);
-            interClass.addField(interceptorDefine);
+            classesTypeMap.put(internalInterceptorName, interceptorType.getBytes());
 
-            byte[] bytes = interClass.toBytecode();
+            try {
+                File debuggingClassesRootPath = null;
+                try {
+                    debuggingClassesRootPath = new File(AgentPackagePath.getPath(), "/debugging");
+                    if (!debuggingClassesRootPath.exists()) {
+                        debuggingClassesRootPath.mkdir();
+                    }
+                } catch (AgentPackageNotFoundException e) {
+                    logger.error(e, "Can't find the root path for creating /debugging folder.");
+                }
 
-            interClass.toClass();
+                try {
+                    interceptorType.saveIn(debuggingClassesRootPath);
+                } catch (IOException e) {
+                    logger.error(e, "Can't save class {} to file.");
+                }
+            } catch (Throwable t) {
+                logger.error(t, "Save debugging classes fail.");
+            }
 
-            classesTypeMap.put(internalInterceptorName, bytes);
+            classesTypeMap.put(internalInterceptorName, interceptorType.getBytes());
+
+            InstrumentDebuggingClass.INSTANCE.log(interceptorType);
         } catch (Exception e) {
             throw new PluginException("Generate Dynamic plugin failure", e);
         }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/BootstrapInstrumentBoost.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/BootstrapInstrumentBoost.java
@@ -193,28 +193,6 @@ public class BootstrapInstrumentBoost {
 
             classesTypeMap.put(internalInterceptorName, interceptorType.getBytes());
 
-            try {
-                File debuggingClassesRootPath = null;
-                try {
-                    debuggingClassesRootPath = new File(AgentPackagePath.getPath(), "/debugging");
-                    if (!debuggingClassesRootPath.exists()) {
-                        debuggingClassesRootPath.mkdir();
-                    }
-                } catch (AgentPackageNotFoundException e) {
-                    logger.error(e, "Can't find the root path for creating /debugging folder.");
-                }
-
-                try {
-                    interceptorType.saveIn(debuggingClassesRootPath);
-                } catch (IOException e) {
-                    logger.error(e, "Can't save class {} to file.");
-                }
-            } catch (Throwable t) {
-                logger.error(t, "Save debugging classes fail.");
-            }
-
-            classesTypeMap.put(internalInterceptorName, interceptorType.getBytes());
-
             InstrumentDebuggingClass.INSTANCE.log(interceptorType);
         } catch (Exception e) {
             throw new PluginException("Generate Dynamic plugin failure", e);

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -81,7 +81,6 @@
                                     <exclude>io.opencensus:*</exclude>
                                     <exclude>com.google.*:*</exclude>
                                     <exclude>com.google.guava:guava</exclude>
-                                    <exclude>org.javassist:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>

--- a/apm-sniffer/apm-agent/src/main/java/org/apache/skywalking/apm/agent/SkyWalkingAgent.java
+++ b/apm-sniffer/apm-agent/src/main/java/org/apache/skywalking/apm/agent/SkyWalkingAgent.java
@@ -39,6 +39,7 @@ import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 import org.apache.skywalking.apm.agent.core.plugin.AbstractClassEnhancePluginDefine;
 import org.apache.skywalking.apm.agent.core.plugin.EnhanceContext;
+import org.apache.skywalking.apm.agent.core.plugin.InstrumentDebuggingClass;
 import org.apache.skywalking.apm.agent.core.plugin.PluginBootstrap;
 import org.apache.skywalking.apm.agent.core.plugin.PluginException;
 import org.apache.skywalking.apm.agent.core.plugin.PluginFinder;
@@ -171,7 +172,7 @@ public class SkyWalkingAgent {
                 logger.debug("On Transformation class {}.", typeDescription.getName());
             }
 
-            InstrumentDebuggingClass.INSTANCE.log(typeDescription, dynamicType);
+            InstrumentDebuggingClass.INSTANCE.log(dynamicType);
         }
 
         @Override

--- a/docs/en/setup/service-agent/java-agent/README.md
+++ b/docs/en/setup/service-agent/java-agent/README.md
@@ -105,7 +105,7 @@ Now, we have the following known optional plugins.
 * [Customize enhance](Customize-enhance-trace.md) Trace methods based on description files, rather than write plugin or change source codes.
 * Plugin of Spring Cloud Gateway 2.1.x in optional plugin folder. Please only active this plugin when you install agent in Spring Gateway.
 
-# Bootstrap class plugins
+## Bootstrap class plugins
 All bootstrap plugins are optional, due to unexpected risk. Bootstrap plugins are provided in `bootstrap-plugins` folder.
 
 **Make sure `bootstrapJarTmp` writable by agent, which is required by bootstrap instrumentation. New temp jar files will be generated there.**.


### PR DESCRIPTION
Through @raphw helps in these days, I got the ideas of how to use ByteBuddy only to do bootstrap instrumentation. So, I remove the javassist from the agent side dependency, and from my tests, all features are still there.

New in this PR, add several byte buddy annotation classes(used by us) into the bootstrap class loader.

@candyleer As you are doing the instrumentation of jdk HTTP Connection, please verify.

FYI All @apache/skywalking-committers, javassist will be gone from the agent. Only depend on ByteBuddy again, at least we wouldn't need to have concerns about that, javassist was no longer supported in JDK6 for at least a year ago.