### PR TITLE
Fix the zookeeper plugin has many nodes in the cluster case

### DIFF
--- a/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/zookeeper/ClientCnxnInterceptor.java
+++ b/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/zookeeper/ClientCnxnInterceptor.java
@@ -37,6 +37,8 @@ import org.apache.zookeeper.proto.RequestHeader;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -82,9 +84,14 @@ public class ClientCnxnInterceptor implements InstanceMethodsAroundInterceptor, 
             field.setAccessible(true);
             @SuppressWarnings("unchecked")
             List<InetSocketAddress> serverAddresses = (List<InetSocketAddress>) field.get(hostProvider);
-            StringBuilder peer = new StringBuilder();
+            List<String> addresses = new ArrayList<String>();
             for (InetSocketAddress address : serverAddresses) {
-                peer.append(address.getHostName()).append(":").append(address.getPort()).append(";");
+                addresses.add(address.getHostName() + ":" + address.getPort());
+            }
+            Collections.sort(addresses);
+            StringBuilder peer = new StringBuilder();
+            for (String address : addresses) {
+                peer.append(address).append(";");
             }
             objInst.setSkyWalkingDynamicField(peer.toString());
         } catch (NoSuchFieldException e) {

--- a/docs/en/setup/service-agent/java-agent/Supported-list.md
+++ b/docs/en/setup/service-agent/java-agent/Supported-list.md
@@ -60,7 +60,7 @@
 * Service Discovery
   * [Netflix Eureka](https://github.com/Netflix/eureka)
 * Distributed Coordination
-  * [Zookeeper](https://github.com/apache/zookeeper) 3.4.x (Optional² & Except 3.4.4)
+  * [Zookeeper](https://github.com/apache/zookeeper) 3.4.0+ (Optional² & Except 3.4.4)
 * Spring Ecosystem
   * Spring Bean annotations(@Bean, @Service, @Component, @Repository) 3.x and 4.x (Optional²)
   * Spring Core Async SuccessCallback/FailureCallback/ListenableFutureCallback 4.x


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
https://github.com/apache/skywalking/issues/3371
___
### Bug fix
- Bug description.
The zookeeper plugin has many nodes in the cluster case

- How to fix?
Add a sort list between the addresses list and the peer

