### PR TITLE
Make JDK 12 works for bootstrap instrumentation

### DIFF
--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -37,7 +37,7 @@
         <jetty.version>9.4.2.v20170220</jetty.version>
         <grpc.version>1.14.0</grpc.version>
         <guava.version>20.0</guava.version>
-        <bytebuddy.version>1.9.2</bytebuddy.version>
+        <bytebuddy.version>1.9.16</bytebuddy.version>
         <disruptor.version>3.3.6</disruptor.version>
         <wiremock.version>2.6.0</wiremock.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/BootstrapInstrumentBoost.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/BootstrapInstrumentBoost.java
@@ -90,8 +90,8 @@ public class BootstrapInstrumentBoost {
         }
 
         /**
-         * This strategy is no longer available after Java 11.
-         * Inject the classes into bootstrap class loader.
+         * Inject the classes into bootstrap class loader by using Unsafe Strategy.
+         * ByteBuddy adapts the sun.misc.Unsafe and jdk.internal.misc.Unsafe automatically.
          */
         ClassInjector.UsingUnsafe.ofBootLoader().injectRaw(classesTypeMap);
         agentBuilder = agentBuilder.enableUnsafeBootstrapInjection();

--- a/docs/en/setup/service-agent/java-agent/README.md
+++ b/docs/en/setup/service-agent/java-agent/README.md
@@ -1,5 +1,5 @@
 # Setup java agent
-1. Agent is available for JDK 1.6 - 11.
+1. Agent is available for JDK 1.6 - 12.
 1. Find `agent` folder in SkyWalking release package
 1. Set `agent.service_name` in `config/agent.config`. Could be any String in English.
 1. Set `collector.backend_service` in `config/agent.config`. Default point to `127.0.0.1:11800`, only works for local backend.
@@ -20,7 +20,10 @@ The agent release dist is included in Apache [official release](http://skywalkin
          apm-feign-default-http-9.x.jar
          apm-httpClient-4.x-plugin.jar
          .....
-    +--- logs
+    +-- optional-plugins
+         apm-gson-2.x-plugin.jar
+         .....
+    +-- logs
     skywalking-agent.jar
 ```
 


### PR DESCRIPTION
By using the latest ByteBuddy, it could adapt between JDK11- and JDK12+, which make us don't have to worry about the Unsafe package rename.

Now, the injection works in JDK 12 now.

Thanks to @raphw.

FYI @apache/skywalking-committers 