### PR TITLE
Gateway & Webflux plugin compatible with these scene

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/AbstractServerResponseMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/AbstractServerResponseMethodInterceptor.java
@@ -33,7 +33,7 @@ import org.springframework.web.server.ServerWebExchange;
 
 import java.lang.reflect.Method;
 
-public class BodyInserterResponseMethodInterceptor implements InstanceMethodsAroundInterceptor {
+public class AbstractServerResponseMethodInterceptor implements InstanceMethodsAroundInterceptor {
 
     /**
      * The error reason
@@ -43,22 +43,24 @@ public class BodyInserterResponseMethodInterceptor implements InstanceMethodsAro
 
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes, MethodInterceptResult result) throws Throwable {
-        EnhancedInstance instance = (EnhancedInstance) allArguments[0];
-        AbstractSpan span = (AbstractSpan) instance.getSkyWalkingDynamicField();
-        if (span == null) {
-            return;
-        }
-        ServerWebExchange exchange = (ServerWebExchange) allArguments[0];
-        HttpStatus status = exchange.getResponse().getStatusCode();
-        if (status != null && status.value() >= 400) {
-            span.errorOccurred();
-            if (exchange.getAttribute(ERROR_ATTRIBUTE) != null) {
-                span.log((Throwable) exchange.getAttribute(ERROR_ATTRIBUTE));
+        EnhancedInstance instance = DispatcherHandlerHandleMethodInterceptor.getInstance(allArguments[0]);
+        if (instance != null) {
+            AbstractSpan span = (AbstractSpan) instance.getSkyWalkingDynamicField();
+            if (span == null) {
+                return;
             }
-            Tags.STATUS_CODE.set(span, Integer.toString(status.value()));
+            ServerWebExchange exchange = (ServerWebExchange) allArguments[0];
+            HttpStatus status = exchange.getResponse().getStatusCode();
+            if (status != null && status.value() >= 400) {
+                span.errorOccurred();
+                if (exchange.getAttribute(ERROR_ATTRIBUTE) != null) {
+                    span.log((Throwable) exchange.getAttribute(ERROR_ATTRIBUTE));
+                }
+                Tags.STATUS_CODE.set(span, Integer.toString(status.value()));
+            }
+            ContextManager.stopSpan(span);
+            ((EnhancedInstance) allArguments[0]).setSkyWalkingDynamicField(null);
         }
-        ContextManager.stopSpan(span);
-        ((EnhancedInstance) allArguments[0]).setSkyWalkingDynamicField(null);
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/DispatcherHandlerHandleMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/DispatcherHandlerHandleMethodInterceptor.java
@@ -34,6 +34,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.ServerWebExchangeDecorator;
+import org.springframework.web.server.adapter.DefaultServerWebExchange;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -45,23 +47,25 @@ public class DispatcherHandlerHandleMethodInterceptor implements InstanceMethods
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
                              MethodInterceptResult result) throws Throwable {
-        ContextCarrier contextCarrier = new ContextCarrier();
-        CarrierItem next = contextCarrier.items();
-        ServerWebExchange exchange = (ServerWebExchange) allArguments[0];
-        EnhancedInstance instance = (EnhancedInstance) allArguments[0];
-        HttpHeaders headers = exchange.getRequest().getHeaders();
-        while (next.hasNext()) {
-            next = next.next();
-            List<String> header = headers.get(next.getHeadKey());
-            if (header != null && header.size() > 0) {
-                next.setHeadValue(header.get(0));
+        EnhancedInstance instance = DispatcherHandlerHandleMethodInterceptor.getInstance(allArguments[0]);
+        if (instance != null) {
+            ContextCarrier contextCarrier = new ContextCarrier();
+            CarrierItem next = contextCarrier.items();
+            ServerWebExchange exchange = (ServerWebExchange) allArguments[0];
+            HttpHeaders headers = exchange.getRequest().getHeaders();
+            while (next.hasNext()) {
+                next = next.next();
+                List<String> header = headers.get(next.getHeadKey());
+                if (header != null && header.size() > 0) {
+                    next.setHeadValue(header.get(0));
+                }
             }
+            AbstractSpan span = ContextManager.createEntrySpan(WIP_OPERATION_NAME, contextCarrier);
+            span.setComponent(ComponentsDefine.SPRING_WEBFLUX);
+            SpanLayer.asHttp(span);
+            Tags.URL.set(span, exchange.getRequest().getURI().toString());
+            instance.setSkyWalkingDynamicField(span);
         }
-        AbstractSpan span = ContextManager.createEntrySpan(WIP_OPERATION_NAME, contextCarrier);
-        span.setComponent(ComponentsDefine.SPRING_WEBFLUX);
-        SpanLayer.asHttp(span);
-        Tags.URL.set(span, exchange.getRequest().getURI().toString());
-        instance.setSkyWalkingDynamicField(span);
     }
 
     @Override
@@ -73,5 +77,18 @@ public class DispatcherHandlerHandleMethodInterceptor implements InstanceMethods
     @Override
     public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
                                       Class<?>[] argumentsTypes, Throwable t) {
+    }
+
+    public static EnhancedInstance getInstance(Object o) {
+        EnhancedInstance instance = null;
+        if (o instanceof ServerWebExchangeDecorator) {
+            ServerWebExchange delegate = ((ServerWebExchangeDecorator) o).getDelegate();
+            if (delegate instanceof DefaultServerWebExchange) {
+                instance = (EnhancedInstance) delegate;
+            }
+        } else if (o instanceof DefaultServerWebExchange) {
+            instance = (EnhancedInstance) o;
+        }
+        return instance;
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/DispatcherHandlerHandleResultMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/DispatcherHandlerHandleResultMethodInterceptor.java
@@ -40,11 +40,13 @@ public class DispatcherHandlerHandleResultMethodInterceptor implements InstanceM
     @Override
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
                               Object ret) throws Throwable {
-        EnhancedInstance instance = (EnhancedInstance) allArguments[0];
-        AbstractSpan span = (AbstractSpan) instance.getSkyWalkingDynamicField();
-        if (span != null) {
-            ContextManager.stopSpan(span);
-            instance.setSkyWalkingDynamicField(null);
+        EnhancedInstance instance = DispatcherHandlerHandleMethodInterceptor.getInstance(allArguments[0]);
+        if (instance != null) {
+            AbstractSpan span = (AbstractSpan) instance.getSkyWalkingDynamicField();
+            if (span != null) {
+                ContextManager.stopSpan(span);
+                instance.setSkyWalkingDynamicField(null);
+            }
         }
         return ret;
     }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/DispatcherHandlerInvokeHandlerMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/DispatcherHandlerInvokeHandlerMethodInterceptor.java
@@ -41,25 +41,27 @@ public class DispatcherHandlerInvokeHandlerMethodInterceptor implements Instance
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
                              MethodInterceptResult result) throws Throwable {
-        EnhancedInstance instance = (EnhancedInstance) allArguments[0];
-        AbstractSpan span = (AbstractSpan) instance.getSkyWalkingDynamicField();
-        if (span == null) {
-            return;
-        }
-        String handleClassName = allArguments[1].getClass().getSimpleName();
-        int index = handleClassName.indexOf(ROUTER_SEARCH);
-        if (index != -1) {
-            String operationName = handleClassName.substring(0, index);
-            try {
-                Field field = allArguments[1].getClass().getDeclaredField(ROUTER_FIELD);
-                field.setAccessible(true);
-                operationName = operationName + DOT + field.get(allArguments[1]).getClass().getName();
-            } catch (NoSuchFieldException ignore) {
+        EnhancedInstance instance = DispatcherHandlerHandleMethodInterceptor.getInstance(allArguments[0]);
+        if (instance != null) {
+            AbstractSpan span = (AbstractSpan) instance.getSkyWalkingDynamicField();
+            if (span == null) {
+                return;
             }
-            span.setOperationName(operationName);
-        } else if (allArguments[1] instanceof HandlerMethod) {
-            HandlerMethod handler = (HandlerMethod) allArguments[1];
-            span.setOperationName(getHandlerMethodOperationName(handler));
+            String handleClassName = allArguments[1].getClass().getSimpleName();
+            int index = handleClassName.indexOf(ROUTER_SEARCH);
+            if (index != -1) {
+                String operationName = handleClassName.substring(0, index);
+                try {
+                    Field field = allArguments[1].getClass().getDeclaredField(ROUTER_FIELD);
+                    field.setAccessible(true);
+                    operationName = operationName + DOT + field.get(allArguments[1]).getClass().getName();
+                } catch (NoSuchFieldException ignore) {
+                }
+                span.setOperationName(operationName);
+            } else if (allArguments[1] instanceof HandlerMethod) {
+                HandlerMethod handler = (HandlerMethod) allArguments[1];
+                span.setOperationName(getHandlerMethodOperationName(handler));
+            }
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/ServerWebExchangeConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/ServerWebExchangeConstructorInterceptor.java
@@ -25,7 +25,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceC
  *
  * @author zhaoyuguang
  */
-public class DefaultServerWebExchangeConstructorInterceptor implements InstanceConstructorInterceptor {
+public class ServerWebExchangeConstructorInterceptor implements InstanceConstructorInterceptor {
     @Override
     public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
     }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/define/ServerWebExchangeInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/define/ServerWebExchangeInstrumentation.java
@@ -25,42 +25,38 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsIn
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
 import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
 
-import static net.bytebuddy.matcher.ElementMatchers.named;
-import static org.apache.skywalking.apm.agent.core.plugin.match.MultiClassNameMatch.byMultiClassMatch;
+import static net.bytebuddy.matcher.ElementMatchers.any;
+import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
 
 /**
  * @author zhaoyuguang
  */
 
-public class BodyInserterResponseInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
-
-    @Override
-    protected ClassMatch enhanceClass() {
-        return byMultiClassMatch("org.springframework.web.reactive.function.server.DefaultServerResponseBuilder$BodyInserterResponse",
-                "org.springframework.web.reactive.function.server.DefaultServerResponseBuilder$BodyInserterServerResponse");
-    }
-
+public class ServerWebExchangeInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
     @Override
     public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
-        return new ConstructorInterceptPoint[0];
+        return new ConstructorInterceptPoint[]{
+            new ConstructorInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getConstructorMatcher() {
+                    return any();
+                }
+
+                @Override
+                public String getConstructorInterceptor() {
+                    return "org.apache.skywalking.apm.plugin.spring.webflux.v5.ServerWebExchangeConstructorInterceptor";
+                }
+            }
+        };
     }
 
     @Override
     public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
-        return new InstanceMethodsInterceptPoint[] {
-            new InstanceMethodsInterceptPoint() {
-                @Override public ElementMatcher<MethodDescription> getMethodsMatcher() {
-                    return named("writeToInternal");
-                }
+        return new InstanceMethodsInterceptPoint[0];
+    }
 
-                @Override public String getMethodsInterceptor() {
-                    return "org.apache.skywalking.apm.plugin.spring.webflux.v5.BodyInserterResponseMethodInterceptor";
-                }
-
-                @Override public boolean isOverrideArgs() {
-                    return false;
-                }
-            }
-        };
+    @Override
+    protected ClassMatch enhanceClass() {
+        return byName("org.springframework.web.server.adapter.DefaultServerWebExchange");
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/webflux-5.x-plugin/src/main/resources/skywalking-plugin.def
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 spring-webflux-5.x=org.apache.skywalking.apm.plugin.spring.webflux.v5.define.DispatcherHandlerInstrumentation
-spring-webflux-5.x=org.apache.skywalking.apm.plugin.spring.webflux.v5.define.DefaultServerWebExchangeInstrumentation
-spring-webflux-5.x=org.apache.skywalking.apm.plugin.spring.webflux.v5.define.BodyInserterResponseInstrumentation
+spring-webflux-5.x=org.apache.skywalking.apm.plugin.spring.webflux.v5.define.ServerWebExchangeInstrumentation
+spring-webflux-5.x=org.apache.skywalking.apm.plugin.spring.webflux.v5.define.AbstractServerResponseInstrumentation

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/cloud/gateway/v21x/NettyRoutingFilterInterceptor.java
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/cloud/gateway/v21x/NettyRoutingFilterInterceptor.java
@@ -27,6 +27,8 @@ import org.apache.skywalking.apm.plugin.spring.cloud.gateway.v21x.context.Consta
 import org.apache.skywalking.apm.plugin.spring.cloud.gateway.v21x.context.SWTransmitter;
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.ServerWebExchangeDecorator;
+import org.springframework.web.server.adapter.DefaultServerWebExchange;
 
 import java.lang.reflect.Method;
 
@@ -43,16 +45,19 @@ public class NettyRoutingFilterInterceptor implements InstanceMethodsAroundInter
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
                              MethodInterceptResult result) throws Throwable {
-        ServerWebExchange exchange = (ServerWebExchange) allArguments[0];
-        AbstractSpan span = (AbstractSpan) ((EnhancedInstance) allArguments[0]).getSkyWalkingDynamicField();
-        String operationName = SPRING_CLOUD_GATEWAY_ROUTE_PREFIX;
-        if (span != null) {
-            Route route = exchange.getRequiredAttribute(GATEWAY_ROUTE_ATTR);
-            operationName = operationName + route.getId();
-            span.setOperationName(operationName);
-            SWTransmitter transmitter = new SWTransmitter(span.prepareForAsync(), ContextManager.capture(), operationName);
-            ContextManager.stopSpan(span);
-            ContextManager.getRuntimeContext().put(Constants.SPRING_CLOUD_GATEWAY_TRANSMITTER, transmitter);
+        EnhancedInstance instance = NettyRoutingFilterInterceptor.getInstance(allArguments[0]);
+        if (instance != null) {
+            ServerWebExchange exchange = (ServerWebExchange) allArguments[0];
+            AbstractSpan span = (AbstractSpan) instance.getSkyWalkingDynamicField();
+            String operationName = SPRING_CLOUD_GATEWAY_ROUTE_PREFIX;
+            if (span != null) {
+                Route route = exchange.getRequiredAttribute(GATEWAY_ROUTE_ATTR);
+                operationName = operationName + route.getId();
+                span.setOperationName(operationName);
+                SWTransmitter transmitter = new SWTransmitter(span.prepareForAsync(), ContextManager.capture(), operationName);
+                ContextManager.stopSpan(span);
+                ContextManager.getRuntimeContext().put(Constants.SPRING_CLOUD_GATEWAY_TRANSMITTER, transmitter);
+            }
         }
     }
 
@@ -69,5 +74,18 @@ public class NettyRoutingFilterInterceptor implements InstanceMethodsAroundInter
     @Override
     public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
                                       Class<?>[] argumentsTypes, Throwable t) {
+    }
+
+    public static EnhancedInstance getInstance(Object o) {
+        EnhancedInstance instance = null;
+        if (o instanceof ServerWebExchangeDecorator) {
+            ServerWebExchange delegate = ((ServerWebExchangeDecorator) o).getDelegate();
+            if (delegate instanceof DefaultServerWebExchange) {
+                instance = (EnhancedInstance) delegate;
+            }
+        } else if (o instanceof DefaultServerWebExchange) {
+            instance = (EnhancedInstance) o;
+        }
+        return instance;
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance
___
### Bug fix
- Bug description.

When you access a Gateway API case Exception through a browser, the class that handles the respone is`org.springframework.web.reactive.function.server.DefaultEntityResponseBuilder$DefaultEntityResponse`,  recurrence process: 
![image](https://user-images.githubusercontent.com/10150229/64316365-2e23bd80-cfe7-11e9-893a-e131179c7e55.png)

- How to fix?
Add this class at BodyInserterResponseInstrumentation and rename it to AbstractServerResponseInstrumentation

- Bug description.

When we use Filter, the ServerWebExchange of DispatcherHandlerHandle is a proxy class, but when the API case abnormal, the ServerWebExchange of AbstractServerResponse exchanges the real object, so I put the span in the real object.

- How to fix?
```java
    public static EnhancedInstance getInstance(Object o) {
        EnhancedInstance instance = null;
        if (o instanceof ServerWebExchangeDecorator) {
            ServerWebExchange delegate = ((ServerWebExchangeDecorator) o).getDelegate();
            if (delegate instanceof DefaultServerWebExchange) {
                instance = (EnhancedInstance) delegate;
            }
        } else if (o instanceof DefaultServerWebExchange) {
            instance = (EnhancedInstance) o;
        }
        return instance;
    }
```

