### PR TITLE
Increase test service latency to help it to be counted

### DIFF
--- a/test/e2e/e2e-agent-reboot/src/main/java/org/apache/skywalking/e2e/sample/client/TestController.java
+++ b/test/e2e/e2e-agent-reboot/src/main/java/org/apache/skywalking/e2e/sample/client/TestController.java
@@ -42,7 +42,8 @@ public class TestController {
     }
 
     @PostMapping("/users")
-    public User createAuthor(@RequestBody final User user) {
+    public User createAuthor(@RequestBody final User user) throws InterruptedException {
+        Thread.sleep(1000L);
         return userRepo.save(user);
     }
 }

--- a/test/e2e/e2e-single-service/src/main/java/org/apache/skywalking/e2e/sample/client/TestController.java
+++ b/test/e2e/e2e-single-service/src/main/java/org/apache/skywalking/e2e/sample/client/TestController.java
@@ -42,7 +42,8 @@ public class TestController {
     }
 
     @PostMapping("/users")
-    public User createAuthor(@RequestBody final User user) {
+    public User createAuthor(@RequestBody final User user) throws InterruptedException {
+        Thread.sleep(1000L);
         return userRepo.save(user);
     }
 }


### PR DESCRIPTION
The current latency of the test service is too slow, causing it's not counted and
the query result is 0, this patch increases the latency intentionally by sleeping
1 second

Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance
