### PR TITLE
Stabilize unit test

### DIFF
--- a/Jenkinsfile-E2E
+++ b/Jenkinsfile-E2E
@@ -53,11 +53,17 @@ pipeline {
             }
         }
 
+        stage('Compile Test Codes') {
+            steps {
+                sh './mvnw -f test/e2e/pom.xml clean'
+            }
+        }
+
         stage('Run End-to-End Tests') {
             parallel {
                 stage('Run Single Node Tests') {
                     steps {
-                        sh './mvnw -DskipSurefire=false -Dbuild.id=${BUILD_ID} -f test/e2e/pom.xml -pl e2e-single-service -am verify'
+                        sh './mvnw -Dbuild.id=${BUILD_ID} -f test/e2e/pom.xml -pl e2e-single-service -am verify'
                     }
                 }
 

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/logging/core/FileWriterTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/logging/core/FileWriterTest.java
@@ -36,7 +36,7 @@ public class FileWriterTest {
     @BeforeClass
     public static void beforeTestFile() throws IOException {
         Config.Logging.MAX_FILE_SIZE = 10;
-        File directory = new File("");
+        File directory = new File(System.getProperty("java.io.tmpdir", "/tmp"));
         Config.Logging.DIR = directory.getCanonicalPath() + Constants.PATH_SEPARATOR + "/log-test/";
     }
 
@@ -57,16 +57,13 @@ public class FileWriterTest {
         Config.Logging.DIR = "";
     }
 
-    private static boolean deleteDir(File dir) {
+    private static void deleteDir(File dir) {
         if (dir.isDirectory()) {
             String[] children = dir.list();
             for (int i = 0; i < children.length; i++) {
-                boolean success = deleteDir(new File(dir, children[i]));
-                if (!success) {
-                    return false;
-                }
+                deleteDir(new File(dir, children[i]));
             }
         }
-        return dir.delete();
+        dir.delete();
     }
 }


### PR DESCRIPTION
The FileWriterTest creates files in the source directory(failed to
delete them due to a bug in the `deleteDir` method), making
them being checked by checkstyle plugin and failed to pass.

Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

Eventually, the unstability of CI is due to (partialy) a bug in the `org.apache.skywalking.apm.agent.core.logging.core.FileWriterTest`, here I move the log directory to `tmp` directory and fix the bug of `deleteDir`.

Below is the log downloaded from the Jenkins workspace:

[rat.txt](https://github.com/apache/skywalking/files/3518483/rat.txt)
