### PR TITLE
Refactor web hook callback to SPI

### DIFF
--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmModuleProvider.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmModuleProvider.java
@@ -19,6 +19,10 @@
 package org.apache.skywalking.oap.server.core.alarm.provider;
 
 import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.alarm.*;
 import org.apache.skywalking.oap.server.library.module.*;
@@ -50,7 +54,15 @@ public class AlarmModuleProvider extends ModuleProvider {
         RulesReader reader = new RulesReader(applicationReader);
         Rules rules = reader.readRules();
         notifyHandler = new NotifyHandler(rules);
-        notifyHandler.init(new AlarmStandardPersistence());
+
+        List<AlarmCallback> alarmCallbacks = new ArrayList<>();
+        ServiceLoader<AlarmCallback> callbackLoader = ServiceLoader.load(AlarmCallback.class);
+        for (AlarmCallback alarmCallbackImpl : callbackLoader) {
+            alarmCallbacks.add(alarmCallbackImpl);
+        }
+
+        notifyHandler.init(alarmCallbacks);
+
         this.registerServiceImplementation(MetricsNotify.class, notifyHandler);
     }
 

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandler.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandler.java
@@ -18,12 +18,24 @@
 
 package org.apache.skywalking.oap.server.core.alarm.provider;
 
-import java.util.*;
+import java.util.List;
+
 import org.apache.skywalking.oap.server.core.CoreModule;
-import org.apache.skywalking.oap.server.core.alarm.*;
-import org.apache.skywalking.oap.server.core.analysis.metrics.*;
-import org.apache.skywalking.oap.server.core.cache.*;
-import org.apache.skywalking.oap.server.core.register.*;
+import org.apache.skywalking.oap.server.core.alarm.AlarmCallback;
+import org.apache.skywalking.oap.server.core.alarm.EndpointMetaInAlarm;
+import org.apache.skywalking.oap.server.core.alarm.MetaInAlarm;
+import org.apache.skywalking.oap.server.core.alarm.MetricsNotify;
+import org.apache.skywalking.oap.server.core.alarm.ServiceInstanceMetaInAlarm;
+import org.apache.skywalking.oap.server.core.alarm.ServiceMetaInAlarm;
+import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
+import org.apache.skywalking.oap.server.core.analysis.metrics.MetricsMetaInfo;
+import org.apache.skywalking.oap.server.core.analysis.metrics.WithMetadata;
+import org.apache.skywalking.oap.server.core.cache.EndpointInventoryCache;
+import org.apache.skywalking.oap.server.core.cache.ServiceInstanceInventoryCache;
+import org.apache.skywalking.oap.server.core.cache.ServiceInventoryCache;
+import org.apache.skywalking.oap.server.core.register.EndpointInventory;
+import org.apache.skywalking.oap.server.core.register.ServiceInstanceInventory;
+import org.apache.skywalking.oap.server.core.register.ServiceInventory;
 import org.apache.skywalking.oap.server.core.source.DefaultScopeDefine;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 
@@ -33,10 +45,8 @@ public class NotifyHandler implements MetricsNotify {
     private EndpointInventoryCache endpointInventoryCache;
 
     private final AlarmCore core;
-    private final Rules rules;
 
     public NotifyHandler(Rules rules) {
-        this.rules = rules;
         core = new AlarmCore(rules);
     }
 
@@ -94,12 +104,7 @@ public class NotifyHandler implements MetricsNotify {
         runningRules.forEach(rule -> rule.in(metaInAlarm, metrics));
     }
 
-    public void init(AlarmCallback... callbacks) {
-        List<AlarmCallback> allCallbacks = new ArrayList<>();
-        for (AlarmCallback callback : callbacks) {
-            allCallbacks.add(callback);
-        }
-        allCallbacks.add(new WebhookCallback(rules.getWebhooks()));
+    public void init(List<AlarmCallback> allCallbacks) {
         core.start(allCallbacks);
     }
 

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/WebHooks.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/WebHooks.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.oap.server.core.alarm.provider;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+/**
+ * @author kezhenxu94
+ */
+@Getter
+@Setter
+@ToString
+public class WebHooks {
+    private List<String> webhooks;
+}

--- a/oap-server/server-alarm-plugin/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.core.alarm.AlarmCallback
+++ b/oap-server/server-alarm-plugin/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.core.alarm.AlarmCallback
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+org.apache.skywalking.oap.server.core.alarm.provider.WebhookCallback

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandlerTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandlerTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.skywalking.oap.server.core.alarm.provider;
 
+import java.util.Collections;
+
 import com.google.common.collect.Lists;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.alarm.*;
@@ -199,11 +201,11 @@ public class NotifyHandlerTest {
 
         notifyHandler = new NotifyHandler(rules);
 
-        notifyHandler.init(alarmMessageList -> {
+        notifyHandler.init(Collections.singletonList(alarmMessageList -> {
             for (AlarmMessage message : alarmMessageList) {
                 assertNotNull(message);
             }
-        });
+        }));
 
         moduleManager = mock(ModuleManager.class);
 

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/WebhookCallbackTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/WebhookCallbackTest.java
@@ -56,9 +56,7 @@ public class WebhookCallbackTest implements Servlet {
 
     @Test
     public void testWebhook() {
-        List<String> remoteEndpoints = new ArrayList<>();
-        remoteEndpoints.add("http://127.0.0.1:8778/webhook/receiveAlarm");
-        WebhookCallback webhookCallback = new WebhookCallback(remoteEndpoints);
+        WebhookCallback webhookCallback = new WebhookCallback();
         List<AlarmMessage> alarmMessages = new ArrayList<>(2);
         AlarmMessage alarmMessage = new AlarmMessage();
         alarmMessage.setScopeId(DefaultScopeDefine.ALL);

--- a/oap-server/server-alarm-plugin/src/test/resources/alarm-webhooks.yml
+++ b/oap-server/server-alarm-plugin/src/test/resources/alarm-webhooks.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+webhooks:
+  - http://127.0.0.1/notify/
+  - http://127.0.0.1/go-wechat/
+

--- a/oap-server/server-core/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.core.alarm.AlarmCallback
+++ b/oap-server/server-core/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.core.alarm.AlarmCallback
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+org.apache.skywalking.oap.server.core.alarm.AlarmStandardPersistence

--- a/oap-server/server-starter/src/main/resources/alarm-webhooks.yml
+++ b/oap-server/server-starter/src/main/resources/alarm-webhooks.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+webhooks:
+  - http://127.0.0.1/notify/
+  - http://127.0.0.1/go-wechat/
+


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

we have many issues asking how to set alarm notifications to third party systems, but for now we only support web hook, web hook is absolutely useful, but IMHO (as a SkyWalking user), since we already have a server(s) (OAP) running, why bother to set up another http server just for a web hook and proxy the alarm message to third-party systems.

So here I propose refactoring the `AlarmCallback` to SPI, and make the web hook as one of the implementations (also default implementation), and thus we provide possibilities for our users to provide some third-party system implementations, such as Email, Dingtalk, WeChat, Slack or anything else, although they can't be included in the main repo, they can be placed in the SkyAPM org, WDYT? @wu-sheng 