### PR TITLE
update fix vertx plugin NPE

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/ServerConnectionInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/ServerConnectionInterceptor.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.vertx3;
+
+import io.vertx.core.http.HttpServerRequest;
+import org.apache.skywalking.apm.agent.core.context.CarrierItem;
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author wentjiang
+ */
+public class ServerConnectionInterceptor implements InstanceMethodsAroundInterceptor {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                             MethodInterceptResult result) throws Throwable {
+        HttpServerRequest request = (HttpServerRequest) allArguments[0];
+        ContextCarrier contextCarrier = new ContextCarrier();
+        CarrierItem next = contextCarrier.items();
+        while (next.hasNext()) {
+            next = next.next();
+            next.setHeadValue(request.headers().get(next.getHeadKey()));
+            request.headers().remove(next.getHeadKey());
+        }
+
+        AbstractSpan span = ContextManager.createEntrySpan(toPath(request.uri()), contextCarrier);
+        span.setComponent(ComponentsDefine.VERTX);
+        SpanLayer.asHttp(span);
+        Tags.HTTP.METHOD.set(span, request.method().toString());
+        Tags.URL.set(span, request.uri());
+        ((EnhancedInstance) request.response()).setSkyWalkingDynamicField(new VertxContext(
+            ContextManager.capture(), span.prepareForAsync()));
+    }
+
+    @Override
+    public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                              Object ret) throws Throwable {
+        ContextManager.stopSpan();
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
+                                      Class<?>[] argumentsTypes, Throwable t) {
+        ContextManager.activeSpan().errorOccurred().log(t);
+    }
+
+    private static String toPath(String uri) {
+        int index = uri.indexOf("?");
+        if (index > -1) {
+            return uri.substring(0, index);
+        } else {
+            return uri;
+        }
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/ServerConnectionInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/ServerConnectionInstrumentation.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.vertx3.define;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.NameMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+/**
+ * {@link ServerConnectionInstrumentation} enhance the <code>handleRequest</code> method
+ * in <code>io.vertx.core.http.impl.ServerConnection</code> class by
+ * <code>ServerConnectionInterceptor</code> class
+ *
+ * @author wentjiang
+ */
+public class ServerConnectionInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
+
+    private static final String ENHANCE_CLASS = "io.vertx.core.http.impl.ServerConnection";
+    private static final String ENHANCE_METHOD = "handleRequest";
+    private static final String INTERCEPT_CLASS = "org.apache.skywalking.apm.plugin.vertx3.ServerConnectionInterceptor";
+
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return new ConstructorInterceptPoint[0];
+    }
+
+    @Override
+    public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[]{
+            new InstanceMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named(ENHANCE_METHOD);
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return NameMatch.byName(ENHANCE_CLASS);
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/resources/skywalking-plugin.def
@@ -23,3 +23,4 @@ vertx-core-3.x=org.apache.skywalking.apm.plugin.vertx3.define.HttpClientRequestI
 vertx-core-3.x=org.apache.skywalking.apm.plugin.vertx3.define.HttpServerResponseImplEndInstrumentation
 vertx-core-3.x=org.apache.skywalking.apm.plugin.vertx3.define.HttpServerResponseImplHandleExceptionInstrumentation
 vertx-core-3.x=org.apache.skywalking.apm.plugin.vertx3.define.RouterImplAcceptInstrumentation
+vertx-core-3.x=org.apache.skywalking.apm.plugin.vertx3.define.ServerConnectionInstrumentation


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
https://github.com/apache/skywalking/issues/3338
___
### Bug fix
- Bug description.
my project use vertx v3.4 ,the agent log show
java.lang.NullPointerException
at org.apache.skywalking.apm.plugin.vertx3.HttpServerResponseImplEndInterceptor.beforeMethod(HttpServerResponseImplEndInterceptor.java:39)

- How to fix?
I review code and debug, the context is null, so I find there are not use class io.vertx.ext.web.impl.RouterImpl in my project
finally,I solve it by I create io.vertx.core.http.impl.ServerConnection enhance, it works healthy
___
### New feature or improvement
- Describe the details and related test reports.
