### PR TITLE
Sync latest ALS from Envoy API

### DIFF
--- a/oap-server/server-receiver-plugin/receiver-proto/src/main/proto/envoy/data/accesslog/v2/accesslog.proto
+++ b/oap-server/server-receiver-plugin/receiver-proto/src/main/proto/envoy/data/accesslog/v2/accesslog.proto
@@ -12,10 +12,7 @@ import "envoy/api/v2/core/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
-import "gogoproto/gogo.proto";
 import "validate/validate.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: gRPC access logs]
 // Envoy access logs describe incoming interaction with Envoy over a fixed
@@ -28,10 +25,12 @@ option (gogoproto.stable_marshaler_all) = true;
 // Fields describing *upstream* interaction will explicitly include ``upstream``
 // in their name.
 
-// [#not-implemented-hide:]
 message TCPAccessLogEntry {
   // Common properties shared by all Envoy access logs.
   AccessLogCommon common_properties = 1;
+
+  // Properties of the TCP connection.
+  ConnectionProperties connection_properties = 2;
 }
 
 message HTTPAccessLogEntry {
@@ -54,6 +53,15 @@ message HTTPAccessLogEntry {
   HTTPResponseProperties response = 4;
 }
 
+// Defines fields for a connection
+message ConnectionProperties {
+  // Number of bytes received from downstream.
+  uint64 received_bytes = 1;
+
+  // Number of bytes sent to downstream.
+  uint64 sent_bytes = 2;
+}
+
 // Defines fields that are shared by all Envoy access logs.
 message AccessLogCommon {
   // [#not-implemented-hide:]
@@ -74,37 +82,37 @@ message AccessLogCommon {
 
   // The time that Envoy started servicing this request. This is effectively the time that the first
   // downstream byte is received.
-  google.protobuf.Timestamp start_time = 5 [(gogoproto.stdtime) = true];
+  google.protobuf.Timestamp start_time = 5;
 
   // Interval between the first downstream byte received and the last
   // downstream byte received (i.e. time it takes to receive a request).
-  google.protobuf.Duration time_to_last_rx_byte = 6 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_rx_byte = 6;
 
   // Interval between the first downstream byte received and the first upstream byte sent. There may
   // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
   // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
   // not accounting for kernel socket buffer time, etc.
-  google.protobuf.Duration time_to_first_upstream_tx_byte = 7 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_first_upstream_tx_byte = 7;
 
   // Interval between the first downstream byte received and the last upstream byte sent. There may
   // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
   // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
   // not accounting for kernel socket buffer time, etc.
-  google.protobuf.Duration time_to_last_upstream_tx_byte = 8 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_upstream_tx_byte = 8;
 
   // Interval between the first downstream byte received and the first upstream
   // byte received (i.e. time it takes to start receiving a response).
-  google.protobuf.Duration time_to_first_upstream_rx_byte = 9 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_first_upstream_rx_byte = 9;
 
   // Interval between the first downstream byte received and the last upstream
   // byte received (i.e. time it takes to receive a complete response).
-  google.protobuf.Duration time_to_last_upstream_rx_byte = 10 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_upstream_rx_byte = 10;
 
   // Interval between the first downstream byte received and the first downstream byte sent.
   // There may be a considerable delta between the *time_to_first_upstream_rx_byte* and this field
   // due to filters. Additionally, the same caveats apply as documented in
   // *time_to_last_downstream_tx_byte* about not accounting for kernel socket buffer time, etc.
-  google.protobuf.Duration time_to_first_downstream_tx_byte = 11 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_first_downstream_tx_byte = 11;
 
   // Interval between the first downstream byte received and the last downstream byte sent.
   // Depending on protocol, buffering, windowing, filters, etc. there may be a considerable delta
@@ -112,7 +120,7 @@ message AccessLogCommon {
   // time. In the current implementation it does not include kernel socket buffer time. In the
   // current implementation it also does not include send window buffering inside the HTTP/2 codec.
   // In the future it is likely that work will be done to make this duration more accurate.
-  google.protobuf.Duration time_to_last_downstream_tx_byte = 12 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_downstream_tx_byte = 12;
 
   // The upstream remote/destination address that handles this exchange. This does not include
   // retries.
@@ -142,6 +150,14 @@ message AccessLogCommon {
   // upstream transport socket. Common TLS failures are in
   // :ref:`TLS trouble shooting <arch_overview_ssl_trouble_shooting>`.
   string upstream_transport_failure_reason = 18;
+
+  // The name of the route
+  string route_name = 19;
+
+  // This field is the downstream direct remote address on which the request from the user was
+  // received. Note: This is always the physical peer, even if the remote address is inferred from
+  // for example the x-forwarder-for header, proxy protocol, etc.
+  envoy.api.v2.core.Address downstream_direct_remote_address = 20;
 }
 
 // Flags indicating occurrences during request/response processing.
@@ -207,11 +223,14 @@ message ResponseFlags {
 
   // Indicates that the stream idle timeout was hit, resulting in a downstream 408.
   bool stream_idle_timeout = 17;
+
+  // Indicates that the request was rejected because an envoy request header failed strict
+  // validation.
+  bool invalid_envoy_request_headers = 18;
 }
 
 // Properties of a negotiated TLS connection.
 message TLSProperties {
-  // [#not-implemented-hide:]
   enum TLSVersion {
     VERSION_UNSPECIFIED = 0;
     TLSv1 = 1;
@@ -219,11 +238,9 @@ message TLSProperties {
     TLSv1_2 = 3;
     TLSv1_3 = 4;
   }
-  // [#not-implemented-hide:]
   // Version of TLS that was negotiated.
   TLSVersion tls_version = 1;
 
-  // [#not-implemented-hide:]
   // TLS cipher suite negotiated during handshake. The value is a
   // four-digit hex code defined by the IANA TLS Cipher Suite Registry
   // (e.g. ``009C`` for ``TLS_RSA_WITH_AES_128_GCM_SHA256``).
@@ -255,6 +272,9 @@ message TLSProperties {
 
   // Properties of the peer certificate used to negotiate TLS.
   CertificateProperties peer_certificate_properties = 5;
+
+  // The TLS session ID.
+  string tls_session_id = 6;
 }
 
 message HTTPRequestProperties {
@@ -332,4 +352,7 @@ message HTTPResponseProperties {
 
   // Map of trailers configured to be logged.
   map<string, string> response_trailers = 5;
+
+  // The HTTP response code details.
+  string response_code_details = 6;
 }


### PR DESCRIPTION
Make https://github.com/envoyproxy/envoy/pull/8278 available. After Envoy release includes this, we could use `downstream_direct_remote_address` to replace `downstream_remote_address`. It will provide metrics when `proxy->sidecar`.