### PR TITLE
GC time metrics should be total time.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,73 @@ Changes by Version
 ==================
 Release Notes.
 
+6.3.0
+------------------
+
+#### Project
+* e2e tests have been added, and verify every pull request.
+* Use ArrayList to replace LinkedList in DataCarrier for much better performance.
+* Add plugin instrumentation definition check in CI.
+* DataCarrier performance improvement by avoiding false-sharing.
+
+#### Java Agent
+* Java agent supports JDK 9 - 12, but don't support Java Module yet.
+* Support JVM class auto instrumentation, cataloged as bootstrap plugin.
+* Support JVM HttpClient and HttpsClient plugin.[Optional]
+* Support backend upgrade without rebooting required.
+* Open Redefine and Retransform by other agents.
+* Support Servlet 2.5 in Jetty, Tomcat and SpringMVC plugins.
+* Add new config item to restrict the length of span#peer.
+* Refactor `ContextManager#stopSpan`.
+* Add gRPC timeout.
+* Support Logback AsyncAppender print tid 
+* Fix gRPC reconnect bug.
+* Fix trace segment service doesn't report `onComplete`.
+* Fix wrong logger class name.
+* Fix gRPC plugin bug.
+
+#### Backend
+* Support agent reset command downstream when the storage is erased, mostly because of backend upgrade.
+* Backend stream flow refactor.
+* High dimensionality metrics(Hour/Day/Month) are changed to lower priority, to ease the storage payload.
+* Add OAP metrics cache to ease the storage query payload and improve performance.
+* Remove DataCarrier in trace persistent of ElasticSearch storage, by leveraging the elasticsearch bulk queue.
+* OAP internal communication protocol changed. Don't be compatible with old releases.
+* Improve ElasticSearch storage bulk performance.
+* Support etcd as dynamic configuration center.
+* Simplify the PxxMetrics and ThermodynamicMetrics functions for better performance and GC.
+* Support JVM metrics self observability.
+* Add the new OAL runtime engine.
+* Add gRPC timeout.
+* Add Charset in the alarm web hook.
+* Support Spring @Async plugin.
+* Fix buffer lost.
+* Fix dirty read in ElasticSearch storage.
+* Fix bug of cluster management plugins in un-Mixed mode.
+* Fix wrong logger class name.
+* Fix delete bug in ElasticSearch when using namespace.
+* Fix MySQL TTL failure.
+* Totally remove `IDs can't be null` log, to avoid misleading.
+* Fix provider has been initialized repeatedly.
+* Adjust providers conflict log message.
+
+#### UI
+* Fix refresh is not working after endpoint and instance changed.
+* Fix endpoint selector but.
+* Fix wrong copy value in slow traces.
+* Fix can't show trace when it is broken partially(Because of agent sampling or fail safe).
+* Fix database and response time graph bugs.
+
+#### Document
+* Add bootstrap plugin development document.
+* Alarm documentation typo fixed.
+* Clarify the Docker file purpose.
+* Fix a license typo.
+
+
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/34?closed=1)
+
+
 6.2.0
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,7 @@ Release Notes.
 * Totally remove `IDs can't be null` log, to avoid misleading.
 * Fix provider has been initialized repeatedly.
 * Adjust providers conflict log message.
+* Fix using wrong gc time metrics in OAL.
 
 #### UI
 * Fix refresh is not working after endpoint and instance changed.

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
@@ -40,6 +40,7 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
             <version>${spring-aop.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/oap-server/server-starter/src/main/resources/official_analysis.oal
+++ b/oap-server/server-starter/src/main/resources/official_analysis.oal
@@ -77,8 +77,8 @@ instance_jvm_memory_heap = from(ServiceInstanceJVMMemory.used).filter(heapStatus
 instance_jvm_memory_noheap = from(ServiceInstanceJVMMemory.used).filter(heapStatus == false).longAvg();
 instance_jvm_memory_heap_max = from(ServiceInstanceJVMMemory.max).filter(heapStatus == true).longAvg();
 instance_jvm_memory_noheap_max = from(ServiceInstanceJVMMemory.max).filter(heapStatus == false).longAvg();
-instance_jvm_young_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.NEW).longAvg();
-instance_jvm_old_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.OLD).longAvg();
+instance_jvm_young_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.NEW).sum();
+instance_jvm_old_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.OLD).sum();
 instance_jvm_young_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.NEW).sum();
 instance_jvm_old_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.OLD).sum();
 

--- a/oap-server/server-telemetry/telemetry-prometheus/src/main/java/org/apache/skywalking/oap/server/telemetry/prometheus/PrometheusTelemetryProvider.java
+++ b/oap-server/server-telemetry/telemetry-prometheus/src/main/java/org/apache/skywalking/oap/server/telemetry/prometheus/PrometheusTelemetryProvider.java
@@ -23,7 +23,9 @@ import io.prometheus.client.hotspot.*;
 import java.io.IOException;
 import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.telemetry.TelemetryModule;
+import org.apache.skywalking.oap.server.telemetry.api.MetricsCollector;
 import org.apache.skywalking.oap.server.telemetry.api.MetricsCreator;
+import org.apache.skywalking.oap.server.telemetry.none.MetricsCollectorNoop;
 
 /**
  * Start the Prometheus
@@ -51,6 +53,7 @@ public class PrometheusTelemetryProvider extends ModuleProvider {
 
     @Override public void prepare() throws ServiceNotProvidedException, ModuleStartException {
         this.registerServiceImplementation(MetricsCreator.class, new PrometheusMetricsCreator());
+        this.registerServiceImplementation(MetricsCollector.class, new MetricsCollectorNoop());
         try {
             new HTTPServer(config.getHost(), config.getPort());
         } catch (IOException e) {


### PR DESCRIPTION
Use `sum` to replace `longAvg` in GC time calculation. The `longAvg` OP makes the metrics meaning the avg GC time per report period.

This bug is reported from the community. FYI @apache/skywalking-committers 