### PR TITLE
Exclude generated sources from test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,14 +541,15 @@
                         <excludes>
                             <exclude>org/apache/skywalking/**/*Test.class</exclude>
                             <exclude>org/apache/skywalking/**/Test*.class</exclude>
-                            <exclude>org/apache/skywalking/apm/network/register/v2/**/*.java</exclude>
-                            <exclude>org/apache/skywalking/apm/network/common/**/*.java</exclude>
-                            <exclude>org/apache/skywalking/apm/network/servicemesh/**/*.java</exclude>
-                            <exclude>org/apache/skywalking/apm/network/language/**/*.java</exclude>
-                            <exclude>org/apache/skywalking/oap/server/core/remote/grpc/proto/*.java</exclude>
-                            <exclude>org/apache/skywalking/oal/rt/grammar/*.java</exclude>
-                            <exclude>org/apache/skywalking/oap/server/exporter/grpc/*.java</exclude>
-                            <exclude>org/apache/skywalking/oap/server/configuration/service/*.java</exclude>
+                            <exclude>org/apache/skywalking/apm/network/register/v2/**/*.class</exclude>
+                            <exclude>org/apache/skywalking/apm/network/common/**/*.class</exclude>
+                            <exclude>org/apache/skywalking/apm/network/servicemesh/**/*.class</exclude>
+                            <exclude>org/apache/skywalking/apm/network/language/**/*.class</exclude>
+                            <exclude>org/apache/skywalking/oap/server/core/remote/grpc/proto/*.class</exclude>
+                            <exclude>org/apache/skywalking/oal/rt/grammar/*.class</exclude>
+                            <exclude>org/apache/skywalking/oap/server/exporter/grpc/*.class</exclude>
+                            <exclude>org/apache/skywalking/oap/server/configuration/service/*.class</exclude>
+                            <exclude>grpc/health/v1/*.class</exclude>
                         </excludes>
                     </instrumentation>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -541,7 +541,14 @@
                         <excludes>
                             <exclude>org/apache/skywalking/**/*Test.class</exclude>
                             <exclude>org/apache/skywalking/**/Test*.class</exclude>
-                            <exclude>**/generated-sources/**</exclude>
+                            <exclude>org/apache/skywalking/apm/network/register/v2/**/*.java</exclude>
+                            <exclude>org/apache/skywalking/apm/network/common/**/*.java</exclude>
+                            <exclude>org/apache/skywalking/apm/network/servicemesh/**/*.java</exclude>
+                            <exclude>org/apache/skywalking/apm/network/language/**/*.java</exclude>
+                            <exclude>org/apache/skywalking/oap/server/core/remote/grpc/proto/*.java</exclude>
+                            <exclude>org/apache/skywalking/oal/rt/grammar/*.java</exclude>
+                            <exclude>org/apache/skywalking/oap/server/exporter/grpc/*.java</exclude>
+                            <exclude>org/apache/skywalking/oap/server/configuration/service/*.java</exclude>
                         </excludes>
                     </instrumentation>
                 </configuration>


### PR DESCRIPTION
Turns out `**/generated-sources/**` doesn't exclude the generated sources correctly, this patch excludes the same sources as `checkstyle` plugin