### PR TITLE
Fix bug: NetworkAddressInventory uses wrong builder to convert data

### DIFF
--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2NetworkAddressInventoryCacheDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2NetworkAddressInventoryCacheDAO.java
@@ -63,7 +63,7 @@ public class H2NetworkAddressInventoryCacheDAO extends H2SQLExecutor implements 
                 try (ResultSet resultSet = h2Client.executeQuery(connection, sql.toString(), lastUpdateTime)) {
                     NetworkAddressInventory addressInventory;
                     do {
-                        addressInventory = (NetworkAddressInventory)toStorageData(resultSet, NetworkAddressInventory.INDEX_NAME, new ServiceInventory.Builder());
+                        addressInventory = (NetworkAddressInventory)toStorageData(resultSet, NetworkAddressInventory.INDEX_NAME, new NetworkAddressInventory.Builder());
                         if (addressInventory != null) {
                             addressInventories.add(addressInventory);
                         }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

NetworkAddressInventory uses wrong builder to convert data, in some cases it would throw NPE