### PR TITLE
Issues:spring-cloud-gateway traceid does not transmit #3411

### DIFF
--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/cloud/gateway/v21x/NettyRoutingFilterInterceptor.java
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/cloud/gateway/v21x/NettyRoutingFilterInterceptor.java
@@ -45,10 +45,9 @@ public class NettyRoutingFilterInterceptor implements InstanceMethodsAroundInter
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
                              MethodInterceptResult result) throws Throwable {
-        EnhancedInstance instance = NettyRoutingFilterInterceptor.getInstance(allArguments[0]);
-        if (instance != null) {
+        if (objInst != null) {
             ServerWebExchange exchange = (ServerWebExchange) allArguments[0];
-            AbstractSpan span = (AbstractSpan) instance.getSkyWalkingDynamicField();
+            AbstractSpan span =ContextManager.activeSpan();
             String operationName = SPRING_CLOUD_GATEWAY_ROUTE_PREFIX;
             if (span != null) {
                 Route route = exchange.getRequiredAttribute(GATEWAY_ROUTE_ATTR);
@@ -74,18 +73,5 @@ public class NettyRoutingFilterInterceptor implements InstanceMethodsAroundInter
     @Override
     public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
                                       Class<?>[] argumentsTypes, Throwable t) {
-    }
-
-    public static EnhancedInstance getInstance(Object o) {
-        EnhancedInstance instance = null;
-        if (o instanceof ServerWebExchangeDecorator) {
-            ServerWebExchange delegate = ((ServerWebExchangeDecorator) o).getDelegate();
-            if (delegate instanceof DefaultServerWebExchange) {
-                instance = (EnhancedInstance) delegate;
-            }
-        } else if (o instanceof DefaultServerWebExchange) {
-            instance = (EnhancedInstance) o;
-        }
-        return instance;
     }
 }


### PR DESCRIPTION
skywalking version:6.4.0-SNAPSHOT

spring-cloud-gateway-version:2.1.2.RELEASE

Problem Description:

Custom filter,traceid does not transmit.When the filter implements the "GlobalFilter, Ordered" interface,"DefaultServerWebExchange" is not an implementation of "EnhancedInstance".Line number:NettyRoutingFilterInterceptor#89.
Solution:

Direct use of "InstanceMethodsAroundInterceptor" interface parameter "EnhancedInstance objInst".

Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
