### PR TITLE
Update ControllerConstructorInterceptor.java

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/mvc/v4/ControllerConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/mvc/v4/ControllerConstructorInterceptor.java
@@ -45,10 +45,13 @@ public class ControllerConstructorInterceptor implements InstanceConstructorInte
         String basePath = "";
         RequestMapping basePathRequestMapping = objInst.getClass().getAnnotation(RequestMapping.class);
         if (basePathRequestMapping != null) {
-            if (basePathRequestMapping.value().length > 0) {
-                basePath = basePathRequestMapping.value()[0];
-            } else if (basePathRequestMapping.path().length > 0) {
-                basePath = basePathRequestMapping.path()[0];
+            try {
+                if (basePathRequestMapping.value().length > 0) {
+                    basePath = basePathRequestMapping.value()[0];
+                } else if (basePathRequestMapping.path().length > 0) {
+                    basePath = basePathRequestMapping.path()[0];
+                }
+            } catch (NoSuchMethodError noSuchMethodError) {
             }
         }
         EnhanceRequireObjectCache enhanceRequireObjectCache = new EnhanceRequireObjectCache();


### PR DESCRIPTION
catch NoSuchMethodError

Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix


- Related issues
#2659
___
### Bug fix
- Bug description.
when we useing springVersion='4.1.6.RELEASE',there is no SuchMethod of RequestMapping.path().
in this case,it will throw NoSuchMethodError ,then  faild to  setSkyWalkingDynamicField.
so in then method of org.apache.skywalking.apm.plugin.spring.mvc.commons.interceptor.AbstractMethodInterceptor#beforeMethod ,it will throw NullPointerException.

![image](https://user-images.githubusercontent.com/31895647/63697134-db137300-c84e-11e9-9b2c-1637b5720822.png)
![image](https://user-images.githubusercontent.com/31895647/63697911-5f1a2a80-c850-11e9-9696-b0056da49189.png)

![image](https://user-images.githubusercontent.com/31895647/63697735-0cd90980-c850-11e9-94f0-2d13a5505184.png)

- How to fix?
to catch NoSuchMethodError
___
### New feature or improvement
- Describe the details and related test reports.
