### PR TITLE
Fix variable name and log in e2e tests.

### DIFF
--- a/test/e2e/e2e-agent-reboot/src/test/java/org/apache/skywalking/e2e/AgentRebootITCase.java
+++ b/test/e2e/e2e-agent-reboot/src/test/java/org/apache/skywalking/e2e/AgentRebootITCase.java
@@ -235,8 +235,8 @@ public class AgentRebootITCase {
     private void verifyInstancesMetrics(Instances instances) throws Exception {
         for (Instance instance : instances.getInstances()) {
             for (String metricsName : ALL_INSTANCE_METRICS) {
-                LOGGER.info("verifying service instance response time: {}", instance);
-                final Metrics instanceRespTime = queryClient.metrics(
+                LOGGER.info("verifying service instance {}, metrics {}", instance, metricsName);
+                final Metrics instanceMetrics = queryClient.metrics(
                     new MetricsQuery()
                         .stepByMinute()
                         .metricsName(metricsName)
@@ -246,8 +246,8 @@ public class AgentRebootITCase {
                 MetricsValueMatcher greaterThanZero = new MetricsValueMatcher();
                 greaterThanZero.setValue("gt 0");
                 instanceRespTimeMatcher.setValue(greaterThanZero);
-                instanceRespTimeMatcher.verify(instanceRespTime);
-                LOGGER.info("{}: {}", metricsName, instanceRespTime);
+                instanceRespTimeMatcher.verify(instanceMetrics);
+                LOGGER.info("{}: {}", metricsName, instanceMetrics);
             }
         }
     }
@@ -257,12 +257,12 @@ public class AgentRebootITCase {
             if (!endpoint.getLabel().equals("/e2e/users")) {
                 continue;
             }
-            for (String metricName : ALL_ENDPOINT_METRICS) {
-                LOGGER.info("verifying endpoint {}, metrics: {}", endpoint, metricName);
+            for (String metricsName : ALL_ENDPOINT_METRICS) {
+                LOGGER.info("verifying endpoint {}, metrics: {}", endpoint, metricsName);
                 final Metrics metrics = queryClient.metrics(
                     new MetricsQuery()
                         .stepByMinute()
-                        .metricsName(metricName)
+                        .metricsName(metricsName)
                         .id(endpoint.getKey())
                 );
                 AtLeastOneOfMetricsMatcher instanceRespTimeMatcher = new AtLeastOneOfMetricsMatcher();
@@ -270,26 +270,26 @@ public class AgentRebootITCase {
                 greaterThanZero.setValue("gt 0");
                 instanceRespTimeMatcher.setValue(greaterThanZero);
                 instanceRespTimeMatcher.verify(metrics);
-                LOGGER.info("metrics: {}", metrics);
+                LOGGER.info("{}: {}", metricsName, metrics);
             }
         }
     }
 
     private void verifyServiceMetrics(Service service) throws Exception {
-        for (String metricName : ALL_SERVICE_METRICS) {
-            LOGGER.info("verifying service {}, metrics: {}", service, metricName);
-            final Metrics instanceRespTime = queryClient.metrics(
+        for (String metricsName : ALL_SERVICE_METRICS) {
+            LOGGER.info("verifying service {}, metrics: {}", service, metricsName);
+            final Metrics serviceMetrics = queryClient.metrics(
                 new MetricsQuery()
                     .stepByMinute()
-                    .metricsName(metricName)
+                    .metricsName(metricsName)
                     .id(service.getKey())
             );
             AtLeastOneOfMetricsMatcher instanceRespTimeMatcher = new AtLeastOneOfMetricsMatcher();
             MetricsValueMatcher greaterThanZero = new MetricsValueMatcher();
             greaterThanZero.setValue("gt 0");
             instanceRespTimeMatcher.setValue(greaterThanZero);
-            instanceRespTimeMatcher.verify(instanceRespTime);
-            LOGGER.info("instanceRespTime: {}", instanceRespTime);
+            instanceRespTimeMatcher.verify(serviceMetrics);
+            LOGGER.info("{}}: {}", metricsName, serviceMetrics);
         }
     }
 

--- a/test/e2e/e2e-cluster/test-runner/src/test/java/org/apache/skywalking/e2e/ClusterVerificationITCase.java
+++ b/test/e2e/e2e-cluster/test-runner/src/test/java/org/apache/skywalking/e2e/ClusterVerificationITCase.java
@@ -227,8 +227,8 @@ public class ClusterVerificationITCase {
 
                 boolean valid = false;
                 while (!valid) {
-                    LOGGER.warn("instanceRespTime is null, will retry to query");
-                    Metrics instanceRespTime = queryClient.metrics(
+                    LOGGER.warn("instanceMetrics is null, will retry to query");
+                    Metrics instanceMetrics = queryClient.metrics(
                             new MetricsQuery()
                                 .stepByMinute()
                                 .metricsName(metricsName)
@@ -241,13 +241,13 @@ public class ClusterVerificationITCase {
                     greaterThanZero.setValue("gt 0");
                     instanceRespTimeMatcher.setValue(greaterThanZero);
                     try {
-                        instanceRespTimeMatcher.verify(instanceRespTime);
+                        instanceRespTimeMatcher.verify(instanceMetrics);
                         valid = true;
                     } catch (Throwable ignored) {
                         generateTraffic();
                         Thread.sleep(retryInterval);
                     }
-                    LOGGER.info("{}: {}", metricsName, instanceRespTime);
+                    LOGGER.info("{}: {}", metricsName, instanceMetrics);
                 }
             }
         }

--- a/test/e2e/e2e-single-service/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
+++ b/test/e2e/e2e-single-service/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
@@ -188,7 +188,8 @@ public class SampleVerificationITCase {
         }
     }
 
-    private Instances verifyServiceInstances(LocalDateTime minutesAgo, LocalDateTime now, Service service) throws Exception {
+    private Instances verifyServiceInstances(LocalDateTime minutesAgo, LocalDateTime now,
+        Service service) throws Exception {
         InputStream expectedInputStream;
         Instances instances = queryClient.instances(
             new InstancesQuery()
@@ -203,7 +204,8 @@ public class SampleVerificationITCase {
         return instances;
     }
 
-    private Endpoints verifyServiceEndpoints(LocalDateTime minutesAgo, LocalDateTime now, Service service) throws Exception {
+    private Endpoints verifyServiceEndpoints(LocalDateTime minutesAgo, LocalDateTime now,
+        Service service) throws Exception {
         Endpoints instances = queryClient.endpoints(
             new EndpointQuery().serviceId(service.getKey())
         );
@@ -218,7 +220,7 @@ public class SampleVerificationITCase {
         for (Instance instance : instances.getInstances()) {
             for (String metricsName : ALL_INSTANCE_METRICS) {
                 LOGGER.info("verifying service instance response time: {}", instance);
-                final Metrics instanceRespTime = queryClient.metrics(
+                final Metrics instanceMetrics = queryClient.metrics(
                     new MetricsQuery()
                         .stepByMinute()
                         .metricsName(metricsName)
@@ -228,8 +230,8 @@ public class SampleVerificationITCase {
                 MetricsValueMatcher greaterThanZero = new MetricsValueMatcher();
                 greaterThanZero.setValue("gt 0");
                 instanceRespTimeMatcher.setValue(greaterThanZero);
-                instanceRespTimeMatcher.verify(instanceRespTime);
-                LOGGER.info("{}: {}", metricsName, instanceRespTime);
+                instanceRespTimeMatcher.verify(instanceMetrics);
+                LOGGER.info("{}: {}", metricsName, instanceMetrics);
             }
         }
     }
@@ -252,7 +254,7 @@ public class SampleVerificationITCase {
                 greaterThanZero.setValue("gt 0");
                 instanceRespTimeMatcher.setValue(greaterThanZero);
                 instanceRespTimeMatcher.verify(metrics);
-                LOGGER.info("metrics: {}", metrics);
+                LOGGER.info("{}: {}", metricName, metrics);
             }
         }
     }
@@ -260,7 +262,7 @@ public class SampleVerificationITCase {
     private void verifyServiceMetrics(Service service) throws Exception {
         for (String metricName : ALL_SERVICE_METRICS) {
             LOGGER.info("verifying service {}, metrics: {}", service, metricName);
-            final Metrics instanceRespTime = queryClient.metrics(
+            final Metrics serviceMetrics = queryClient.metrics(
                 new MetricsQuery()
                     .stepByMinute()
                     .metricsName(metricName)
@@ -270,8 +272,8 @@ public class SampleVerificationITCase {
             MetricsValueMatcher greaterThanZero = new MetricsValueMatcher();
             greaterThanZero.setValue("gt 0");
             instanceRespTimeMatcher.setValue(greaterThanZero);
-            instanceRespTimeMatcher.verify(instanceRespTime);
-            LOGGER.info("instanceRespTime: {}", instanceRespTime);
+            instanceRespTimeMatcher.verify(serviceMetrics);
+            LOGGER.info("{}: {}", metricName, serviceMetrics);
         }
     }
 


### PR DESCRIPTION
The variable and logs have some typo and inaccurate names. Simple rename.