### PR TITLE
Fix bug: state not updated when GRPC auto reconnect to the same server

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannel.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannel.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.apm.agent.core.remote;
 
 import io.grpc.Channel;
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
@@ -71,6 +72,10 @@ public class GRPCChannel {
 
     public boolean isShutdown() {
         return originChannel.isShutdown();
+    }
+
+    public boolean isConnected() {
+        return originChannel.getState(false) == ConnectivityState.READY;
     }
 
     public static class Builder {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
@@ -105,9 +105,15 @@ public class GRPCChannelManager implements BootService, Runnable {
                             .build();
 
                         notify(GRPCChannelStatus.CONNECTED);
+                        reconnect = false;
+                    } else if (managedChannel.isConnected()) {
+                        // Reconnect to the same server is automatically done by GRPC,
+                        // therefore we are responsible to check the connectivity and
+                        // set the state and notify listeners
+                        notify(GRPCChannelStatus.CONNECTED);
+                        reconnect = false;
                     }
 
-                    reconnect = false;
                     return;
                 } catch (Throwable t) {
                     logger.error(t, "Create channel to {} fail.", server);


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

___
### Bug fix
- Bug description.
Most of the components (such as ServiceAndEndpointRegisterClient) depend on the status change callback org.apache.skywalking.apm.agent.core.remote.GRPCChannelListener#statusChanged (triggered by notify line 106), if there is only one OAP node and it's restarting, the status would be DISCONNECTED and never change back to CONNECTED, all the components depends on the status won't work since then

- How to fix?
avoid recreating a new channel every time (yet take the advantage of GRPC's auto-reconnectivity) when there is only one server, by checking the existed channel's state.

___
### New feature or improvement
- Describe the details and related test reports.
