### PR TITLE
Upgrade guava version to support higher JDK version

### DIFF
--- a/apm-dist/release-docs/LICENSE
+++ b/apm-dist/release-docs/LICENSE
@@ -231,7 +231,7 @@ The text of each license is the standard Apache 2.0 license.
     Google: grpc 1.15.1: https://grpc.io/ , Apache 2.0
     Google: gprc-java 1.14.0: https://github.com/grpc/grpc-java, Apache 2.0
     Google: gprc-java 1.15.1: https://github.com/grpc/grpc-java, Apache 2.0
-    Google: guava 20.0: https://github.com/google/guava , Apache 2.0
+    Google: guava 23.1: https://github.com/google/guava , Apache 2.0
     Google: guice 4.1.0: https://github.com/google/guice , Apache 2.0
     Google: gson 2.8.1: https://github.com/google/gson , Apache 2.0
     Google: opencensus-java 0.12.3: https://github.com/census-instrumentation/opencensus-java , Apache 2.0
@@ -275,7 +275,7 @@ The text of each license is the standard Apache 2.0 license.
     netty 5.5.0: https://github.com/netty/netty/blob/4.1/LICENSE.txt, Apache 2.0
     annotations 13.0: http://www.jetbrains.org, Apache 2.0
     compiler 0.9.3: https://github.com/spullara/mustache.java, Apache 2.0
-    error_prone_annotations 2.0.19: https://github.com/google/error-prone, Apache 2.0
+    error_prone_annotations 2.0.18: https://github.com/google/error-prone, Apache 2.0
     hppc 0.7.1: https://github.com/carrotsearch/hppc, Apache 2.0
     instrumentation-api 0.4.3: https://github.com/google/instrumentation-java, Apache 2.0
     jackson-annotations 2.8.0: https://github.com/FasterXML/jackson-annotations, Apache 2.0

--- a/docs/en/setup/backend/backend-ui-setup.md
+++ b/docs/en/setup/backend/backend-ui-setup.md
@@ -9,7 +9,7 @@ server and UI startup.
 1. **Webapp env**, in `webapp` folder. UI frontend jar file is in here and its `webapp.yml` setting file. 
 
 ## Quick start
-Requirement: **JDK8**
+Requirement: **JDK8 to JDK12 are tested**, other versions are not tested and may or may not work.
 
 Before you do quick start, you should know, quick start is to run skywalking backend and UI for preview
 or demonstration. In here, performance and long-term running are not our goals. 

--- a/oap-server/pom.xml
+++ b/oap-server/pom.xml
@@ -222,6 +222,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>

--- a/oap-server/pom.xml
+++ b/oap-server/pom.xml
@@ -48,7 +48,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.version>2.9.0</log4j.version>
-        <guava.version>20.0</guava.version>
+        <guava.version>23.1-jre</guava.version>
         <snakeyaml.version>1.18</snakeyaml.version>
         <gson.version>2.8.1</gson.version>
         <graphql-java-tools.version>5.2.3</graphql-java-tools.version>

--- a/tools/dependencies/known-oap-backend-dependencies.txt
+++ b/tools/dependencies/known-oap-backend-dependencies.txt
@@ -1,5 +1,5 @@
 aggs-matrix-stats-client-6.3.2.jar
-animal-sniffer-annotations-1.17.jar
+animal-sniffer-annotations-1.14.jar
 annotations-13.0.jar
 antlr4-runtime-4.7.1.jar
 aopalliance-1.0.jar
@@ -33,7 +33,7 @@ elasticsearch-rest-client-6.3.2.jar
 elasticsearch-rest-high-level-client-6.3.2.jar
 elasticsearch-secure-sm-6.3.2.jar
 elasticsearch-x-content-6.3.2.jar
-error_prone_annotations-2.2.0.jar
+error_prone_annotations-2.0.18.jar
 etcd4j-2.17.0.jar
 fastjson-1.2.47.jar
 freemarker-2.3.28.jar
@@ -47,7 +47,7 @@ grpc-protobuf-1.15.1.jar
 grpc-protobuf-lite-1.15.1.jar
 grpc-stub-1.15.1.jar
 gson-2.8.1.jar
-guava-20.0.jar
+guava-23.1-jre.jar
 guice-4.1.0.jar
 h2-1.4.196.jar
 HdrHistogram-2.1.9.jar


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

#3540 and #3477 

https://github.com/apache/skywalking/blob/5b039e9747fac98444b4ec423a5d57524202f286/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/annotation/AnnotationScan.java#L54-L56

the `classpath.getTopLevelClassesRecursive("org.apache.skywalking")` returns empty `set` under JDK 8+, and it turns out to be an issue of Guava, see https://github.com/google/guava/issues/3249#issuecomment-416234877 , this patch upgrades the Guava version to 23.1, and I've verified locally the exception disappear and OAP starts successfully