### PR TITLE
zipkin receive issue fix for Not in Gzip format and span.kind is null

### DIFF
--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/analysis/transform/SegmentBuilder.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/analysis/transform/SegmentBuilder.java
@@ -145,7 +145,8 @@ public class SegmentBuilder {
         if (!isSegmentRoot && parentSegmentSpan != null) {
             spanBuilder.setParentSpanId(parentSegmentSpan.getSpanId());
         }
-        Span.Kind kind = span.kind();
+        //Add default Span.kind to SERVER in case span.kind is null
+        Span.Kind kind = span.kind() == null ? Span.Kind.SERVER : span.kind();
         String opName = Strings.isNullOrEmpty(span.name()) ? "-" : span.name();
         spanBuilder.setOperationName(opName);
         ClientSideSpan clientSideSpan;

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanProcessor.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanProcessor.java
@@ -69,7 +69,7 @@ public class SpanProcessor {
     private InputStream getInputStream(HttpServletRequest request) throws IOException {
         InputStream requestInStream;
 
-        String headEncoding = request.getHeader("accept-encoding");
+        String headEncoding = request.getHeader("Content-Encoding");
         if (headEncoding != null && (headEncoding.indexOf("gzip") != -1)) {
             requestInStream = new GZIPInputStream(request.getInputStream());
         } else {

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/trace/SpanForward.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/trace/SpanForward.java
@@ -73,7 +73,8 @@ public class SpanForward {
             }
 
             String spanName = span.name();
-            Span.Kind kind = span.kind();
+            //Add default Span.kind to SERVER in case span.kind is null
+            Span.Kind kind = span.kind() == null ? Span.Kind.SERVER : span.kind();
             switch (kind) {
                 case SERVER:
                 case CONSUMER:

--- a/oap-server/server-storage-plugin/storage-zipkin-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/zipkin/elasticsearch/ZipkinTraceQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-zipkin-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/zipkin/elasticsearch/ZipkinTraceQueryEsDAO.java
@@ -186,7 +186,8 @@ public class ZipkinTraceQueryEsDAO extends EsDAO implements ITraceQueryDAO {
             swSpan.setParentSpanId(-1);
             swSpan.setSegmentSpanId(span.id());
             swSpan.setSegmentId(span.id());
-            Span.Kind kind = span.kind();
+            //Add default Span.kind to SERVER in case span.kind is null
+            Span.Kind kind = span.kind() == null ? Span.Kind.SERVER : span.kind();
             switch (kind) {
                 case CLIENT:
                 case PRODUCER:


### PR DESCRIPTION
1. Correct HTTP Header to fix "Not in GZIP format" when receive zipkin data

2. Add default value to Span.kind to Server as per Span.kind maybe null.

Please answer these questions before submitting pull request

- Why submit this pull request?
- [ X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
https://github.com/apache/skywalking/issues/2641
___
### Bug fix
- Bug description.
We use nginx with opentracing lib to send zipkin format data to Skywalking APM.
We found that Not in GZIP format issue and the default value of span.kind is null that cause nullpoint exception.

- How to fix?
After reference src code  of zipkin (https://github.com/openzipkin/zipkin with tag 2.9.1) that is same version of current zipkin lib referenced.  We change to Header value to "Content-Encoding" to solved GZIP issue.
And we add default value of span.kind with SERVER, so that with SW_RECEIVER_ZIPKIN_NEED_ANALYSIS=false mode, zipkin data can be show in trace.
___
### New feature or improvement
- Describe the details and related test reports.
