### PR TITLE
resolve NPE problems from the error logs of the prd environment

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManager.java
@@ -162,7 +162,9 @@ public class ContextManager implements BootService {
     }
 
     public static void stopSpan() {
-        stopSpan(activeSpan());
+        if (get() != null) {
+            stopSpan(activeSpan());
+        }
     }
 
     public static void stopSpan(AbstractSpan span) {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/dictionary/NetworkAddressDictionary.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/dictionary/NetworkAddressDictionary.java
@@ -43,6 +43,9 @@ public enum NetworkAddressDictionary {
 
     public PossibleFound find(String networkAddress) {
         Integer applicationId = applicationDictionary.get(networkAddress);
+        if (networkAddress == null || (networkAddress.length()) == 0) {
+            return new NotFound();
+        }
         if (applicationId != null) {
             return new Found(applicationId);
         } else {


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix

- Related issues
#2638
___
### Bug fix
ERROR 2019-08-27 15:56:06:852 pool-5-thread-2 InstMethodsInterWithOverrideArgs :  class[class com.rabbitmq.client.impl.ChannelN] before method[basicPublish] intercept failure 
java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at org.apache.skywalking.apm.agent.core.dictionary.NetworkAddressDictionary.find(NetworkAddressDictionary.java:45)
	at org.apache.skywalking.apm.agent.core.context.TracingContext.createExitSpan(TracingContext.java:322)
	at org.apache.skywalking.apm.agent.core.context.ContextManager.createExitSpan(ContextManager.java:115)

- How to fix?
add the avoid logic of  NPE 
___
### New feature or improvement
- Describe the details and related test reports.
