### PR TITLE
Add cached writer.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
@@ -27,12 +27,12 @@ import org.apache.skywalking.apm.util.StringUtil;
 
 public class WriterFactory {
 
-    private static volatile IWriter writer;
+    private static volatile IWriter WRITER;
 
     public static IWriter getLogWriter() {
 
-        if (writer != null) {
-            return writer;
+        if (WRITER != null) {
+            return WRITER;
         }
 
         if (!useConsole() && SnifferConfigInitializer.isInitCompleted() && AgentPackagePath.isPathFound()) {
@@ -43,12 +43,12 @@ public class WriterFactory {
                     e.printStackTrace();
                 }
             }
-            writer = FileWriter.get();
+            WRITER = FileWriter.get();
         } else {
-            writer = SystemOutWriter.INSTANCE;
+            WRITER = SystemOutWriter.INSTANCE;
         }
 
-        return writer;
+        return WRITER;
     }
 
     private static boolean useConsole() {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
@@ -25,33 +25,35 @@ import org.apache.skywalking.apm.agent.core.conf.Config;
 import org.apache.skywalking.apm.agent.core.conf.SnifferConfigInitializer;
 import org.apache.skywalking.apm.util.StringUtil;
 
+/**
+ * @author Alan Lau
+ */
 public class WriterFactory {
 
     private static volatile IWriter WRITER;
 
     public static IWriter getLogWriter() {
 
-        if (WRITER != null) {
-            return WRITER;
-        }
-
-        if (!useConsole() && SnifferConfigInitializer.isInitCompleted() && AgentPackagePath.isPathFound()) {
-            if (StringUtil.isEmpty(Config.Logging.DIR)) {
-                try {
-                    Config.Logging.DIR = AgentPackagePath.getPath() + "/logs";
-                } catch (AgentPackageNotFoundException e) {
-                    e.printStackTrace();
+        switch (Config.Logging.OUTPUT) {
+            case FILE:
+                if (WRITER != null) {
+                    return WRITER;
                 }
-            }
-            WRITER = FileWriter.get();
-        } else {
-            WRITER = SystemOutWriter.INSTANCE;
+                if (SnifferConfigInitializer.isInitCompleted() && AgentPackagePath.isPathFound()) {
+                    if (StringUtil.isEmpty(Config.Logging.DIR)) {
+                        try {
+                            Config.Logging.DIR = AgentPackagePath.getPath() + "/logs";
+                        } catch (AgentPackageNotFoundException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    WRITER = FileWriter.get();
+                }
+                break;
+            default:
+                return SystemOutWriter.INSTANCE;
+
         }
-
         return WRITER;
-    }
-
-    private static boolean useConsole() {
-        return LogOutput.CONSOLE == Config.Logging.OUTPUT;
     }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
@@ -30,7 +30,7 @@ import org.apache.skywalking.apm.util.StringUtil;
  */
 public class WriterFactory {
 
-    private static volatile IWriter WRITER;
+    private static IWriter WRITER;
 
     public static IWriter getLogWriter() {
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
@@ -27,7 +27,7 @@ import org.apache.skywalking.apm.util.StringUtil;
 
 public class WriterFactory {
 
-    private static IWriter writer;
+    private static volatile IWriter writer;
 
     public static IWriter getLogWriter() {
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
@@ -48,6 +48,8 @@ public class WriterFactory {
                         }
                     }
                     WRITER = FileWriter.get();
+                } else {
+                    return SystemOutWriter.INSTANCE;
                 }
                 break;
             default:

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/WriterFactory.java
@@ -26,7 +26,15 @@ import org.apache.skywalking.apm.agent.core.conf.SnifferConfigInitializer;
 import org.apache.skywalking.apm.util.StringUtil;
 
 public class WriterFactory {
+
+    private static IWriter writer;
+
     public static IWriter getLogWriter() {
+
+        if (writer != null) {
+            return writer;
+        }
+
         if (!useConsole() && SnifferConfigInitializer.isInitCompleted() && AgentPackagePath.isPathFound()) {
             if (StringUtil.isEmpty(Config.Logging.DIR)) {
                 try {
@@ -35,10 +43,12 @@ public class WriterFactory {
                     e.printStackTrace();
                 }
             }
-            return FileWriter.get();
+            writer = FileWriter.get();
         } else {
-            return SystemOutWriter.INSTANCE;
+            writer = SystemOutWriter.INSTANCE;
         }
+
+        return writer;
     }
 
     private static boolean useConsole() {


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

I found that every time we get log, we need exe whole getLogWriter.
Add cached writer. so we need not call whole method always. 