### PR TITLE
[test/plugin] rename the package of testcases

### DIFF
--- a/test/plugin/run.sh
+++ b/test/plugin/run.sh
@@ -149,7 +149,7 @@ do
     cp ./config/expectedData.yaml ${case_work_base}/data
 
     # echo "build ${testcase_name}"
-    ${mvnw} clean package -D${testcase_name}
+    ${mvnw} clean package -Dtest.framework.version=${version}
 
     mv ./target/${scenario_name}.war ${case_work_base}
 

--- a/test/plugin/run.sh
+++ b/test/plugin/run.sh
@@ -149,7 +149,7 @@ do
     cp ./config/expectedData.yaml ${case_work_base}/data
 
     # echo "build ${testcase_name}"
-    ${mvnw} clean package -P${testcase_name}
+    ${mvnw} clean package -D${testcase_name}
 
     mv ./target/${scenario_name}.war ${case_work_base}
 

--- a/test/plugin/scenarios/httpclient-4.3.x-scenario/pom.xml
+++ b/test/plugin/scenarios/httpclient-4.3.x-scenario/pom.xml
@@ -30,7 +30,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler.version>1.8</compiler.version>
 
-
         <test.framework>Httpclient</test.framework>
         <test.framework.version>4.3</test.framework.version>
     </properties>
@@ -60,93 +59,6 @@
             <version>${test.framework.version}</version>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.3</id>
-            <properties>
-                <test.framework.version>4.3</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.5.3</id>
-            <properties>
-                <test.framework.version>4.5.3</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.5.4</id>
-            <properties>
-                <test.framework.version>4.5.4</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.5.2</id>
-            <properties>
-                <test.framework.version>4.5.2</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.5.1</id>
-            <properties>
-                <test.framework.version>4.5.1</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.5</id>
-            <properties>
-                <test.framework.version>4.5</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.4.1</id>
-            <properties>
-                <test.framework.version>4.4.1</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.4</id>
-            <properties>
-                <test.framework.version>4.4</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.3.6</id>
-            <properties>
-                <test.framework.version>4.3.6</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.3.5</id>
-            <properties>
-                <test.framework.version>4.3.5</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.3.4</id>
-            <properties>
-                <test.framework.version>4.3.4</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.3.3</id>
-            <properties>
-                <test.framework.version>4.3.3</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.3.2</id>
-            <properties>
-                <test.framework.version>4.3.2</test.framework.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>httpclient-4.3.x-scenario-4.3.1</id>
-            <properties>
-                <test.framework.version>4.3.1</test.framework.version>
-            </properties>
-        </profile>
-    </profiles>
 
     <build>
         <finalName>httpclient-4.3.x-scenario</finalName>

--- a/test/plugin/scenarios/httpclient-4.3.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/httpclient/CaseServlet.java
+++ b/test/plugin/scenarios/httpclient-4.3.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/httpclient/CaseServlet.java
@@ -16,7 +16,7 @@
  *
  */
 
-package test.apache.skywalking.apm.testcase.httpclient;
+package org.apache.skywalking.apm.testcase.httpclient;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -24,18 +24,37 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
-public class ServletForContextPropagate extends HttpServlet {
+public class CaseServlet extends HttpServlet {
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.setContentType("application/json");
-        PrintWriter out = resp.getWriter();
-        out.print("{'test':'test'}");
-        out.flush();
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        HttpGet httpGet = new HttpGet("http://localhost:8080" + req.getContextPath() + "/case/context-propagate");
+        CloseableHttpResponse response1 = httpclient.execute(httpGet);
+        try {
+            HttpEntity entity1 = response1.getEntity();
+            EntityUtils.consume(entity1);
+        } finally {
+            response1.close();
+        }
+
+        PrintWriter printWriter = resp.getWriter();
+        printWriter.write("success");
+        printWriter.flush();
+        printWriter.close();
     }
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         doGet(req, resp);
     }
+
 }

--- a/test/plugin/scenarios/httpclient-4.3.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/httpclient/HealthCheckServlet.java
+++ b/test/plugin/scenarios/httpclient-4.3.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/httpclient/HealthCheckServlet.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package test.apache.skywalking.apm.testcase.httpclient;
+package org.apache.skywalking.apm.testcase.httpclient;
 
 import java.io.IOException;
 import java.io.PrintWriter;

--- a/test/plugin/scenarios/httpclient-4.3.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/httpclient/ServletForContextPropagate.java
+++ b/test/plugin/scenarios/httpclient-4.3.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/httpclient/ServletForContextPropagate.java
@@ -16,7 +16,7 @@
  *
  */
 
-package test.apache.skywalking.apm.testcase.httpclient;
+package org.apache.skywalking.apm.testcase.httpclient;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -24,37 +24,18 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
 
-public class CaseServlet extends HttpServlet {
-
+public class ServletForContextPropagate extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-
-        HttpGet httpGet = new HttpGet("http://localhost:8080" + req.getContextPath() + "/case/context-propagate");
-        CloseableHttpResponse response1 = httpclient.execute(httpGet);
-        try {
-            HttpEntity entity1 = response1.getEntity();
-            EntityUtils.consume(entity1);
-        } finally {
-            response1.close();
-        }
-
-        PrintWriter printWriter = resp.getWriter();
-        printWriter.write("success");
-        printWriter.flush();
-        printWriter.close();
+        resp.setContentType("application/json");
+        PrintWriter out = resp.getWriter();
+        out.print("{'test':'test'}");
+        out.flush();
     }
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         doGet(req, resp);
     }
-
 }

--- a/test/plugin/scenarios/httpclient-4.3.x-scenario/src/main/webapp/WEB-INF/web.xml
+++ b/test/plugin/scenarios/httpclient-4.3.x-scenario/src/main/webapp/WEB-INF/web.xml
@@ -24,12 +24,12 @@
 
     <servlet>
         <servlet-name>caseServlet</servlet-name>
-        <servlet-class>test.apache.skywalking.apm.testcase.httpclient.CaseServlet</servlet-class>
+        <servlet-class>org.apache.skywalking.apm.testcase.httpclient.CaseServlet</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>healthCheck</servlet-name>
-        <servlet-class>test.apache.skywalking.apm.testcase.httpclient.HealthCheckServlet</servlet-class>
+        <servlet-class>org.apache.skywalking.apm.testcase.httpclient.HealthCheckServlet</servlet-class>
     </servlet>
 
     <servlet-mapping>
@@ -44,7 +44,7 @@
 
     <servlet>
         <servlet-name>servletForContextPropagate</servlet-name>
-        <servlet-class>test.apache.skywalking.apm.testcase.httpclient.ServletForContextPropagate</servlet-class>
+        <servlet-class>org.apache.skywalking.apm.testcase.httpclient.ServletForContextPropagate</servlet-class>
     </servlet>
 
     <servlet-mapping>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [x] New feature provided
- [ ] Improve performance

- Related issues
#3584 

We have to use this package name, `org.apache.skywalking.apm.testcase.httpclient`. 
We don't need to type very long code for profile anymore. (This is @mrproliu 's idea. Thanks)