### PR TITLE
Remove coveralls report due to its unavailability

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
 
                         stage('Test & Report') {
                             steps {
-                                sh './mvnw -P"agent,backend,ui,dist,CI-with-IT" org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent clean install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report'
+                                sh './mvnw -P"agent,backend,ui,dist,CI-with-IT" org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent clean install org.jacoco:jacoco-maven-plugin:0.8.3:report'
                                 sh './mvnw javadoc:javadoc -Dmaven.test.skip=true'
                             }
                         }


### PR DESCRIPTION
Maybe someday we'll bring the coverage comment back, so I did not remove the coverage plugin totally (just remove the report that causes the failure of CI)