### PR TITLE
update official docker repos, moved to apache org

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
         soft: -1
         hard: -1
   oap:
-    image: skywalking/oap
+    image: apache/skywalking-oap-server
     container_name: oap
     depends_on:
       - elasticsearch
@@ -44,7 +44,7 @@ services:
       SW_STORAGE: elasticsearch
       SW_STORAGE_ES_CLUSTER_NODES: elasticsearch:9200
   ui:
-    image: skywalking/ui
+    image: apache/skywalking-ui
     container_name: ui
     depends_on:
       - oap


### PR DESCRIPTION
- Why submit this pull request?

`docker-compose.yml` refers to no longer existing docker hub repos, as they moved to Apache Docker Hub organization.
Replaced with correct OAP server and UI docker image repo references.
