### PR TITLE
Add agent version in gRPC connection establish stage

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/AgentIDDecorator.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/AgentIDDecorator.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.agent.core.remote;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+
+/**
+ * Add agent version(Described in MANIFEST.MF) to the connection establish stage.
+ *
+ * @author wusheng
+ */
+public class AgentIDDecorator implements ChannelDecorator {
+    private static final ILog logger = LogManager.getLogger(AgentIDDecorator.class);
+    private static final Metadata.Key<String> AGENT_VERSION_HEAD_HEADER_NAME =
+        Metadata.Key.of("Agent-Version", Metadata.ASCII_STRING_MARSHALLER);
+    private String version = "UNKNOWN";
+
+    public AgentIDDecorator() {
+        try {
+            Enumeration<URL> resources = AgentIDDecorator.class.getClassLoader().getResources(JarFile.MANIFEST_NAME);
+            while (resources.hasMoreElements()) {
+                URL url = resources.nextElement();
+                InputStream is = url.openStream();
+                if (is != null) {
+                    Manifest manifest = new Manifest(is);
+                    Attributes mainAttribs = manifest.getMainAttributes();
+                    String projectName = mainAttribs.getValue("Implementation-Vendor-Id");
+                    if (projectName != null) {
+                        if (projectName.equals("org.apache.skywalking")) {
+                            version = mainAttribs.getValue("Implementation-Version");
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Can't read version from MANIFEST.MF in the agent jar");
+        }
+    }
+
+    @Override public Channel build(Channel channel) {
+        return ClientInterceptors.intercept(channel, new ClientInterceptor() {
+            @Override
+            public <REQ, RESP> ClientCall<REQ, RESP> interceptCall(MethodDescriptor<REQ, RESP> method,
+                CallOptions options, Channel channel) {
+                return new ForwardingClientCall.SimpleForwardingClientCall<REQ, RESP>(channel.newCall(method, options)) {
+                    @Override
+                    public void start(Listener<RESP> responseListener, Metadata headers) {
+                        headers.put(AGENT_VERSION_HEAD_HEADER_NAME, version);
+
+                        super.start(responseListener, headers);
+                    }
+                };
+            }
+        });
+    }
+}

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
@@ -18,12 +18,23 @@
 
 package org.apache.skywalking.apm.agent.core.remote;
 
-import io.grpc.*;
-import java.util.*;
-import java.util.concurrent.*;
-import org.apache.skywalking.apm.agent.core.boot.*;
+import io.grpc.Channel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.skywalking.apm.agent.core.boot.BootService;
+import org.apache.skywalking.apm.agent.core.boot.DefaultImplementor;
+import org.apache.skywalking.apm.agent.core.boot.DefaultNamedThreadFactory;
 import org.apache.skywalking.apm.agent.core.conf.Config;
-import org.apache.skywalking.apm.agent.core.logging.api.*;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 import org.apache.skywalking.apm.util.RunnableWithExceptionProtection;
 
 /**
@@ -101,6 +112,7 @@ public class GRPCChannelManager implements BootService, Runnable {
                         managedChannel = GRPCChannel.newBuilder(ipAndPort[0], Integer.parseInt(ipAndPort[1]))
                             .addManagedChannelBuilder(new StandardChannelBuilder())
                             .addManagedChannelBuilder(new TLSChannelBuilder())
+                            .addChannelDecorator(new AgentIDDecorator())
                             .addChannelDecorator(new AuthenticationDecorator())
                             .build();
 


### PR DESCRIPTION
Make the OAP backend could get the agent version, in case that service vendors need to verify.