### PR TITLE
[Feature] Support ElasticSearch 7 as storage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "test/e2e/e2e-ttl/e2e-ttl-es/src/main/proto"]
 	path = test/e2e/e2e-ttl/e2e-ttl-es/src/main/proto
 	url = https://github.com/apache/skywalking-data-collect-protocol.git
+[submodule "test/e2e/e2e-ttl/e2e-ttl-es7/src/main/proto"]
+	path = test/e2e/e2e-ttl/e2e-ttl-es7/src/main/proto
+	url = https://github.com/apache/skywalking-data-collect-protocol.git

--- a/Jenkinsfile-E2E
+++ b/Jenkinsfile-E2E
@@ -69,9 +69,15 @@ pipeline {
                             }
                         }
 
-                        stage('Agent Reboot Tests') {
+                        stage('TTL ES6 Tests') {
                             steps {
-                                sh 'bash -x test/e2e/run.sh e2e-agent-reboot'
+                                sh 'bash -x test/e2e/run.sh e2e-ttl/e2e-ttl-es'
+                            }
+                        }
+
+                        stage('Cluster Tests (ES7/ZK)') {
+                            steps {
+                                sh 'bash -x test/e2e/run.sh e2e-cluster/test-runner-es7'
                             }
                         }
                     }
@@ -85,9 +91,15 @@ pipeline {
                             }
                         }
 
-                        stage('TTL ES Tests') {
+                        stage('Agent Reboot Tests') {
                             steps {
-                                sh 'bash -x test/e2e/run.sh e2e-ttl/e2e-ttl-es'
+                                sh 'bash -x test/e2e/run.sh e2e-agent-reboot'
+                            }
+                        }
+
+                        stage('TTL ES7 Tests') {
+                            steps {
+                                sh 'bash -x test/e2e/run.sh e2e-ttl/e2e-ttl-es7'
                             }
                         }
                     }

--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
@@ -18,381 +18,81 @@
 
 package org.apache.skywalking.oap.server.library.client.elasticsearch;
 
-import com.google.common.base.Splitter;
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import javax.net.ssl.SSLContext;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpStatus;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.entity.ContentType;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.nio.entity.NStringEntity;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.apache.http.ssl.SSLContexts;
+
+import com.google.gson.JsonObject;
 import org.apache.skywalking.oap.server.library.client.Client;
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
-import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.ActiveShardCount;
-import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
+ * This class defines some methods that are needed for a storage plugin
+ * to communicate with ElasticSearch
+ *
  * @author peng-yongsheng
+ * @author kezhenxu94
  */
-public class ElasticSearchClient implements Client {
+public interface ElasticSearchClient extends Client {
 
-    private static final Logger logger = LoggerFactory.getLogger(ElasticSearchClient.class);
+    boolean createIndex(String indexName) throws IOException;
 
-    public static final String TYPE = "type";
-    private final String clusterNodes;
-    private final String protocol;
-    private final String trustStorePath;
-    private final String trustStorePass;
-    private final String namespace;
-    private final String user;
-    private final String password;
-    protected RestHighLevelClient client;
+    boolean createIndex(String indexName, JsonObject settings, JsonObject mapping) throws IOException;
 
-    public ElasticSearchClient(String clusterNodes, String protocol, String trustStorePath, String trustStorePass,
-        String namespace, String user, String password) {
-        this.clusterNodes = clusterNodes;
-        this.protocol = protocol;
-        this.namespace = namespace;
-        this.user = user;
-        this.password = password;
-        this.trustStorePath = trustStorePath;
-        this.trustStorePass = trustStorePass;
-    }
-
-    @Override
-    public void connect() throws IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException, CertificateException {
-        List<HttpHost> pairsList = parseClusterNodes(clusterNodes);
-        RestClientBuilder builder;
-        if (StringUtils.isNotBlank(user) && StringUtils.isNotBlank(password)) {
-            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, password));
-
-            if (StringUtils.isBlank(trustStorePath)) {
-                builder = RestClient.builder(pairsList.toArray(new HttpHost[0]))
-                    .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
-            } else {
-                KeyStore truststore = KeyStore.getInstance("jks");
-                try (InputStream is = Files.newInputStream(Paths.get(trustStorePath))) {
-                    truststore.load(is, trustStorePass.toCharArray());
-                }
-                SSLContextBuilder sslBuilder = SSLContexts.custom()
-                    .loadTrustMaterial(truststore, null);
-                final SSLContext sslContext = sslBuilder.build();
-                builder = RestClient.builder(pairsList.toArray(new HttpHost[0]))
-                    .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider).setSSLContext(sslContext));
-            }
-        } else {
-            builder = RestClient.builder(pairsList.toArray(new HttpHost[0]));
-        }
-
-        client = new RestHighLevelClient(builder);
-        client.ping();
-    }
-
-    @Override public void shutdown() throws IOException {
-        client.close();
-    }
-
-    private List<HttpHost> parseClusterNodes(String nodes) {
-        List<HttpHost> httpHosts = new LinkedList<>();
-        logger.info("elasticsearch cluster nodes: {}", nodes);
-        List<String> nodesSplit = Splitter.on(",").omitEmptyStrings().splitToList(nodes);
-
-        for (String node : nodesSplit) {
-            String host = node.split(":")[0];
-            String port = node.split(":")[1];
-            httpHosts.add(new HttpHost(host, Integer.parseInt(port), protocol));
-        }
-
-        return httpHosts;
-    }
-
-    public boolean createIndex(String indexName) throws IOException {
-        indexName = formatIndexName(indexName);
-
-        CreateIndexRequest request = new CreateIndexRequest(indexName);
-        CreateIndexResponse response = client.indices().create(request);
-        logger.debug("create {} index finished, isAcknowledged: {}", indexName, response.isAcknowledged());
-        return response.isAcknowledged();
-    }
-
-    public boolean createIndex(String indexName, JsonObject settings, JsonObject mapping) throws IOException {
-        indexName = formatIndexName(indexName);
-        CreateIndexRequest request = new CreateIndexRequest(indexName);
-        request.settings(settings.toString(), XContentType.JSON);
-        request.mapping(TYPE, mapping.toString(), XContentType.JSON);
-        CreateIndexResponse response = client.indices().create(request);
-        logger.debug("create {} index finished, isAcknowledged: {}", indexName, response.isAcknowledged());
-        return response.isAcknowledged();
-    }
-
-    public List<String> retrievalIndexByAliases(String aliases) throws IOException {
-        aliases = formatIndexName(aliases);
-        Response response = client.getLowLevelClient().performRequest(HttpGet.METHOD_NAME, "/_alias/" + aliases);
-        if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
-            Gson gson = new Gson();
-            InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
-            JsonObject responseJson = gson.fromJson(reader, JsonObject.class);
-            logger.debug("retrieval indexes by aliases {}, response is {}", aliases, responseJson);
-            return new ArrayList<>(responseJson.keySet());
-        }
-        return Collections.emptyList();
-    }
+    List<String> retrievalIndexByAliases(String aliases) throws IOException;
 
     /**
      * If your indexName is retrieved from elasticsearch through {@link #retrievalIndexByAliases(String)} or some other
      * method and it already contains namespace. Then you should delete the index by this method, this method will no
      * longer concatenate namespace.
-     * <p>
+     *
      * https://github.com/apache/skywalking/pull/3017
      */
-    public boolean deleteByIndexName(String indexName) throws IOException {
-        return deleteIndex(indexName, false);
-    }
+    boolean deleteByIndexName(String indexName) throws IOException;
 
     /**
      * If your indexName is obtained from metadata or configuration and without namespace. Then you should delete the
      * index by this method, this method automatically concatenates namespace.
-     * <p>
+     *
      * https://github.com/apache/skywalking/pull/3017
      */
-    public boolean deleteByModelName(String modelName) throws IOException {
-        return deleteIndex(modelName, true);
-    }
+    boolean deleteByModelName(String modelName) throws IOException;
 
-    private boolean deleteIndex(String indexName, boolean formatIndexName) throws IOException {
-        if (formatIndexName) {
-            indexName = formatIndexName(indexName);
-        }
-        DeleteIndexRequest request = new DeleteIndexRequest(indexName);
-        DeleteIndexResponse response;
-        response = client.indices().delete(request);
-        logger.debug("delete {} index finished, isAcknowledged: {}", indexName, response.isAcknowledged());
-        return response.isAcknowledged();
-    }
+    boolean isExistsIndex(String indexName) throws IOException;
 
-    public boolean isExistsIndex(String indexName) throws IOException {
-        indexName = formatIndexName(indexName);
-        GetIndexRequest request = new GetIndexRequest();
-        request.indices(indexName);
-        return client.indices().exists(request);
-    }
+    boolean isExistsTemplate(String indexName) throws IOException;
 
-    public boolean isExistsTemplate(String indexName) throws IOException {
-        indexName = formatIndexName(indexName);
+    boolean createTemplate(String indexName, JsonObject settings, JsonObject mapping) throws IOException;
 
-        Response response = client.getLowLevelClient().performRequest(HttpHead.METHOD_NAME, "/_template/" + indexName);
+    boolean deleteTemplate(String indexName) throws IOException;
 
-        int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode == HttpStatus.SC_OK) {
-            return true;
-        } else if (statusCode == HttpStatus.SC_NOT_FOUND) {
-            return false;
-        } else {
-            throw new IOException("The response status code of template exists request should be 200 or 404, but it is " + statusCode);
-        }
-    }
+    SearchResponse search(String indexName, SearchSourceBuilder searchSourceBuilder) throws IOException;
 
-    public boolean createTemplate(String indexName, JsonObject settings, JsonObject mapping) throws IOException {
-        indexName = formatIndexName(indexName);
+    GetResponse get(String indexName, String id) throws IOException;
 
-        JsonArray patterns = new JsonArray();
-        patterns.add(indexName + "-*");
+    SearchResponse ids(String indexName, String[] ids) throws IOException;
 
-        JsonObject aliases = new JsonObject();
-        aliases.add(indexName, new JsonObject());
+    void forceInsert(String indexName, String id, XContentBuilder source) throws IOException;
 
-        JsonObject template = new JsonObject();
-        template.add("index_patterns", patterns);
-        template.add("aliases", aliases);
-        template.add("settings", settings);
-        template.add("mappings", mapping);
+    void forceUpdate(String indexName, String id, XContentBuilder source, long version) throws IOException;
 
-        HttpEntity entity = new NStringEntity(template.toString(), ContentType.APPLICATION_JSON);
+    void forceUpdate(String indexName, String id, JsonObject source, long seqNumber, long primaryTerm) throws IOException;
 
-        Response response = client.getLowLevelClient().performRequest(HttpPut.METHOD_NAME, "/_template/" + indexName, Collections.emptyMap(), entity);
-        return response.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
-    }
+    void forceUpdate(String indexName, String id, XContentBuilder source) throws IOException;
 
-    public boolean deleteTemplate(String indexName) throws IOException {
-        indexName = formatIndexName(indexName);
+    ElasticSearchInsertRequest prepareInsert(String indexName, String id, XContentBuilder source);
 
-        Response response = client.getLowLevelClient().performRequest(HttpDelete.METHOD_NAME, "/_template/" + indexName);
-        return response.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
-    }
+    ElasticSearchUpdateRequest prepareUpdate(String indexName, String id, XContentBuilder source);
 
-    public SearchResponse search(String indexName, SearchSourceBuilder searchSourceBuilder) throws IOException {
-        indexName = formatIndexName(indexName);
-        SearchRequest searchRequest = new SearchRequest(indexName);
-        searchRequest.types(TYPE);
-        searchRequest.source(searchSourceBuilder);
-        return client.search(searchRequest);
-    }
+    int delete(String indexName, String timeBucketColumnName, long endTimeBucket) throws IOException;
 
-    public GetResponse get(String indexName, String id) throws IOException {
-        indexName = formatIndexName(indexName);
-        GetRequest request = new GetRequest(indexName, TYPE, id);
-        return client.get(request);
-    }
+    void synchronousBulk(BulkRequest request);
 
-    public SearchResponse ids(String indexName, String[] ids) throws IOException {
-        indexName = formatIndexName(indexName);
+    BulkProcessor createBulkProcessor(int bulkActions, int flushInterval, int concurrentRequests);
 
-        SearchRequest searchRequest = new SearchRequest(indexName);
-        searchRequest.types(TYPE);
-        searchRequest.source().query(QueryBuilders.idsQuery().addIds(ids)).size(ids.length);
-        return client.search(searchRequest);
-    }
-
-    public void forceInsert(String indexName, String id, XContentBuilder source) throws IOException {
-        IndexRequest request = prepareInsert(indexName, id, source);
-        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        client.index(request);
-    }
-
-    public void forceUpdate(String indexName, String id, XContentBuilder source, long version) throws IOException {
-        UpdateRequest request = prepareUpdate(indexName, id, source);
-        request.version(version);
-        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        client.update(request);
-    }
-
-    public void forceUpdate(String indexName, String id, XContentBuilder source) throws IOException {
-        UpdateRequest request = prepareUpdate(indexName, id, source);
-        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        client.update(request);
-    }
-
-    public ElasticSearchInsertRequest prepareInsert(String indexName, String id, XContentBuilder source) {
-        indexName = formatIndexName(indexName);
-        return new ElasticSearchInsertRequest(indexName, TYPE, id).source(source);
-    }
-
-    public ElasticSearchUpdateRequest prepareUpdate(String indexName, String id, XContentBuilder source) {
-        indexName = formatIndexName(indexName);
-        return new ElasticSearchUpdateRequest(indexName, TYPE, id).doc(source);
-    }
-
-    public int delete(String indexName, String timeBucketColumnName, long endTimeBucket) throws IOException {
-        indexName = formatIndexName(indexName);
-        Map<String, String> params = Collections.singletonMap("conflicts", "proceed");
-        String jsonString = "{" +
-            "  \"query\": {" +
-            "    \"range\": {" +
-            "      \"" + timeBucketColumnName + "\": {" +
-            "        \"lte\": " + endTimeBucket +
-            "      }" +
-            "    }" +
-            "  }" +
-            "}";
-        HttpEntity entity = new NStringEntity(jsonString, ContentType.APPLICATION_JSON);
-        Response response = client.getLowLevelClient().performRequest(HttpPost.METHOD_NAME, "/" + indexName + "/_delete_by_query", params, entity);
-        logger.debug("delete indexName: {}, jsonString : {}", indexName, jsonString);
-        return response.getStatusLine().getStatusCode();
-    }
-
-    public void synchronousBulk(BulkRequest request) {
-        request.timeout(TimeValue.timeValueMinutes(2));
-        request.setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
-        request.waitForActiveShards(ActiveShardCount.ONE);
-        try {
-            int size = request.requests().size();
-            BulkResponse responses = client.bulk(request);
-            logger.info("Synchronous bulk took time: {} millis, size: {}", responses.getTook().getMillis(), size);
-        } catch (IOException e) {
-            logger.error(e.getMessage(), e);
-        }
-    }
-
-    public BulkProcessor createBulkProcessor(int bulkActions, int flushInterval, int concurrentRequests) {
-        BulkProcessor.Listener listener = new BulkProcessor.Listener() {
-            @Override
-            public void beforeBulk(long executionId, BulkRequest request) {
-                int numberOfActions = request.numberOfActions();
-                logger.debug("Executing bulk [{}] with {} requests", executionId, numberOfActions);
-            }
-
-            @Override
-            public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
-                if (response.hasFailures()) {
-                    logger.warn("Bulk [{}] executed with failures", executionId);
-                } else {
-                    logger.info("Bulk execution id [{}] completed in {} milliseconds, size: {}", executionId, response.getTook().getMillis(), request.requests().size());
-                }
-            }
-
-            @Override
-            public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
-                logger.error("Failed to execute bulk", failure);
-            }
-        };
-
-        return BulkProcessor.builder(client::bulkAsync, listener)
-            .setBulkActions(bulkActions)
-            .setFlushInterval(TimeValue.timeValueSeconds(flushInterval))
-            .setConcurrentRequests(concurrentRequests)
-            .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), 3))
-            .build();
-    }
-
-    public String formatIndexName(String indexName) {
-        if (StringUtils.isNotEmpty(namespace)) {
-            return namespace + "_" + indexName;
-        }
-        return indexName;
-    }
+    String formatIndexName(String indexName);
 }

--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/client/impl/v6/ElasticSearch6Client.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/client/impl/v6/ElasticSearch6Client.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v6;
+
+import com.google.common.base.Splitter;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import javax.net.ssl.SSLContext;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.nio.entity.NStringEntity;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.skywalking.oap.server.library.client.Client;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchInsertRequest;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchUpdateRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author peng-yongsheng
+ */
+public class ElasticSearch6Client implements ElasticSearchClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(ElasticSearch6Client.class);
+
+    public static final String TYPE = "type";
+    private final String clusterNodes;
+    private final String protocol;
+    private final String trustStorePath;
+    private final String trustStorePass;
+    private final String namespace;
+    private final String user;
+    private final String password;
+    protected RestHighLevelClient client;
+
+    public ElasticSearch6Client(String clusterNodes, String protocol, String trustStorePath, String trustStorePass,
+                                String namespace, String user, String password) {
+        this.clusterNodes = clusterNodes;
+        this.protocol = protocol;
+        this.namespace = namespace;
+        this.user = user;
+        this.password = password;
+        this.trustStorePath = trustStorePath;
+        this.trustStorePass = trustStorePass;
+    }
+
+    @Override
+    public void connect() throws IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException, CertificateException {
+        List<HttpHost> pairsList = parseClusterNodes(clusterNodes);
+        RestClientBuilder builder;
+        if (StringUtils.isNotBlank(user) && StringUtils.isNotBlank(password)) {
+            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, password));
+
+            if (StringUtils.isBlank(trustStorePath)) {
+                builder = RestClient.builder(pairsList.toArray(new HttpHost[0]))
+                    .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+            } else {
+                KeyStore truststore = KeyStore.getInstance("jks");
+                try (InputStream is = Files.newInputStream(Paths.get(trustStorePath))) {
+                    truststore.load(is, trustStorePass.toCharArray());
+                }
+                SSLContextBuilder sslBuilder = SSLContexts.custom()
+                    .loadTrustMaterial(truststore, null);
+                final SSLContext sslContext = sslBuilder.build();
+                builder = RestClient.builder(pairsList.toArray(new HttpHost[0]))
+                    .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider).setSSLContext(sslContext));
+            }
+        } else {
+            builder = RestClient.builder(pairsList.toArray(new HttpHost[0]));
+        }
+
+        client = new RestHighLevelClient(builder);
+        client.ping();
+    }
+
+    @Override public void shutdown() throws IOException {
+        client.close();
+    }
+
+    private List<HttpHost> parseClusterNodes(String nodes) {
+        List<HttpHost> httpHosts = new LinkedList<>();
+        logger.info("elasticsearch cluster nodes: {}", nodes);
+        List<String> nodesSplit = Splitter.on(",").omitEmptyStrings().splitToList(nodes);
+
+        for (String node : nodesSplit) {
+            String host = node.split(":")[0];
+            String port = node.split(":")[1];
+            httpHosts.add(new HttpHost(host, Integer.parseInt(port), protocol));
+        }
+
+        return httpHosts;
+    }
+
+    @Override
+    public boolean createIndex(String indexName) throws IOException {
+        indexName = formatIndexName(indexName);
+
+        CreateIndexRequest request = new CreateIndexRequest(indexName);
+        CreateIndexResponse response = client.indices().create(request);
+        logger.debug("create {} index finished, isAcknowledged: {}", indexName, response.isAcknowledged());
+        return response.isAcknowledged();
+    }
+
+    @Override
+    public boolean createIndex(String indexName, JsonObject settings, JsonObject mapping) throws IOException {
+        indexName = formatIndexName(indexName);
+        CreateIndexRequest request = new CreateIndexRequest(indexName);
+        request.settings(settings.toString(), XContentType.JSON);
+        request.mapping(TYPE, mapping.toString(), XContentType.JSON);
+        CreateIndexResponse response = client.indices().create(request);
+        logger.debug("create {} index finished, isAcknowledged: {}", indexName, response.isAcknowledged());
+        return response.isAcknowledged();
+    }
+
+    @Override
+    public List<String> retrievalIndexByAliases(String aliases) throws IOException {
+        aliases = formatIndexName(aliases);
+        Response response = client.getLowLevelClient().performRequest(HttpGet.METHOD_NAME, "/_alias/" + aliases);
+        if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
+            Gson gson = new Gson();
+            InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
+            JsonObject responseJson = gson.fromJson(reader, JsonObject.class);
+            logger.debug("retrieval indexes by aliases {}, response is {}", aliases, responseJson);
+            return new ArrayList<>(responseJson.keySet());
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * If your indexName is retrieved from elasticsearch through {@link #retrievalIndexByAliases(String)} or some other
+     * method and it already contains namespace. Then you should delete the index by this method, this method will no
+     * longer concatenate namespace.
+     * <p>
+     * https://github.com/apache/skywalking/pull/3017
+     */
+    @Override
+    public boolean deleteByIndexName(String indexName) throws IOException {
+        return deleteIndex(indexName, false);
+    }
+
+    /**
+     * If your indexName is obtained from metadata or configuration and without namespace. Then you should delete the
+     * index by this method, this method automatically concatenates namespace.
+     * <p>
+     * https://github.com/apache/skywalking/pull/3017
+     */
+    @Override
+    public boolean deleteByModelName(String modelName) throws IOException {
+        return deleteIndex(modelName, true);
+    }
+
+    private boolean deleteIndex(String indexName, boolean formatIndexName) throws IOException {
+        if (formatIndexName) {
+            indexName = formatIndexName(indexName);
+        }
+        DeleteIndexRequest request = new DeleteIndexRequest(indexName);
+        DeleteIndexResponse response;
+        response = client.indices().delete(request);
+        logger.debug("delete {} index finished, isAcknowledged: {}", indexName, response.isAcknowledged());
+        return response.isAcknowledged();
+    }
+
+    @Override
+    public boolean isExistsIndex(String indexName) throws IOException {
+        indexName = formatIndexName(indexName);
+        GetIndexRequest request = new GetIndexRequest();
+        request.indices(indexName);
+        return client.indices().exists(request);
+    }
+
+    @Override
+    public boolean isExistsTemplate(String indexName) throws IOException {
+        indexName = formatIndexName(indexName);
+
+        Response response = client.getLowLevelClient().performRequest(HttpHead.METHOD_NAME, "/_template/" + indexName);
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        if (statusCode == HttpStatus.SC_OK) {
+            return true;
+        } else if (statusCode == HttpStatus.SC_NOT_FOUND) {
+            return false;
+        } else {
+            throw new IOException("The response status code of template exists request should be 200 or 404, but it is " + statusCode);
+        }
+    }
+
+    @Override
+    public boolean createTemplate(String indexName, JsonObject settings, JsonObject mapping) throws IOException {
+        indexName = formatIndexName(indexName);
+
+        JsonArray patterns = new JsonArray();
+        patterns.add(indexName + "-*");
+
+        JsonObject aliases = new JsonObject();
+        aliases.add(indexName, new JsonObject());
+
+        JsonObject template = new JsonObject();
+        template.add("index_patterns", patterns);
+        template.add("aliases", aliases);
+        template.add("settings", settings);
+        template.add("mappings", mapping);
+
+        HttpEntity entity = new NStringEntity(template.toString(), ContentType.APPLICATION_JSON);
+
+        Response response = client.getLowLevelClient().performRequest(HttpPut.METHOD_NAME, "/_template/" + indexName, Collections.emptyMap(), entity);
+        return response.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
+    }
+
+    @Override
+    public boolean deleteTemplate(String indexName) throws IOException {
+        indexName = formatIndexName(indexName);
+
+        Response response = client.getLowLevelClient().performRequest(HttpDelete.METHOD_NAME, "/_template/" + indexName);
+        return response.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
+    }
+
+    @Override
+    public SearchResponse search(String indexName, SearchSourceBuilder searchSourceBuilder) throws IOException {
+        indexName = formatIndexName(indexName);
+        SearchRequest searchRequest = new SearchRequest(indexName);
+        searchRequest.types(TYPE);
+        searchRequest.source(searchSourceBuilder);
+        return client.search(searchRequest);
+    }
+
+    @Override
+    public GetResponse get(String indexName, String id) throws IOException {
+        indexName = formatIndexName(indexName);
+        GetRequest request = new GetRequest(indexName, TYPE, id);
+        return client.get(request);
+    }
+
+    @Override
+    public SearchResponse ids(String indexName, String[] ids) throws IOException {
+        indexName = formatIndexName(indexName);
+
+        SearchRequest searchRequest = new SearchRequest(indexName);
+        searchRequest.types(TYPE);
+        searchRequest.source().query(QueryBuilders.idsQuery().addIds(ids)).size(ids.length);
+        return client.search(searchRequest);
+    }
+
+    @Override
+    public void forceInsert(String indexName, String id, XContentBuilder source) throws IOException {
+        IndexRequest request = prepareInsert(indexName, id, source);
+        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client.index(request);
+    }
+
+    @Override
+    public void forceUpdate(String indexName, String id, XContentBuilder source, long version) throws IOException {
+        UpdateRequest request = prepareUpdate(indexName, id, source);
+        request.version(version);
+        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client.update(request);
+    }
+
+    @Override
+    public void forceUpdate(String indexName, String id, JsonObject source, long seqNumber, long primaryTerm) throws IOException {
+        throw new UnsupportedOperationException("ElasticSearch 6 doesn't support if_seq_no and if_primary_term");
+    }
+
+    @Override
+    public void forceUpdate(String indexName, String id, XContentBuilder source) throws IOException {
+        UpdateRequest request = prepareUpdate(indexName, id, source);
+        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client.update(request);
+    }
+
+    @Override
+    public ElasticSearchInsertRequest prepareInsert(String indexName, String id, XContentBuilder source) {
+        indexName = formatIndexName(indexName);
+        return new ElasticSearchInsertRequest(indexName, TYPE, id).source(source);
+    }
+
+    @Override
+    public ElasticSearchUpdateRequest prepareUpdate(String indexName, String id, XContentBuilder source) {
+        indexName = formatIndexName(indexName);
+        return new ElasticSearchUpdateRequest(indexName, TYPE, id).doc(source);
+    }
+
+    @Override
+    public int delete(String indexName, String timeBucketColumnName, long endTimeBucket) throws IOException {
+        indexName = formatIndexName(indexName);
+        Map<String, String> params = Collections.singletonMap("conflicts", "proceed");
+        String jsonString = "{" +
+            "  \"query\": {" +
+            "    \"range\": {" +
+            "      \"" + timeBucketColumnName + "\": {" +
+            "        \"lte\": " + endTimeBucket +
+            "      }" +
+            "    }" +
+            "  }" +
+            "}";
+        HttpEntity entity = new NStringEntity(jsonString, ContentType.APPLICATION_JSON);
+        Response response = client.getLowLevelClient().performRequest(HttpPost.METHOD_NAME, "/" + indexName + "/_delete_by_query", params, entity);
+        logger.debug("delete indexName: {}, jsonString : {}", indexName, jsonString);
+        return response.getStatusLine().getStatusCode();
+    }
+
+    @Override
+    public void synchronousBulk(BulkRequest request) {
+        request.timeout(TimeValue.timeValueMinutes(2));
+        request.setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+        request.waitForActiveShards(ActiveShardCount.ONE);
+        try {
+            int size = request.requests().size();
+            BulkResponse responses = client.bulk(request);
+            logger.info("Synchronous bulk took time: {} millis, size: {}", responses.getTook().getMillis(), size);
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public BulkProcessor createBulkProcessor(int bulkActions, int flushInterval, int concurrentRequests) {
+        BulkProcessor.Listener listener = new BulkProcessor.Listener() {
+            @Override
+            public void beforeBulk(long executionId, BulkRequest request) {
+                int numberOfActions = request.numberOfActions();
+                logger.debug("Executing bulk [{}] with {} requests", executionId, numberOfActions);
+            }
+
+            @Override
+            public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+                if (response.hasFailures()) {
+                    logger.warn("Bulk [{}] executed with failures", executionId);
+                } else {
+                    logger.info("Bulk execution id [{}] completed in {} milliseconds, size: {}", executionId, response.getTook().getMillis(), request.requests().size());
+                }
+            }
+
+            @Override
+            public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
+                logger.error("Failed to execute bulk", failure);
+            }
+        };
+
+        return BulkProcessor.builder(client::bulkAsync, listener)
+            .setBulkActions(bulkActions)
+            .setFlushInterval(TimeValue.timeValueSeconds(flushInterval))
+            .setConcurrentRequests(concurrentRequests)
+            .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), 3))
+            .build();
+    }
+
+    @Override
+    public String formatIndexName(String indexName) {
+        if (StringUtils.isNotEmpty(namespace)) {
+            return namespace + "_" + indexName;
+        }
+        return indexName;
+    }
+}

--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/client/impl/v6/ElasticSearch6Client.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/client/impl/v6/ElasticSearch6Client.java
@@ -55,7 +55,6 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.nio.entity.NStringEntity;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
-import org.apache.skywalking.oap.server.library.client.Client;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchInsertRequest;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchUpdateRequest;

--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/client/impl/v7/ElasticSearch7Client.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/client/impl/v7/ElasticSearch7Client.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v7;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ContentType;
+import org.apache.http.nio.entity.NStringEntity;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchInsertRequest;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchUpdateRequest;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v6.ElasticSearch6Client;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+/**
+ * An ElasticSearch 7 client that uses ElasticSearch 6 client to adapt the requests.
+ *
+ * @author kezhenxu94
+ */
+@Slf4j
+public class ElasticSearch7Client extends ElasticSearch6Client {
+    private static final String DOC = "_doc";
+    private static final String UPDATE = "_update";
+    public static final String IF_SEQ_NO = "if_seq_no";
+    public static final String SEQ_NO = "_seq_no";
+    public static final String IF_PRIMARY_TERM = "if_primary_term";
+    public static final String PRIMARY_TERM = "_primary_term";
+
+    public ElasticSearch7Client(String clusterNodes, String protocol,
+                                String trustStorePath, String trustStorePass,
+                                String namespace, String user, String password) {
+        super(clusterNodes, protocol, trustStorePath, trustStorePass, namespace, user, password);
+    }
+
+    @Override
+    public boolean createIndex(String indexName, JsonObject settings, JsonObject mapping) throws IOException {
+        indexName = formatIndexName(indexName);
+        CreateIndexRequest request = new CreateIndexRequest(indexName);
+        request.settings(settings.toString(), XContentType.JSON);
+        request.mapping("properties", mapping.getAsJsonObject("properties").toString(), XContentType.JSON);
+        CreateIndexResponse response = client.indices().create(request);
+        log.debug("create {} index finished, isAcknowledged: {}", indexName, response.isAcknowledged());
+        return response.isAcknowledged();
+    }
+
+    @Override
+    public SearchResponse search(String indexName, SearchSourceBuilder searchSourceBuilder) throws IOException {
+        indexName = formatIndexName(indexName);
+        SearchRequest searchRequest = new SearchRequest(indexName);
+        searchRequest.source(searchSourceBuilder);
+        return client.search(searchRequest);
+    }
+
+    @Override
+    public GetResponse get(String indexName, String id) throws IOException {
+        indexName = formatIndexName(indexName);
+        GetRequest request = new GetRequest(indexName, DOC, id);
+        return client.get(request);
+    }
+
+    @Override
+    public SearchResponse ids(String indexName, String[] ids) throws IOException {
+        indexName = formatIndexName(indexName);
+
+        SearchRequest searchRequest = new SearchRequest(indexName);
+        searchRequest.source().query(QueryBuilders.idsQuery().addIds(ids)).size(ids.length);
+        return client.search(searchRequest);
+    }
+
+    @Override
+    public void forceUpdate(String indexName, String id, JsonObject source, long seqNumber, long primaryTerm) throws IOException {
+        Map<String, String> params = new HashMap<>();
+        params.put(IF_SEQ_NO, String.valueOf(seqNumber));
+        params.put(IF_PRIMARY_TERM, String.valueOf(primaryTerm));
+        HttpEntity entity = new NStringEntity(source.toString(), ContentType.APPLICATION_JSON);
+        Response response = client.getLowLevelClient().performRequest(HttpPut.METHOD_NAME, "/" + indexName + "/" + DOC + "/" + id, params, entity);
+        if (HttpStatus.SC_OK != response.getStatusLine().getStatusCode()) {
+            log.error("Failed to update doc in ElasticSearch: {}", response);
+            throw new RuntimeException("Failed to update doc in ElasticSearch");
+        }
+    }
+
+    @Override
+    public ElasticSearchInsertRequest prepareInsert(String indexName, String id, XContentBuilder source) {
+        indexName = formatIndexName(indexName);
+        return new ElasticSearchInsertRequest(indexName, DOC, id).source(source);
+    }
+
+    @Override
+    public ElasticSearchUpdateRequest prepareUpdate(String indexName, String id, XContentBuilder source) {
+        indexName = formatIndexName(indexName);
+        return new ElasticSearchUpdateRequest(indexName, DOC, id).doc(source);
+    }
+
+}

--- a/oap-server/server-library/library-client/src/test/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ITElasticSearchClient.java
+++ b/oap-server/server-library/library-client/src/test/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ITElasticSearchClient.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v6.ElasticSearch6Client;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.get.GetResponse;
@@ -70,7 +71,7 @@ public class ITElasticSearchClient {
     public void before() throws Exception {
         final String esAddress = System.getProperty("elastic.search.address");
         final String esProtocol = System.getProperty("elastic.search.protocol");
-        client = new ElasticSearchClient(esAddress, esProtocol, "", "", namespace, "test", "test");
+        client = new ElasticSearch6Client(esAddress, esProtocol, "", "", namespace, "test", "test");
         client.connect();
     }
 

--- a/oap-server/server-starter/src/main/assembly/application.yml
+++ b/oap-server/server-starter/src/main/assembly/application.yml
@@ -93,6 +93,26 @@ storage:
 #    concurrentRequests: ${SW_STORAGE_ES_CONCURRENT_REQUESTS:2} # the number of concurrent requests
 #    metadataQueryMaxSize: ${SW_STORAGE_ES_QUERY_MAX_SIZE:5000}
 #    segmentQueryMaxSize: ${SW_STORAGE_ES_QUERY_SEGMENT_SIZE:200}
+#  elasticsearch7:
+#    nameSpace: ${SW_NAMESPACE:""}
+#    clusterNodes: ${SW_STORAGE_ES_CLUSTER_NODES:localhost:9200}
+#    protocol: ${SW_STORAGE_ES_HTTP_PROTOCOL:"http"}
+#    #trustStorePath: ${SW_SW_STORAGE_ES_SSL_JKS_PATH:"../es_keystore.jks"}
+#    #trustStorePass: ${SW_SW_STORAGE_ES_SSL_JKS_PASS:""}
+#    user: ${SW_ES_USER:""}
+#    password: ${SW_ES_PASSWORD:""}
+#    indexShardsNumber: ${SW_STORAGE_ES_INDEX_SHARDS_NUMBER:2}
+#    indexReplicasNumber: ${SW_STORAGE_ES_INDEX_REPLICAS_NUMBER:0}
+#    # Those data TTL settings will override the same settings in core module.
+#    recordDataTTL: ${SW_STORAGE_ES_RECORD_DATA_TTL:7} # Unit is day
+#    otherMetricsDataTTL: ${SW_STORAGE_ES_OTHER_METRIC_DATA_TTL:45} # Unit is day
+#    monthMetricsDataTTL: ${SW_STORAGE_ES_MONTH_METRIC_DATA_TTL:18} # Unit is month
+#    # Batch process setting, refer to https://www.elastic.co/guide/en/elasticsearch/client/java-api/5.5/java-docs-bulk-processor.html
+#    bulkActions: ${SW_STORAGE_ES_BULK_ACTIONS:1000} # Execute the bulk every 1000 requests
+#    flushInterval: ${SW_STORAGE_ES_FLUSH_INTERVAL:10} # flush the bulk every 10 seconds whatever the number of requests
+#    concurrentRequests: ${SW_STORAGE_ES_CONCURRENT_REQUESTS:2} # the number of concurrent requests
+#    metadataQueryMaxSize: ${SW_STORAGE_ES_QUERY_MAX_SIZE:5000}
+#    segmentQueryMaxSize: ${SW_STORAGE_ES_QUERY_SEGMENT_SIZE:200}
   h2:
     driver: ${SW_STORAGE_H2_DRIVER:org.h2.jdbcx.JdbcDataSource}
     url: ${SW_STORAGE_H2_URL:jdbc:h2:mem:skywalking-oap-db}

--- a/oap-server/server-starter/src/main/resources/application.yml
+++ b/oap-server/server-starter/src/main/resources/application.yml
@@ -92,6 +92,26 @@ storage:
     concurrentRequests: ${SW_STORAGE_ES_CONCURRENT_REQUESTS:2} # the number of concurrent requests
     metadataQueryMaxSize: ${SW_STORAGE_ES_QUERY_MAX_SIZE:5000}
     segmentQueryMaxSize: ${SW_STORAGE_ES_QUERY_SEGMENT_SIZE:200}
+#  elasticsearch7:
+#    nameSpace: ${SW_NAMESPACE:""}
+#    clusterNodes: ${SW_STORAGE_ES_CLUSTER_NODES:localhost:9200}
+#    protocol: ${SW_STORAGE_ES_HTTP_PROTOCOL:"http"}
+#    #trustStorePath: ${SW_SW_STORAGE_ES_SSL_JKS_PATH:"../es_keystore.jks"}
+#    #trustStorePass: ${SW_SW_STORAGE_ES_SSL_JKS_PASS:""}
+#    user: ${SW_ES_USER:""}
+#    password: ${SW_ES_PASSWORD:""}
+#    indexShardsNumber: ${SW_STORAGE_ES_INDEX_SHARDS_NUMBER:2}
+#    indexReplicasNumber: ${SW_STORAGE_ES_INDEX_REPLICAS_NUMBER:0}
+#    # Those data TTL settings will override the same settings in core module.
+#    recordDataTTL: ${SW_STORAGE_ES_RECORD_DATA_TTL:7} # Unit is day
+#    otherMetricsDataTTL: ${SW_STORAGE_ES_OTHER_METRIC_DATA_TTL:45} # Unit is day
+#    monthMetricsDataTTL: ${SW_STORAGE_ES_MONTH_METRIC_DATA_TTL:18} # Unit is month
+#    # Batch process setting, refer to https://www.elastic.co/guide/en/elasticsearch/client/java-api/5.5/java-docs-bulk-processor.html
+#    bulkActions: ${SW_STORAGE_ES_BULK_ACTIONS:1000} # Execute the bulk every 1000 requests
+#    flushInterval: ${SW_STORAGE_ES_FLUSH_INTERVAL:10} # flush the bulk every 10 seconds whatever the number of requests
+#    concurrentRequests: ${SW_STORAGE_ES_CONCURRENT_REQUESTS:2} # the number of concurrent requests
+#    metadataQueryMaxSize: ${SW_STORAGE_ES_QUERY_MAX_SIZE:5000}
+#    segmentQueryMaxSize: ${SW_STORAGE_ES_QUERY_SEGMENT_SIZE:200}
 #  h2:
 #    driver: ${SW_STORAGE_H2_DRIVER:org.h2.jdbcx.JdbcDataSource}
 #    url: ${SW_STORAGE_H2_URL:jdbc:h2:mem:skywalking-oap-db}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
@@ -42,8 +42,9 @@ public class MetricsEsDAO extends EsDAO implements IMetricsDAO {
     @Override public List<Metrics> multiGet(Model model, List<String> ids) throws IOException {
         SearchResponse response = getClient().ids(model.getName(), ids.toArray(new String[0]));
 
-        List<Metrics> result = new ArrayList<>((int)response.getHits().totalHits);
-        for (int i = 0; i < response.getHits().totalHits; i++) {
+        int totalHits = response.getHits().getHits() == null ? 0 : response.getHits().getHits().length;
+        List<Metrics> result = new ArrayList<>(totalHits);
+        for (int i = 0; i < totalHits; i++) {
             Metrics source = storageBuilder.map2Data(response.getHits().getAt(i).getSourceAsMap());
             result.add(source);
         }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
@@ -24,6 +24,7 @@ import org.apache.skywalking.oap.server.core.storage.StorageException;
 import org.apache.skywalking.oap.server.core.storage.model.*;
 import org.apache.skywalking.oap.server.library.client.Client;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v6.ElasticSearch6Client;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.elasticsearch.common.unit.TimeValue;
 import org.slf4j.*;
@@ -108,9 +109,9 @@ public class StorageEsInstaller extends ModelInstaller {
 
     private JsonObject createMapping(Model model) {
         JsonObject mapping = new JsonObject();
-        mapping.add(ElasticSearchClient.TYPE, new JsonObject());
+        mapping.add(ElasticSearch6Client.TYPE, new JsonObject());
 
-        JsonObject type = mapping.get(ElasticSearchClient.TYPE).getAsJsonObject();
+        JsonObject type = mapping.get(ElasticSearch6Client.TYPE).getAsJsonObject();
 
         JsonObject properties = new JsonObject();
         type.add("properties", properties);

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller7.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller7.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base;
+
+import java.io.IOException;
+
+import com.google.gson.JsonObject;
+import org.apache.skywalking.oap.server.core.storage.StorageException;
+import org.apache.skywalking.oap.server.core.storage.model.Model;
+import org.apache.skywalking.oap.server.core.storage.model.ModelColumn;
+import org.apache.skywalking.oap.server.core.storage.model.ModelInstaller;
+import org.apache.skywalking.oap.server.library.client.Client;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v6.ElasticSearch6Client;
+import org.apache.skywalking.oap.server.library.module.ModuleManager;
+import org.elasticsearch.common.unit.TimeValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author peng-yongsheng
+ */
+public class StorageEsInstaller7 extends ModelInstaller {
+
+    private static final Logger logger = LoggerFactory.getLogger(StorageEsInstaller7.class);
+
+    private final int indexShardsNumber;
+    private final int indexReplicasNumber;
+    private final int indexRefreshInterval;
+    private final ColumnTypeEsMapping columnTypeEsMapping;
+
+    public StorageEsInstaller7(ModuleManager moduleManager, int indexShardsNumber, int indexReplicasNumber, int indexRefreshInterval) {
+        super(moduleManager);
+        this.indexShardsNumber = indexShardsNumber;
+        this.indexReplicasNumber = indexReplicasNumber;
+        this.indexRefreshInterval = indexRefreshInterval;
+        this.columnTypeEsMapping = new ColumnTypeEsMapping();
+    }
+
+    @Override protected boolean isExists(Client client, Model model) throws StorageException {
+        ElasticSearch6Client esClient = (ElasticSearch6Client)client;
+        try {
+            if (model.isCapableOfTimeSeries()) {
+                return esClient.isExistsTemplate(model.getName()) && esClient.isExistsIndex(model.getName());
+            } else {
+                return esClient.isExistsIndex(model.getName());
+            }
+        } catch (IOException e) {
+            throw new StorageException(e.getMessage());
+        }
+    }
+
+    @Override protected void createTable(Client client, Model model) throws StorageException {
+        ElasticSearch6Client esClient = (ElasticSearch6Client)client;
+
+        JsonObject settings = createSetting(model.isRecord());
+        JsonObject mapping = createMapping(model);
+        logger.info("index {}'s columnTypeEsMapping builder str: {}", esClient.formatIndexName(model.getName()), mapping.toString());
+
+        try {
+            if (model.isCapableOfTimeSeries()) {
+                if (!esClient.isExistsTemplate(model.getName())) {
+                    boolean isAcknowledged = esClient.createTemplate(model.getName(), settings, mapping);
+                    logger.info("create {} index template finished, isAcknowledged: {}", model.getName(), isAcknowledged);
+                    if (!isAcknowledged) {
+                        throw new StorageException("create " + model.getName() + " index template failure, ");
+                    }
+                }
+                if (!esClient.isExistsIndex(model.getName())) {
+                    String timeSeriesIndexName = TimeSeriesUtils.timeSeries(model);
+                    boolean isAcknowledged = esClient.createIndex(timeSeriesIndexName);
+                    logger.info("create {} index finished, isAcknowledged: {}", timeSeriesIndexName, isAcknowledged);
+                    if (!isAcknowledged) {
+                        throw new StorageException("create " + timeSeriesIndexName + " time series index failure, ");
+                    }
+                }
+            } else {
+                boolean isAcknowledged = esClient.createIndex(model.getName(), settings, mapping);
+                logger.info("create {} index finished, isAcknowledged: {}", model.getName(), isAcknowledged);
+                if (!isAcknowledged) {
+                    throw new StorageException("create " + model.getName() + " index failure, ");
+                }
+            }
+        } catch (IOException e) {
+            throw new StorageException(e.getMessage());
+        }
+    }
+
+    private JsonObject createSetting(boolean record) {
+        JsonObject setting = new JsonObject();
+        setting.addProperty("index.number_of_shards", indexShardsNumber);
+        setting.addProperty("index.number_of_replicas", indexReplicasNumber);
+        setting.addProperty("index.refresh_interval", record ? TimeValue.timeValueSeconds(10).toString() : TimeValue.timeValueSeconds(indexRefreshInterval).toString());
+        setting.addProperty("analysis.analyzer.oap_analyzer.type", "stop");
+        return setting;
+    }
+
+    private JsonObject createMapping(Model model) {
+        JsonObject mapping = new JsonObject();
+        JsonObject properties = new JsonObject();
+        mapping.add("properties", properties);
+
+        for (ModelColumn columnDefine : model.getColumns()) {
+            if (columnDefine.isMatchQuery()) {
+                String matchCName = MatchCNameBuilder.INSTANCE.build(columnDefine.getColumnName().getName());
+
+                JsonObject originalColumn = new JsonObject();
+                originalColumn.addProperty("type", columnTypeEsMapping.transform(columnDefine.getType()));
+                originalColumn.addProperty("copy_to", matchCName);
+                properties.add(columnDefine.getColumnName().getName(), originalColumn);
+
+                JsonObject matchColumn = new JsonObject();
+                matchColumn.addProperty("type", "text");
+                matchColumn.addProperty("analyzer", "oap_analyzer");
+                properties.add(matchCName, matchColumn);
+            } else if (columnDefine.isContent()) {
+                JsonObject column = new JsonObject();
+                column.addProperty("type", "text");
+                column.addProperty("index", false);
+                properties.add(columnDefine.getColumnName().getName(), column);
+            } else {
+                JsonObject column = new JsonObject();
+                column.addProperty("type", columnTypeEsMapping.transform(columnDefine.getType()));
+                properties.add(columnDefine.getColumnName().getName(), column);
+            }
+        }
+
+        logger.debug("elasticsearch index template setting: {}", mapping.toString());
+
+        return mapping;
+    }
+}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/EndpointInventoryCacheEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/EndpointInventoryCacheEsDAO.java
@@ -65,7 +65,8 @@ public class EndpointInventoryCacheEsDAO extends EsDAO implements IEndpointInven
             searchSourceBuilder.size(1);
 
             SearchResponse response = getClient().search(EndpointInventory.INDEX_NAME, searchSourceBuilder);
-            if (response.getHits().totalHits == 1) {
+            int totalHits = response.getHits().getHits() == null ? 0 : response.getHits().getHits().length;
+            if (totalHits == 1) {
                 SearchHit searchHit = response.getHits().getAt(0);
                 return builder.map2Data(searchHit.getSourceAsMap());
             } else {

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/NetworkAddressInventoryCacheEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/NetworkAddressInventoryCacheEsDAO.java
@@ -66,7 +66,8 @@ public class NetworkAddressInventoryCacheEsDAO extends EsDAO implements INetwork
             searchSourceBuilder.size(1);
 
             SearchResponse response = getClient().search(NetworkAddressInventory.INDEX_NAME, searchSourceBuilder);
-            if (response.getHits().totalHits == 1) {
+            int totalHits = response.getHits().getHits() == null ? 0 : response.getHits().getHits().length;
+            if (totalHits == 1) {
                 SearchHit searchHit = response.getHits().getAt(0);
                 return builder.map2Data(searchHit.getSourceAsMap());
             } else {

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInstanceInventoryCacheDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInstanceInventoryCacheDAO.java
@@ -50,7 +50,7 @@ public class ServiceInstanceInventoryCacheDAO extends EsDAO implements IServiceI
             searchSourceBuilder.size(1);
 
             SearchResponse response = getClient().search(ServiceInstanceInventory.INDEX_NAME, searchSourceBuilder);
-            if (response.getHits().totalHits == 1) {
+            if (response.getHits().getHits() != null && response.getHits().getHits().length == 1) {
                 SearchHit searchHit = response.getHits().getAt(0);
                 return builder.map2Data(searchHit.getSourceAsMap());
             } else {

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInventoryCacheEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInventoryCacheEsDAO.java
@@ -76,7 +76,7 @@ public class ServiceInventoryCacheEsDAO extends EsDAO implements IServiceInvento
             searchSourceBuilder.size(1);
 
             SearchResponse response = getClient().search(ServiceInventory.INDEX_NAME, searchSourceBuilder);
-            if (response.getHits().totalHits == 1) {
+            if (response.getHits().getHits() != null && response.getHits().getHits().length == 1) {
                 SearchHit searchHit = response.getHits().getAt(0);
                 return builder.map2Data(searchHit.getSourceAsMap());
             } else {

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/lock/RegisterLockES7DAOImpl.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/lock/RegisterLockES7DAOImpl.java
@@ -29,8 +29,6 @@ import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSear
 import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.EsDAO;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.common.document.DocumentField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/lock/RegisterLockES7DAOImpl.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/lock/RegisterLockES7DAOImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.lock;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+import org.apache.skywalking.oap.server.core.Const;
+import org.apache.skywalking.oap.server.core.register.RegisterSource;
+import org.apache.skywalking.oap.server.core.storage.IRegisterLockDAO;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.EsDAO;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v7.ElasticSearch7Client.PRIMARY_TERM;
+import static org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v7.ElasticSearch7Client.SEQ_NO;
+
+/**
+ * @author peng-yongsheng
+ * @author kezhenxu94
+ */
+public class RegisterLockES7DAOImpl extends EsDAO implements IRegisterLockDAO {
+
+    private static final Logger logger = LoggerFactory.getLogger(RegisterLockES7DAOImpl.class);
+
+    public RegisterLockES7DAOImpl(ElasticSearchClient client) {
+        super(client);
+    }
+
+    @Override
+    public int getId(int scopeId, RegisterSource registerSource) {
+        String id = scopeId + "";
+
+        int sequence = Const.NONE;
+        try {
+            GetResponse response = getClient().get(RegisterLockIndex.NAME, id);
+            if (response.isExists()) {
+                Map<String, Object> source = response.getSource();
+                sequence = ((Number) source.get(RegisterLockIndex.COLUMN_SEQUENCE)).intValue();
+
+                sequence++;
+
+                DocumentField ifSeqNo = response.getField(SEQ_NO);
+                DocumentField ifPrimaryTerm = response.getField(PRIMARY_TERM);
+                lock(id, sequence, ifSeqNo.getValue(), ifPrimaryTerm.getValue());
+            }
+        } catch (Throwable t) {
+            logger.warn("Try to lock the row with the id {} failure, error message: {}", id, t.getMessage(), t);
+            return Const.NONE;
+        }
+        return sequence;
+    }
+
+    private void lock(String id, int sequence, int seqNumber, int primaryTerm) throws IOException {
+        JsonObject source = new JsonObject();
+        source.addProperty(RegisterLockIndex.COLUMN_SEQUENCE, sequence);
+
+        getClient().forceUpdate(RegisterLockIndex.NAME, id, source, seqNumber, primaryTerm);
+    }
+}
+
+

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/lock/RegisterLockInstaller.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/lock/RegisterLockInstaller.java
@@ -24,6 +24,7 @@ import org.apache.skywalking.oap.server.core.analysis.Stream;
 import org.apache.skywalking.oap.server.core.register.worker.InventoryStreamProcessor;
 import org.apache.skywalking.oap.server.core.storage.StorageException;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v6.ElasticSearch6Client;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.common.xcontent.*;
 import org.slf4j.*;
@@ -74,9 +75,9 @@ public class RegisterLockInstaller {
         settings.addProperty("index.refresh_interval", "1s");
 
         JsonObject mapping = new JsonObject();
-        mapping.add(ElasticSearchClient.TYPE, new JsonObject());
+        mapping.add(ElasticSearch6Client.TYPE, new JsonObject());
 
-        JsonObject type = mapping.get(ElasticSearchClient.TYPE).getAsJsonObject();
+        JsonObject type = mapping.get(ElasticSearch6Client.TYPE).getAsJsonObject();
 
         JsonObject properties = new JsonObject();
         type.add("properties", properties);

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/lock/RegisterLockInstaller7.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/lock/RegisterLockInstaller7.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.lock;
+
+import java.io.IOException;
+
+import com.google.gson.JsonObject;
+import org.apache.skywalking.oap.server.core.analysis.Stream;
+import org.apache.skywalking.oap.server.core.register.worker.InventoryStreamProcessor;
+import org.apache.skywalking.oap.server.core.storage.StorageException;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author peng-yongsheng
+ */
+public class RegisterLockInstaller7 {
+
+    private static final Logger logger = LoggerFactory.getLogger(RegisterLockInstaller7.class);
+
+    private final ElasticSearchClient client;
+
+    public RegisterLockInstaller7(ElasticSearchClient client) {
+        this.client = client;
+    }
+
+    public void install() throws StorageException {
+        boolean debug = System.getProperty("debug") != null;
+
+        try {
+            if (!client.isExistsIndex(RegisterLockIndex.NAME)) {
+                logger.info("table: {} does not exist", RegisterLockIndex.NAME);
+                createIndex();
+            } else if (debug) {
+                logger.info("table: {} exists", RegisterLockIndex.NAME);
+                deleteIndex();
+                createIndex();
+            }
+
+            for (Class registerSource : InventoryStreamProcessor.getInstance().getAllRegisterSources()) {
+                int scopeId = ((Stream)registerSource.getAnnotation(Stream.class)).scopeId();
+                putIfAbsent(scopeId);
+            }
+        } catch (IOException e) {
+            throw new StorageException(e.getMessage());
+        }
+    }
+
+    private void deleteIndex() throws IOException {
+        client.deleteByModelName(RegisterLockIndex.NAME);
+    }
+
+    private void createIndex() throws IOException {
+        JsonObject settings = new JsonObject();
+        settings.addProperty("index.number_of_shards", 1);
+        settings.addProperty("index.number_of_replicas", 0);
+        settings.addProperty("index.refresh_interval", "1s");
+
+        JsonObject mapping = new JsonObject();
+        JsonObject properties = new JsonObject();
+        mapping.add("properties", properties);
+
+        JsonObject column = new JsonObject();
+        column.addProperty("type", "integer");
+        properties.add(RegisterLockIndex.COLUMN_SEQUENCE, column);
+
+        client.createIndex(RegisterLockIndex.NAME, settings, mapping);
+    }
+
+    private void putIfAbsent(int scopeId) throws IOException {
+        GetResponse response = client.get(RegisterLockIndex.NAME, String.valueOf(scopeId));
+        if (!response.isExists()) {
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+            builder.field(RegisterLockIndex.COLUMN_SEQUENCE, 1);
+            builder.endObject();
+
+            client.forceInsert(RegisterLockIndex.NAME, String.valueOf(scopeId), builder);
+        }
+    }
+}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AlarmQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AlarmQueryEsDAO.java
@@ -65,7 +65,8 @@ public class AlarmQueryEsDAO extends EsDAO implements IAlarmQueryDAO {
         SearchResponse response = getClient().search(AlarmRecord.INDEX_NAME, sourceBuilder);
 
         Alarms alarms = new Alarms();
-        alarms.setTotal((int)response.getHits().totalHits);
+        int totalHits = response.getHits().getHits() == null ? 0 : response.getHits().getHits().length;
+        alarms.setTotal(totalHits);
 
         for (SearchHit searchHit : response.getHits().getHits()) {
             AlarmRecord.Builder builder = new AlarmRecord.Builder();

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/LogQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/LogQueryEsDAO.java
@@ -85,7 +85,8 @@ public class LogQueryEsDAO extends EsDAO implements ILogQueryDAO {
         SearchResponse response = getClient().search(metricName, sourceBuilder);
 
         Logs logs = new Logs();
-        logs.setTotal((int)response.getHits().totalHits);
+        int totalHits = response.getHits().getHits() == null ? 0 : response.getHits().getHits().length;
+        logs.setTotal(totalHits);
 
         for (SearchHit searchHit : response.getHits().getHits()) {
             Log log = new Log();

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
@@ -81,7 +81,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.size(0);
 
         SearchResponse response = getClient().search(ServiceInventory.INDEX_NAME, sourceBuilder);
-        return (int)response.getHits().getTotalHits();
+        return response.getHits().getHits() == null ? 0 : response.getHits().getHits().length;
     }
 
     @Override public int numOfEndpoint(long startTimestamp, long endTimestamp) throws IOException {
@@ -95,7 +95,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.size(0);
 
         SearchResponse response = getClient().search(EndpointInventory.INDEX_NAME, sourceBuilder);
-        return (int)response.getHits().getTotalHits();
+        return response.getHits().getHits() == null ? 0 : response.getHits().getHits().length;
     }
 
     @Override
@@ -107,7 +107,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
 
         SearchResponse response = getClient().search(ServiceInventory.INDEX_NAME, sourceBuilder);
 
-        return (int)response.getHits().getTotalHits();
+        return response.getHits().getHits() == null ? 0 : response.getHits().getHits().length;
     }
 
     @Override

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TraceQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TraceQueryEsDAO.java
@@ -107,7 +107,8 @@ public class TraceQueryEsDAO extends EsDAO implements ITraceQueryDAO {
         SearchResponse response = getClient().search(SegmentRecord.INDEX_NAME, sourceBuilder);
 
         TraceBrief traceBrief = new TraceBrief();
-        traceBrief.setTotal((int)response.getHits().totalHits);
+        int totalHits = response.getHits().getHits() == null ? 0 : response.getHits().getHits().length;
+        traceBrief.setTotal(totalHits);
 
         for (SearchHit searchHit : response.getHits().getHits()) {
             BasicTrace basicTrace = new BasicTrace();

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/v6/StorageModuleElasticsearch6Provider.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/v6/StorageModuleElasticsearch6Provider.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.storage.plugin.elasticsearch;
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.v6;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
@@ -44,12 +44,13 @@ import org.apache.skywalking.oap.server.core.storage.query.IMetricsQueryDAO;
 import org.apache.skywalking.oap.server.core.storage.query.ITopNRecordsQueryDAO;
 import org.apache.skywalking.oap.server.core.storage.query.ITopologyQueryDAO;
 import org.apache.skywalking.oap.server.core.storage.query.ITraceQueryDAO;
-import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v6.ElasticSearch6Client;
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
 import org.apache.skywalking.oap.server.library.module.ModuleProvider;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
 import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.StorageModuleElasticsearchConfig;
 import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.BatchProcessEsDAO;
 import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.HistoryDeleteEsDAO;
 import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.StorageEsDAO;
@@ -73,12 +74,12 @@ import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.ttl.Elastic
 /**
  * @author peng-yongsheng
  */
-public class StorageModuleElasticsearchProvider extends ModuleProvider {
+public class StorageModuleElasticsearch6Provider extends ModuleProvider {
 
     protected final StorageModuleElasticsearchConfig config;
-    protected ElasticSearchClient elasticSearchClient;
+    protected ElasticSearch6Client elasticSearchClient;
 
-    public StorageModuleElasticsearchProvider() {
+    public StorageModuleElasticsearch6Provider() {
         super();
         this.config = new StorageModuleElasticsearchConfig();
     }
@@ -103,7 +104,7 @@ public class StorageModuleElasticsearchProvider extends ModuleProvider {
         if (!StringUtil.isEmpty(config.getNameSpace())) {
             config.setNameSpace(config.getNameSpace().toLowerCase());
         }
-        elasticSearchClient = new ElasticSearchClient(config.getClusterNodes(), config.getProtocol(), config.getTrustStorePath(), config.getTrustStorePass(), config.getNameSpace(), config.getUser(), config.getPassword());
+        elasticSearchClient = new ElasticSearch6Client(config.getClusterNodes(), config.getProtocol(), config.getTrustStorePath(), config.getTrustStorePass(), config.getNameSpace(), config.getUser(), config.getPassword());
 
         this.registerServiceImplementation(IBatchDAO.class, new BatchProcessEsDAO(elasticSearchClient, config.getBulkActions(), config.getFlushInterval(), config.getConcurrentRequests()));
         this.registerServiceImplementation(StorageDAO.class, new StorageEsDAO(elasticSearchClient));

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/v7/StorageModuleElasticsearch7Provider.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/v7/StorageModuleElasticsearch7Provider.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.v7;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+
+import org.apache.skywalking.apm.util.StringUtil;
+import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.config.ConfigService;
+import org.apache.skywalking.oap.server.core.storage.IBatchDAO;
+import org.apache.skywalking.oap.server.core.storage.IHistoryDeleteDAO;
+import org.apache.skywalking.oap.server.core.storage.IRegisterLockDAO;
+import org.apache.skywalking.oap.server.core.storage.StorageDAO;
+import org.apache.skywalking.oap.server.core.storage.StorageException;
+import org.apache.skywalking.oap.server.core.storage.StorageModule;
+import org.apache.skywalking.oap.server.core.storage.cache.IEndpointInventoryCacheDAO;
+import org.apache.skywalking.oap.server.core.storage.cache.INetworkAddressInventoryCacheDAO;
+import org.apache.skywalking.oap.server.core.storage.cache.IServiceInstanceInventoryCacheDAO;
+import org.apache.skywalking.oap.server.core.storage.cache.IServiceInventoryCacheDAO;
+import org.apache.skywalking.oap.server.core.storage.query.IAggregationQueryDAO;
+import org.apache.skywalking.oap.server.core.storage.query.IAlarmQueryDAO;
+import org.apache.skywalking.oap.server.core.storage.query.ILogQueryDAO;
+import org.apache.skywalking.oap.server.core.storage.query.IMetadataQueryDAO;
+import org.apache.skywalking.oap.server.core.storage.query.IMetricsQueryDAO;
+import org.apache.skywalking.oap.server.core.storage.query.ITopNRecordsQueryDAO;
+import org.apache.skywalking.oap.server.core.storage.query.ITopologyQueryDAO;
+import org.apache.skywalking.oap.server.core.storage.query.ITraceQueryDAO;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v6.ElasticSearch6Client;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.client.impl.v7.ElasticSearch7Client;
+import org.apache.skywalking.oap.server.library.module.ModuleConfig;
+import org.apache.skywalking.oap.server.library.module.ModuleDefine;
+import org.apache.skywalking.oap.server.library.module.ModuleProvider;
+import org.apache.skywalking.oap.server.library.module.ModuleStartException;
+import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.StorageModuleElasticsearchConfig;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.BatchProcessEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.HistoryDeleteEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.StorageEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.StorageEsInstaller7;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.cache.EndpointInventoryCacheEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.cache.NetworkAddressInventoryCacheEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.cache.ServiceInstanceInventoryCacheDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.cache.ServiceInventoryCacheEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.lock.RegisterLockES7DAOImpl;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.lock.RegisterLockInstaller7;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query.AggregationQueryEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query.AlarmQueryEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query.LogQueryEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query.MetadataQueryEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query.MetricsQueryEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query.TopNRecordsQueryEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query.TopologyQueryEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query.TraceQueryEsDAO;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.ttl.ElasticsearchStorageTTL;
+
+/**
+ * @author peng-yongsheng
+ * @author kezhenxu94
+ */
+public class StorageModuleElasticsearch7Provider extends ModuleProvider {
+
+    protected final StorageModuleElasticsearchConfig config;
+    protected ElasticSearch6Client elasticSearchClient;
+
+    public StorageModuleElasticsearch7Provider() {
+        super();
+        this.config = new StorageModuleElasticsearchConfig();
+    }
+
+    @Override
+    public String name() {
+        return "elasticsearch7";
+    }
+
+    @Override
+    public Class<? extends ModuleDefine> module() {
+        return StorageModule.class;
+    }
+
+    @Override
+    public ModuleConfig createConfigBeanIfAbsent() {
+        return config;
+    }
+
+    @Override
+    public void prepare() throws ServiceNotProvidedException {
+        if (!StringUtil.isEmpty(config.getNameSpace())) {
+            config.setNameSpace(config.getNameSpace().toLowerCase());
+        }
+        elasticSearchClient = new ElasticSearch7Client(config.getClusterNodes(), config.getProtocol(), config.getTrustStorePath(), config.getTrustStorePass(), config.getNameSpace(), config.getUser(), config.getPassword());
+
+        this.registerServiceImplementation(IBatchDAO.class, new BatchProcessEsDAO(elasticSearchClient, config.getBulkActions(), config.getFlushInterval(), config.getConcurrentRequests()));
+        this.registerServiceImplementation(StorageDAO.class, new StorageEsDAO(elasticSearchClient));
+        this.registerServiceImplementation(IRegisterLockDAO.class, new RegisterLockES7DAOImpl(elasticSearchClient));
+        this.registerServiceImplementation(IHistoryDeleteDAO.class, new HistoryDeleteEsDAO(getManager(), elasticSearchClient, new ElasticsearchStorageTTL()));
+
+        this.registerServiceImplementation(IServiceInventoryCacheDAO.class, new ServiceInventoryCacheEsDAO(elasticSearchClient));
+        this.registerServiceImplementation(IServiceInstanceInventoryCacheDAO.class, new ServiceInstanceInventoryCacheDAO(elasticSearchClient));
+        this.registerServiceImplementation(IEndpointInventoryCacheDAO.class, new EndpointInventoryCacheEsDAO(elasticSearchClient));
+        this.registerServiceImplementation(INetworkAddressInventoryCacheDAO.class, new NetworkAddressInventoryCacheEsDAO(elasticSearchClient));
+
+        this.registerServiceImplementation(ITopologyQueryDAO.class, new TopologyQueryEsDAO(elasticSearchClient));
+        this.registerServiceImplementation(IMetricsQueryDAO.class, new MetricsQueryEsDAO(elasticSearchClient));
+        this.registerServiceImplementation(ITraceQueryDAO.class, new TraceQueryEsDAO(elasticSearchClient, config.getSegmentQueryMaxSize()));
+        this.registerServiceImplementation(IMetadataQueryDAO.class, new MetadataQueryEsDAO(elasticSearchClient, config.getMetadataQueryMaxSize()));
+        this.registerServiceImplementation(IAggregationQueryDAO.class, new AggregationQueryEsDAO(elasticSearchClient));
+        this.registerServiceImplementation(IAlarmQueryDAO.class, new AlarmQueryEsDAO(elasticSearchClient));
+        this.registerServiceImplementation(ITopNRecordsQueryDAO.class, new TopNRecordsQueryEsDAO(elasticSearchClient));
+        this.registerServiceImplementation(ILogQueryDAO.class, new LogQueryEsDAO(elasticSearchClient));
+    }
+
+    @Override
+    public void start() throws ModuleStartException {
+        overrideCoreModuleTTLConfig();
+
+        try {
+            elasticSearchClient.connect();
+
+            StorageEsInstaller7 installer = new StorageEsInstaller7(getManager(), config.getIndexShardsNumber(), config.getIndexReplicasNumber(), config.getIndexRefreshInterval());
+            installer.install(elasticSearchClient);
+
+            RegisterLockInstaller7 lockInstaller = new RegisterLockInstaller7(elasticSearchClient);
+            lockInstaller.install();
+        } catch (StorageException | IOException | KeyStoreException | NoSuchAlgorithmException | KeyManagementException | CertificateException e) {
+            throw new ModuleStartException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void notifyAfterCompleted() {
+    }
+
+    @Override
+    public String[] requiredModules() {
+        return new String[] {CoreModule.NAME};
+    }
+
+    private void overrideCoreModuleTTLConfig() {
+        ConfigService configService = getManager().find(CoreModule.NAME).provider().getService(ConfigService.class);
+        configService.getDataTTLConfig().setRecordDataTTL(config.getRecordDataTTL());
+        configService.getDataTTLConfig().setMinuteMetricsDataTTL(config.getMinuteMetricsDataTTL());
+        configService.getDataTTLConfig().setHourMetricsDataTTL(config.getHourMetricsDataTTL());
+        configService.getDataTTLConfig().setDayMetricsDataTTL(config.getDayMetricsDataTTL());
+        configService.getDataTTLConfig().setMonthMetricsDataTTL(config.getMonthMetricsDataTTL());
+    }
+}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
@@ -16,4 +16,5 @@
 #
 #
 
-org.apache.skywalking.oap.server.storage.plugin.elasticsearch.StorageModuleElasticsearchProvider
+org.apache.skywalking.oap.server.storage.plugin.elasticsearch.v6.StorageModuleElasticsearch6Provider
+org.apache.skywalking.oap.server.storage.plugin.elasticsearch.v7.StorageModuleElasticsearch7Provider

--- a/oap-server/server-storage-plugin/storage-jaeger-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jaeger/elasticsearch/JaegerStorageModuleElasticsearch7Provider.java
+++ b/oap-server/server-storage-plugin/storage-jaeger-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jaeger/elasticsearch/JaegerStorageModuleElasticsearch7Provider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.jaeger.elasticsearch;
+
+import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.cache.ServiceInventoryCache;
+import org.apache.skywalking.oap.server.core.storage.query.ITraceQueryDAO;
+import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.v7.StorageModuleElasticsearch7Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author peng-yongsheng
+ */
+public class JaegerStorageModuleElasticsearch7Provider extends StorageModuleElasticsearch7Provider {
+
+    private static final Logger logger = LoggerFactory.getLogger(JaegerStorageModuleElasticsearch7Provider.class);
+    private JaegerTraceQueryEsDAO traceQueryEsDAO;
+
+    @Override
+    public String name() {
+        return "jaeger-elasticsearch7";
+    }
+
+    @Override
+    public void prepare() throws ServiceNotProvidedException {
+        super.prepare();
+        traceQueryEsDAO = new JaegerTraceQueryEsDAO(elasticSearchClient);
+        this.registerServiceImplementation(ITraceQueryDAO.class, traceQueryEsDAO);
+    }
+
+    @Override public void notifyAfterCompleted() {
+        super.notifyAfterCompleted();
+        traceQueryEsDAO.setServiceInventoryCache(getManager().find(CoreModule.NAME).provider().getService(ServiceInventoryCache.class));
+    }
+
+    @Override
+    public String[] requiredModules() {
+        return new String[] {CoreModule.NAME};
+    }
+}

--- a/oap-server/server-storage-plugin/storage-jaeger-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jaeger/elasticsearch/JaegerStorageModuleElasticsearchProvider.java
+++ b/oap-server/server-storage-plugin/storage-jaeger-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jaeger/elasticsearch/JaegerStorageModuleElasticsearchProvider.java
@@ -22,13 +22,13 @@ import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.cache.ServiceInventoryCache;
 import org.apache.skywalking.oap.server.core.storage.query.ITraceQueryDAO;
 import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
-import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.StorageModuleElasticsearchProvider;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.v6.StorageModuleElasticsearch6Provider;
 import org.slf4j.*;
 
 /**
  * @author peng-yongsheng
  */
-public class JaegerStorageModuleElasticsearchProvider extends StorageModuleElasticsearchProvider {
+public class JaegerStorageModuleElasticsearchProvider extends StorageModuleElasticsearch6Provider {
 
     private static final Logger logger = LoggerFactory.getLogger(JaegerStorageModuleElasticsearchProvider.class);
     private JaegerTraceQueryEsDAO traceQueryEsDAO;

--- a/oap-server/server-storage-plugin/storage-jaeger-plugin/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
+++ b/oap-server/server-storage-plugin/storage-jaeger-plugin/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
@@ -17,3 +17,4 @@
 #
 
 org.apache.skywalking.oap.server.storage.plugin.jaeger.elasticsearch.JaegerStorageModuleElasticsearchProvider
+org.apache.skywalking.oap.server.storage.plugin.jaeger.elasticsearch.JaegerStorageModuleElasticsearch7Provider

--- a/oap-server/server-storage-plugin/storage-zipkin-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/zipkin/elasticsearch/ZipkinStorageModuleElasticsearch7Provider.java
+++ b/oap-server/server-storage-plugin/storage-zipkin-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/zipkin/elasticsearch/ZipkinStorageModuleElasticsearch7Provider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.zipkin.elasticsearch;
+
+import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.cache.ServiceInventoryCache;
+import org.apache.skywalking.oap.server.core.storage.query.ITraceQueryDAO;
+import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.v7.StorageModuleElasticsearch7Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author peng-yongsheng
+ */
+public class ZipkinStorageModuleElasticsearch7Provider extends StorageModuleElasticsearch7Provider {
+
+    private static final Logger logger = LoggerFactory.getLogger(ZipkinStorageModuleElasticsearch7Provider.class);
+    private ZipkinTraceQueryEsDAO traceQueryEsDAO;
+
+    @Override
+    public String name() {
+        return "zipkin-elasticsearch7";
+    }
+
+    @Override
+    public void prepare() throws ServiceNotProvidedException {
+        super.prepare();
+        traceQueryEsDAO = new ZipkinTraceQueryEsDAO(elasticSearchClient);
+        this.registerServiceImplementation(ITraceQueryDAO.class, traceQueryEsDAO);
+    }
+
+    @Override public void notifyAfterCompleted() {
+        super.notifyAfterCompleted();
+        traceQueryEsDAO.setServiceInventoryCache(getManager().find(CoreModule.NAME).provider().getService(ServiceInventoryCache.class));
+    }
+
+    @Override
+    public String[] requiredModules() {
+        return new String[] {CoreModule.NAME};
+    }
+}

--- a/oap-server/server-storage-plugin/storage-zipkin-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/zipkin/elasticsearch/ZipkinStorageModuleElasticsearchProvider.java
+++ b/oap-server/server-storage-plugin/storage-zipkin-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/zipkin/elasticsearch/ZipkinStorageModuleElasticsearchProvider.java
@@ -22,13 +22,13 @@ import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.cache.ServiceInventoryCache;
 import org.apache.skywalking.oap.server.core.storage.query.ITraceQueryDAO;
 import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
-import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.StorageModuleElasticsearchProvider;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.v6.StorageModuleElasticsearch6Provider;
 import org.slf4j.*;
 
 /**
  * @author peng-yongsheng
  */
-public class ZipkinStorageModuleElasticsearchProvider extends StorageModuleElasticsearchProvider {
+public class ZipkinStorageModuleElasticsearchProvider extends StorageModuleElasticsearch6Provider {
 
     private static final Logger logger = LoggerFactory.getLogger(ZipkinStorageModuleElasticsearchProvider.class);
     private ZipkinTraceQueryEsDAO traceQueryEsDAO;

--- a/oap-server/server-storage-plugin/storage-zipkin-plugin/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
+++ b/oap-server/server-storage-plugin/storage-zipkin-plugin/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
@@ -17,3 +17,4 @@
 #
 
 org.apache.skywalking.oap.server.storage.plugin.zipkin.elasticsearch.ZipkinStorageModuleElasticsearchProvider
+org.apache.skywalking.oap.server.storage.plugin.zipkin.elasticsearch.ZipkinStorageModuleElasticsearch7Provider

--- a/test/e2e/e2e-cluster/pom.xml
+++ b/test/e2e/e2e-cluster/pom.xml
@@ -35,5 +35,6 @@
         <module>consumer</module>
         <module>gateway</module>
         <module>test-runner</module>
+        <module>test-runner-es7</module>
     </modules>
 </project>

--- a/test/e2e/e2e-cluster/test-runner-es7/pom.xml
+++ b/test/e2e/e2e-cluster/test-runner-es7/pom.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>e2e-cluster</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>test-runner-es7</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>e2e-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>gateway</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>provider</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>consumer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <properties>
+        <provider.name>provider</provider.name>
+        <consumer.name>consumer</consumer.name>
+        <gateway.name>gateway</gateway.name>
+        <elasticsearch.version>7.4.0</elasticsearch.version>
+        <e2e.container.version>1.1</e2e.container.version>
+        <e2e.container.name.prefix>skywalking-e2e-container-${build.id}-cluster</e2e.container.name.prefix>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <containerNamePattern>%a-%t-%i</containerNamePattern>
+                    <imagePullPolicy>Always</imagePullPolicy>
+                    <images>
+                        <image>
+                            <name>elastic/elasticsearch:${elasticsearch.version}</name>
+                            <alias>${e2e.container.name.prefix}-elasticsearch</alias>
+                            <run>
+                                <ports>
+                                    <port>es.port:9200</port>
+                                </ports>
+                                <wait>
+                                    <http>
+                                        <url>http://localhost:${es.port}</url>
+                                        <method>GET</method>
+                                        <status>200</status>
+                                    </http>
+                                    <time>120000</time>
+                                </wait>
+                                <env>
+                                    <discovery.type>single-node</discovery.type>
+                                </env>
+                            </run>
+                        </image>
+                        <image>
+                            <name>zookeeper:${zookeeper.image.version}</name>
+                            <alias>${e2e.container.name.prefix}-zookeeper</alias>
+                            <run>
+                                <ports>
+                                    <port>zk.port:2181</port>
+                                </ports>
+                                <wait>
+                                    <log>binding to port</log>
+                                    <time>120000</time>
+                                </wait>
+                            </run>
+                        </image>
+                        <image>
+                            <name>skyapm/e2e-container:${e2e.container.version}</name>
+                            <alias>${e2e.container.name.prefix}</alias>
+                            <run>
+                                <env>
+                                    <MODE>cluster</MODE>
+                                    <SW_STORAGE_ES_CLUSTER_NODES>
+                                        ${e2e.container.name.prefix}-elasticsearch:9200
+                                    </SW_STORAGE_ES_CLUSTER_NODES>
+                                    <SW_CLUSTER_ZK_HOST_PORT>
+                                        ${e2e.container.name.prefix}-zookeeper:2181
+                                    </SW_CLUSTER_ZK_HOST_PORT>
+
+                                    <INSTRUMENTED_SERVICE_1>
+                                        ${provider.name}-${project.version}.jar
+                                    </INSTRUMENTED_SERVICE_1>
+                                    <INSTRUMENTED_SERVICE_1_OPTS>
+                                        -DSW_AGENT_COLLECTOR_BACKEND_SERVICES=127.0.0.1:11800
+                                        -DSW_AGENT_NAME=${provider.name}
+                                    </INSTRUMENTED_SERVICE_1_OPTS>
+                                    <INSTRUMENTED_SERVICE_1_ARGS>
+                                        --server.port=9090
+                                    </INSTRUMENTED_SERVICE_1_ARGS>
+
+                                    <INSTRUMENTED_SERVICE_2>
+                                        ${consumer.name}-${project.version}.jar
+                                    </INSTRUMENTED_SERVICE_2>
+                                    <INSTRUMENTED_SERVICE_2_OPTS>
+                                        -DSW_AGENT_COLLECTOR_BACKEND_SERVICES=127.0.0.1:11801
+                                        -DSW_AGENT_NAME=${consumer.name}
+                                    </INSTRUMENTED_SERVICE_2_OPTS>
+                                    <INSTRUMENTED_SERVICE_2_ARGS>
+                                        --server.port=9091
+                                    </INSTRUMENTED_SERVICE_2_ARGS>
+                                </env>
+                                <dependsOn>
+                                    <container>${e2e.container.name.prefix}-elasticsearch</container>
+                                    <container>${e2e.container.name.prefix}-zookeeper</container>
+                                </dependsOn>
+                                <ports>
+                                    <port>+webapp.host:webapp.port:8081</port>
+                                    <port>+service.host:service.port:9091</port>
+                                </ports>
+                                <links>
+                                    <link>${e2e.container.name.prefix}-elasticsearch</link>
+                                    <link>${e2e.container.name.prefix}-zookeeper</link>
+                                </links>
+                                <volumes>
+                                    <bind>
+                                        <volume>
+                                            ${sw.home}:/sw
+                                        </volume>
+                                        <volume>
+                                            ../${gateway.name}/target/${gateway.name}-${project.version}.jar:/home/${gateway.name}-${project.version}.jar
+                                        </volume>
+                                        <volume>
+                                            ../${provider.name}/target/${provider.name}-${project.version}.jar:/home/${provider.name}-${project.version}.jar
+                                        </volume>
+                                        <volume>
+                                            ../${consumer.name}/target/${consumer.name}-${project.version}.jar:/home/${consumer.name}-${project.version}.jar
+                                        </volume>
+                                        <volume>
+                                            ${project.basedir}/src/docker/rc.d:/rc.d:ro
+                                        </volume>
+                                        <volume>
+                                            ${project.basedir}/src/docker/clusterize.awk:/clusterize.awk
+                                        </volume>
+                                    </bind>
+                                </volumes>
+                                <wait>
+                                    <log>SkyWalking e2e container is ready for tests</log>
+                                    <time>3000000</time>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+
+            <!-- set the system properties that can be used in test codes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <sw.webapp.host>${webapp.host}</sw.webapp.host>
+                        <sw.webapp.port>${webapp.port}</sw.webapp.port>
+                        <service.host>${service.host}</service.host>
+                        <service.port>${service.port}</service.port>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/test/e2e/e2e-cluster/test-runner-es7/src/docker/clusterize.awk
+++ b/test/e2e/e2e-cluster/test-runner-es7/src/docker/clusterize.awk
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/awk -f
+
+BEGIN {
+    in_cluster_section=0;
+    in_cluster_zk_section=0;
+
+    in_storage_section=0;
+    in_storage_es_section=0;
+    in_storage_es7_section=0;
+    in_storage_h2_section=0;
+}
+
+{
+    if (in_cluster_section == 0) {
+        in_cluster_section=$0 ~ /^cluster:$/
+    } else {
+        in_cluster_section=$0 ~ /^(#|\s{2})/
+    }
+    if (in_storage_section == 0) {
+        in_storage_section=$0 ~ /^storage:$/
+    } else {
+        in_storage_section=$0 ~ /^(#|\s{2})/
+    }
+
+    if (in_cluster_section == 1) {
+        # in the cluster: section now
+        # disable standalone module
+        if ($0 ~ /^  standalone:$/) {
+            print "#" $0
+        } else {
+            if (in_cluster_zk_section == 0) {
+                in_cluster_zk_section=$0 ~ /^#?\s+zookeeper:$/
+            } else {
+                in_cluster_zk_section=$0 ~ /^(#\s{4}|\s{2})/
+            }
+            if (in_cluster_zk_section == 1) {
+                # in the cluster.zookeeper section now
+                # uncomment zk config
+                gsub("^#", "", $0)
+                print
+            } else {
+                print
+            }
+        }
+    } else if (in_storage_section == 1) {
+        # in the storage: section now
+        # disable h2 module
+        if (in_storage_es_section == 0) {
+            in_storage_es_section=$0 ~ /^#?\s+elasticsearch:$/
+        } else {
+            in_storage_es_section=$0 ~ /^#?\s{4}/
+        }
+        if (in_storage_es7_section == 0) {
+            in_storage_es7_section=$0 ~ /^#?\s+elasticsearch7:$/
+        } else {
+            in_storage_es7_section=$0 ~ /^#?\s{4}/
+        }
+        if (in_storage_h2_section == 0) {
+            in_storage_h2_section=$0 ~ /^#?\s+h2:$/
+        } else {
+            in_storage_h2_section=$0 ~ /^#?\s{4}/
+        }
+        if (in_storage_es7_section == 1) {
+            # in the storage.elasticsearch section now
+            # uncomment es config
+            gsub("^#", "", $0)
+            print
+        } else if (in_storage_h2_section == 1) {
+            # comment out h2 config
+            if ($0 !~ /^#/) {
+                print "#" $0
+            } else {
+                print
+            }
+        } else if (in_storage_es_section == 1) {
+            # comment out es config
+            if ($0 !~ /^#/) {
+                print "#" $0
+            } else {
+                print
+            }
+        } else {
+            print
+        }
+    } else {
+        print
+    }
+}
+

--- a/test/e2e/e2e-cluster/test-runner-es7/src/docker/rc.d/rc0-prepare.sh
+++ b/test/e2e/e2e-cluster/test-runner-es7/src/docker/rc.d/rc0-prepare.sh
@@ -1,0 +1,42 @@
+# Licensed to the SkyAPM under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+if test "${MODE}" = "cluster"; then
+    original_wd=$(pwd)
+
+    # substitute application.yml to be capable of cluster mode
+    cd ${SW_HOME}/config \
+        && awk -f /clusterize.awk application.yml > clusterized_app.yml \
+        && mv clusterized_app.yml application.yml \
+        && echo '
+gateways:
+  - name: proxy0
+    instances:
+      - host: 127.0.0.1 # the host/ip of this gateway instance
+        port: 9099 # the port of this gateway instance, defaults to 80
+' > gateways.yml \
+        && sed '/<Loggers>/a<logger name="org.apache.skywalking.oap.server.receiver.trace.provider.UninstrumentedGatewaysConfig" level="DEBUG"/>\
+        \n<logger name="org.apache.skywalking.oap.server.receiver.trace.provider.parser.listener.service.ServiceMappingSpanListener" level="DEBUG"/>' log4j2.xml > log4j2debuggable.xml \
+        && mv log4j2debuggable.xml log4j2.xml
+
+    cd ${SW_HOME}/webapp \
+        && awk '/^\s+listOfServers:/ {gsub("listOfServers:.*", "listOfServers: 127.0.0.1:12800,127.0.0.1:12801", $0)} {print}' webapp.yml > clusterized_webapp.yml \
+        && mv clusterized_webapp.yml webapp.yml
+
+    cd ${original_wd}
+fi

--- a/test/e2e/e2e-cluster/test-runner-es7/src/docker/rc.d/rc1-startup.sh
+++ b/test/e2e/e2e-cluster/test-runner-es7/src/docker/rc.d/rc1-startup.sh
@@ -1,0 +1,88 @@
+# Licensed to the SkyAPM under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+echo 'starting gateway service...' \
+    && java -jar /home/gateway-1.0.0.jar 2>&1 > /tmp/gateway.log &
+
+check_tcp 127.0.0.1 \
+          9099 \
+          60 \
+          10 \
+          'waiting for the gateway service to be ready'
+
+if [[ $? -ne 0 ]]; then
+    echo "gateway service failed to start in 60 * 10 seconds: "
+    cat /tmp/gateway.log
+    exit 1
+fi
+
+echo 'starting OAP server...' \
+    && SW_STORAGE_ES_BULK_ACTIONS=1 \
+    SW_STORAGE_ES_FLUSH_INTERVAL=1 \
+    SW_RECEIVER_BUFFER_PATH=/tmp/oap/trace_buffer1 \
+    SW_SERVICE_MESH_BUFFER_PATH=/tmp/oap/mesh_buffer1 \
+    start_oap 'init'
+
+echo 'starting Web app...' \
+    && start_webapp '0.0.0.0' 8081
+
+if test "${MODE}" = "cluster"; then
+    # start another OAP server in a different port
+    echo 'starting OAP server...' \
+        && SW_CORE_GRPC_PORT=11801 \
+        SW_CORE_REST_PORT=12801 \
+        SW_STORAGE_ES_BULK_ACTIONS=1 \
+        SW_STORAGE_ES_FLUSH_INTERVAL=1 \
+        SW_RECEIVER_BUFFER_PATH=/tmp/oap/trace_buffer2 \
+        SW_SERVICE_MESH_BUFFER_PATH=/tmp/oap/mesh_buffer2 \
+        start_oap 'no-init'
+fi
+
+echo 'starting instrumented services...' && start_instrumented_services
+
+check_tcp 127.0.0.1 \
+          9090 \
+          60 \
+          10 \
+          "waiting for the instrumented service 0 to be ready"
+
+if [[ $? -ne 0 ]]; then
+    echo "instrumented service 0 failed to start in 30 * 10 seconds: "
+    cat ${SERVICE_LOG}/*
+    exit 1
+fi
+
+check_tcp 127.0.0.1 \
+          9091 \
+          60 \
+          10 \
+          "waiting for the instrumented service 1 to be ready"
+
+if [[ $? -ne 0 ]]; then
+    echo "instrumented service 1 failed to start in 24 * 10 seconds: "
+    cat ${SERVICE_LOG}/*
+    exit 1
+fi
+
+echo "SkyWalking e2e container is ready for tests"
+
+tail -f ${OAP_LOG_DIR}/* \
+        ${WEBAPP_LOG_DIR}/* \
+        ${SERVICE_LOG}/* \
+        ${ES_HOME}/logs/elasticsearch.log \
+        ${ES_HOME}/logs/stdout.log

--- a/test/e2e/e2e-cluster/test-runner-es7/src/test/java/org/apache/skywalking/e2e/ClusterVerificationITCase.java
+++ b/test/e2e/e2e-cluster/test-runner-es7/src/test/java/org/apache/skywalking/e2e/ClusterVerificationITCase.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.e2e;
+
+import org.apache.skywalking.e2e.metrics.AtLeastOneOfMetricsMatcher;
+import org.apache.skywalking.e2e.metrics.Metrics;
+import org.apache.skywalking.e2e.metrics.MetricsQuery;
+import org.apache.skywalking.e2e.metrics.MetricsValueMatcher;
+import org.apache.skywalking.e2e.service.Service;
+import org.apache.skywalking.e2e.service.ServicesMatcher;
+import org.apache.skywalking.e2e.service.ServicesQuery;
+import org.apache.skywalking.e2e.service.endpoint.Endpoint;
+import org.apache.skywalking.e2e.service.endpoint.EndpointQuery;
+import org.apache.skywalking.e2e.service.endpoint.Endpoints;
+import org.apache.skywalking.e2e.service.endpoint.EndpointsMatcher;
+import org.apache.skywalking.e2e.service.instance.Instance;
+import org.apache.skywalking.e2e.service.instance.Instances;
+import org.apache.skywalking.e2e.service.instance.InstancesMatcher;
+import org.apache.skywalking.e2e.service.instance.InstancesQuery;
+import org.apache.skywalking.e2e.topo.TopoData;
+import org.apache.skywalking.e2e.topo.TopoMatcher;
+import org.apache.skywalking.e2e.topo.TopoQuery;
+import org.apache.skywalking.e2e.trace.Trace;
+import org.apache.skywalking.e2e.trace.TracesMatcher;
+import org.apache.skywalking.e2e.trace.TracesQuery;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.RestTemplate;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.skywalking.e2e.metrics.MetricsQuery.*;
+
+/**
+ * @author kezhenxu94
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ClusterVerificationITCase {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterVerificationITCase.class);
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final Yaml yaml = new Yaml();
+
+    private SimpleQueryClient queryClient;
+    private String instrumentedServiceUrl;
+    private long retryInterval = TimeUnit.SECONDS.toMillis(30);
+
+    @Before
+    public void setUp() {
+        final String swWebappHost = System.getProperty("sw.webapp.host", "127.0.0.1");
+        final String swWebappPort = System.getProperty("sw.webapp.port", "32791");
+        final String instrumentedServiceHost = System.getProperty("service.host", "127.0.0.1");
+        final String instrumentedServicePort = System.getProperty("service.port", "32790");
+        queryClient = new SimpleQueryClient(swWebappHost, swWebappPort);
+        instrumentedServiceUrl = "http://" + instrumentedServiceHost + ":" + instrumentedServicePort;
+    }
+
+    @Test(timeout = 1200000)
+    @DirtiesContext
+    public void verify() throws Exception {
+        LocalDateTime startTime = LocalDateTime.now(ZoneOffset.UTC);
+
+        // minimum guarantee that the instrumented services registered
+        // which is the prerequisite of following verifications(service instance, service metrics, etc.)
+        List<Service> services = Collections.emptyList();
+        while (services.size() < 2) {
+            try {
+                services = queryClient.services(
+                    new ServicesQuery()
+                        .start(startTime)
+                        .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
+                );
+                Thread.sleep(500); // take a nap to avoid high payload
+            } catch (Throwable ignored) {
+            }
+        }
+
+        verifyTraces(startTime);
+
+        verifyServices(startTime);
+
+        verifyTopo(startTime);
+    }
+
+    private void verifyTopo(LocalDateTime minutesAgo) throws Exception {
+        boolean valid = false;
+        while (!valid) {
+            try {
+                final TopoData topoData = queryClient.topo(
+                        new TopoQuery()
+                                .stepByMinute()
+                                .start(minutesAgo)
+                                .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
+                );
+                LOGGER.info("Actual topology: {}", topoData);
+
+                InputStream expectedInputStream =
+                        new ClassPathResource("expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.topo.yml").getInputStream();
+
+                final TopoMatcher topoMatcher = yaml.loadAs(expectedInputStream, TopoMatcher.class);
+                topoMatcher.verify(topoData);
+                valid = true;
+            } catch (Throwable t) {
+                LOGGER.warn(t.getMessage(), t);
+                generateTraffic();
+                Thread.sleep(retryInterval);
+            }
+        }
+    }
+
+    private void verifyServices(LocalDateTime minutesAgo) throws Exception {
+        List<Service> services = queryClient.services(
+            new ServicesQuery()
+                .start(minutesAgo)
+                .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
+        );
+        while (services.isEmpty()) {
+            LOGGER.warn("services is null, will retry to query");
+            services = queryClient.services(
+                new ServicesQuery()
+                    .start(minutesAgo)
+                    .end(LocalDateTime.now(ZoneOffset.UTC))
+            );
+            Thread.sleep(retryInterval);
+        }
+
+        InputStream expectedInputStream =
+            new ClassPathResource("expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.services.yml").getInputStream();
+
+        final ServicesMatcher servicesMatcher = yaml.loadAs(expectedInputStream, ServicesMatcher.class);
+        servicesMatcher.verify(services);
+
+        for (Service service : services) {
+            LOGGER.info("verifying service instances: {}", service);
+
+            verifyServiceMetrics(service, minutesAgo);
+
+            Instances instances = verifyServiceInstances(minutesAgo, service);
+
+            verifyInstancesMetrics(instances, minutesAgo);
+
+            Endpoints endpoints = verifyServiceEndpoints(minutesAgo, service);
+
+            verifyEndpointsMetrics(endpoints, minutesAgo);
+        }
+    }
+
+    private Instances verifyServiceInstances(LocalDateTime minutesAgo, Service service) throws Exception {
+        Instances instances = queryClient.instances(
+            new InstancesQuery()
+                .serviceId(service.getKey())
+                .start(minutesAgo)
+                .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
+        );
+        while (instances == null) {
+            LOGGER.warn("instances is null, will send traffic data and retry to query");
+            generateTraffic();
+            Thread.sleep(retryInterval);
+            instances = queryClient.instances(
+                new InstancesQuery()
+                    .serviceId(service.getKey())
+                    .start(minutesAgo)
+                    .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
+            );
+        }
+        InputStream expectedInputStream =
+            new ClassPathResource("expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.instances.yml").getInputStream();
+        final InstancesMatcher instancesMatcher = yaml.loadAs(expectedInputStream, InstancesMatcher.class);
+        instancesMatcher.verify(instances);
+        return instances;
+    }
+
+    private Endpoints verifyServiceEndpoints(LocalDateTime minutesAgo, Service service) throws Exception {
+        Endpoints endpoints = queryClient.endpoints(
+            new EndpointQuery().serviceId(service.getKey())
+        );
+        while (endpoints == null) {
+            LOGGER.warn("endpoints is null, will send traffic data and retry to query");
+            generateTraffic();
+            Thread.sleep(retryInterval);
+            endpoints = queryClient.endpoints(
+                new EndpointQuery().serviceId(service.getKey())
+            );
+        }
+        InputStream expectedInputStream =
+            new ClassPathResource("expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.endpoints.yml").getInputStream();
+        final EndpointsMatcher endpointsMatcher = yaml.loadAs(expectedInputStream, EndpointsMatcher.class);
+        endpointsMatcher.verify(endpoints);
+        return endpoints;
+    }
+
+    private void verifyInstancesMetrics(Instances instances, final LocalDateTime minutesAgo) throws Exception {
+        for (Instance instance : instances.getInstances()) {
+            for (String metricsName : ALL_INSTANCE_METRICS) {
+                LOGGER.info("verifying service instance response time: {}", instance);
+
+                boolean valid = false;
+                while (!valid) {
+                    LOGGER.warn("instanceMetrics is null, will retry to query");
+                    Metrics instanceMetrics = queryClient.metrics(
+                            new MetricsQuery()
+                                .stepByMinute()
+                                .metricsName(metricsName)
+                                .start(minutesAgo)
+                                .end(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(1))
+                                .id(instance.getKey())
+                        );
+                    AtLeastOneOfMetricsMatcher instanceRespTimeMatcher = new AtLeastOneOfMetricsMatcher();
+                    MetricsValueMatcher greaterThanZero = new MetricsValueMatcher();
+                    greaterThanZero.setValue("gt 0");
+                    instanceRespTimeMatcher.setValue(greaterThanZero);
+                    try {
+                        instanceRespTimeMatcher.verify(instanceMetrics);
+                        valid = true;
+                    } catch (Throwable ignored) {
+                        generateTraffic();
+                        Thread.sleep(retryInterval);
+                    }
+                    LOGGER.info("{}: {}", metricsName, instanceMetrics);
+                }
+            }
+        }
+    }
+
+    private void verifyEndpointsMetrics(Endpoints endpoints, final LocalDateTime minutesAgo) throws Exception {
+        for (Endpoint endpoint : endpoints.getEndpoints()) {
+            if (!endpoint.getLabel().equals("/e2e/users")) {
+                continue;
+            }
+            for (String metricName : ALL_ENDPOINT_METRICS) {
+                LOGGER.info("verifying endpoint {}, metrics: {}", endpoint, metricName);
+
+                boolean valid = false;
+                while (!valid) {
+                    Metrics endpointMetrics = queryClient.metrics(
+                        new MetricsQuery()
+                            .stepByMinute()
+                            .metricsName(metricName)
+                            .start(minutesAgo)
+                            .end(LocalDateTime.now(ZoneOffset.UTC))
+                            .id(endpoint.getKey())
+                    );
+                    AtLeastOneOfMetricsMatcher instanceRespTimeMatcher = new AtLeastOneOfMetricsMatcher();
+                    MetricsValueMatcher greaterThanZero = new MetricsValueMatcher();
+                    greaterThanZero.setValue("gt 0");
+                    instanceRespTimeMatcher.setValue(greaterThanZero);
+                    try {
+                        instanceRespTimeMatcher.verify(endpointMetrics);
+                        valid = true;
+                    } catch (Throwable ignored) {
+                        generateTraffic();
+                        Thread.sleep(retryInterval);
+                    }
+                    LOGGER.info("{}: {}", metricName, endpointMetrics);
+                }
+            }
+        }
+    }
+
+    private void verifyServiceMetrics(Service service, final LocalDateTime minutesAgo) throws Exception {
+        for (String metricName : ALL_SERVICE_METRICS) {
+            LOGGER.info("verifying service {}, metrics: {}", service, metricName);
+
+            boolean valid = false;
+            while (!valid) {
+                Metrics serviceMetrics = queryClient.metrics(
+                    new MetricsQuery()
+                        .stepByMinute()
+                        .metricsName(metricName)
+                        .start(minutesAgo)
+                        .end(LocalDateTime.now(ZoneOffset.UTC))
+                        .id(service.getKey())
+                );
+                AtLeastOneOfMetricsMatcher instanceRespTimeMatcher = new AtLeastOneOfMetricsMatcher();
+                MetricsValueMatcher greaterThanZero = new MetricsValueMatcher();
+                greaterThanZero.setValue("gt 0");
+                instanceRespTimeMatcher.setValue(greaterThanZero);
+                try {
+                    instanceRespTimeMatcher.verify(serviceMetrics);
+                    valid = true;
+                } catch (Throwable ignored) {
+                    generateTraffic();
+                    Thread.sleep(retryInterval);
+                }
+                LOGGER.info("{}: {}", metricName, serviceMetrics);
+            }
+        }
+    }
+
+    private void verifyTraces(LocalDateTime minutesAgo) throws Exception {
+        final TracesQuery query = new TracesQuery()
+            .stepBySecond()
+            .start(minutesAgo)
+            .orderByStartTime();
+
+        List<Trace> traces = queryClient.traces(query.end(LocalDateTime.now(ZoneOffset.UTC)));
+        while (traces.isEmpty()) {
+            LOGGER.warn("traces is empty, will generate traffic data and retry");
+            generateTraffic();
+            Thread.sleep(retryInterval);
+            traces = queryClient.traces(query.end(LocalDateTime.now(ZoneOffset.UTC)));
+        }
+
+        InputStream expectedInputStream =
+            new ClassPathResource("expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.traces.yml").getInputStream();
+
+        final TracesMatcher tracesMatcher = yaml.loadAs(expectedInputStream, TracesMatcher.class);
+        tracesMatcher.verifyLoosely(traces);
+    }
+
+    private void generateTraffic() {
+        try {
+            final Map<String, String> user = new HashMap<>();
+            user.put("name", "SkyWalking");
+            final ResponseEntity<String> responseEntity = restTemplate.postForEntity(
+                    instrumentedServiceUrl + "/e2e/users",
+                    user,
+                    String.class
+            );
+            LOGGER.info("responseEntity: {}, {}", responseEntity.getStatusCode(), responseEntity.getBody());
+        } catch (Throwable t) {
+            LOGGER.warn(t.getMessage(), t);
+        }
+    }
+}

--- a/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.endpoints.yml
+++ b/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.endpoints.yml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1 health-check by docker-maven-plugin
+# 1 drop table if exists, because we have `ddl-auto: create-drop`
+# 1 drop sequence
+# 1 create sequence
+# 1 create table statement
+
+endpoints:
+  - key: not null
+    label: /e2e/users

--- a/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.instances.yml
+++ b/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.instances.yml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1 health-check by docker-maven-plugin
+# 1 drop table if exists, because we have `ddl-auto: create-drop`
+# 1 drop sequence
+# 1 create sequence
+# 1 create table statement
+
+instances:
+  - key: gt 0
+    label: not null
+    attributes:
+      - name: os_name
+        value: not null
+      - name: host_name
+        value: not null
+      - name: process_no
+        value: gt 0
+      - name: ipv4s
+        value: not null

--- a/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.services.yml
+++ b/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.services.yml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1 health-check by docker-maven-plugin
+# 1 drop table if exists, because we have `ddl-auto: create-drop`
+# 1 drop sequence
+# 1 create sequence
+# 1 create table statement
+
+services:
+  - key: not null
+    label: provider
+
+  - key: not null
+    label: consumer

--- a/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.topo.yml
+++ b/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.topo.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nodes:
+  - id: not null
+    name: User
+    type: USER
+  - id: not null
+    name: provider
+    type: Tomcat
+  - id: not null
+    name: consumer
+    type: Tomcat
+  - id: not null
+    name: "localhost:-1"
+    type: H2
+  - id: not null
+    name: "127.0.0.1:9099"
+    type: Unknown
+calls:
+  - id: not null
+    source: not null
+    target: not null
+  - id: not null
+    source: not null
+    target: not null
+  - id: not null
+    source: not null
+    target: not null
+  - id: not null
+    source: not null
+    target: not null

--- a/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.traces.yml
+++ b/test/e2e/e2e-cluster/test-runner-es7/src/test/resources/expected-data/org.apache.skywalking.e2e.ClusterVerificationITCase.traces.yml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+traces:
+  - key: not null
+    endpointNames:
+      - /e2e/users
+    duration: ge 0
+    start: gt 0
+    isError: false
+    traceIds:
+      - not null

--- a/test/e2e/e2e-ttl/e2e-ttl-es7/pom.xml
+++ b/test/e2e/e2e-ttl/e2e-ttl-es7/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>e2e-ttl</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>e2e-ttl-es7</artifactId>
+
+    <properties>
+        <e2e.dist.directory>dist-for-ttl-es</e2e.dist.directory>
+        <e2e.container.version>1.2</e2e.container.version>
+        <elasticsearch.version>7.4.0</elasticsearch.version>
+        <e2e.container.name.prefix>skywalking-e2e-container-${build.id}-ttl-es</e2e.container.name.prefix>
+        <grpc.version>1.14.0</grpc.version>
+        <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
+        <protobuf-maven-plugin.version>0.5.0</protobuf-maven-plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>e2e-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+            <version>${grpc.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <containerNamePattern>%a-%t-%i</containerNamePattern>
+                    <imagePullPolicy>Always</imagePullPolicy>
+                    <images>
+                        <image>
+                            <name>elastic/elasticsearch:${elasticsearch.version}</name>
+                            <alias>${e2e.container.name.prefix}-elasticsearch</alias>
+                            <run>
+                                <ports>
+                                    <port>es.port:9200</port>
+                                </ports>
+                                <wait>
+                                    <http>
+                                        <url>http://localhost:${es.port}</url>
+                                        <method>GET</method>
+                                        <status>200</status>
+                                    </http>
+                                    <time>120000</time>
+                                </wait>
+                                <env>
+                                    <discovery.type>single-node</discovery.type>
+                                </env>
+                            </run>
+                        </image>
+                        <image>
+                            <name>skyapm/e2e-container:${e2e.container.version}</name>
+                            <alias>${e2e.container.name.prefix}</alias>
+                            <run>
+                                <env>
+                                    <MODE>standalone</MODE>
+                                    <SW_STORAGE_ES_CLUSTER_NODES>
+                                        ${e2e.container.name.prefix}-elasticsearch:9200
+                                    </SW_STORAGE_ES_CLUSTER_NODES>
+                                </env>
+                                <dependsOn>
+                                    <container>${e2e.container.name.prefix}-elasticsearch</container>
+                                </dependsOn>
+                                <ports>
+                                    <port>+webapp.host:webapp.port:8081</port>
+                                    <port>+oap.host:oap.port:11800</port>
+                                </ports>
+                                <links>
+                                    <link>${e2e.container.name.prefix}-elasticsearch</link>
+                                </links>
+                                <volumes>
+                                    <bind>
+                                        <volume>${sw.home}:/sw</volume>
+                                        <volume>${project.basedir}/src/docker/rc.d:/rc.d:ro</volume>
+                                        <volume>${project.basedir}/src/docker/es_storage.awk:/es_storage.awk</volume>
+                                    </bind>
+                                </volumes>
+                                <wait>
+                                    <log>SkyWalking e2e container is ready for tests</log>
+                                    <time>3000000</time>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+
+            <!-- set the system properties that can be used in test codes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <sw.webapp.host>${webapp.host}</sw.webapp.host>
+                        <sw.webapp.port>${webapp.port}</sw.webapp.port>
+                        <oap.host>${oap.host}</oap.host>
+                        <oap.port>${oap.port}</oap.port>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>${protobuf-maven-plugin.version}</version>
+                <configuration>
+                    <!--
+                      The version of protoc must match protobuf-java. If you don't depend on
+                      protobuf-java directly, you will be transitively depending on the
+                      protobuf-java version that grpc depends on.
+                    -->
+                    <protocArtifact>com.google.protobuf:protoc:3.3.0:exe:${os.detected.classifier}
+                    </protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.8.0:exe:${os.detected.classifier}
+                    </pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os-maven-plugin.version}</version>
+            </extension>
+        </extensions>
+    </build>
+
+</project>

--- a/test/e2e/e2e-ttl/e2e-ttl-es7/src/docker/es_storage.awk
+++ b/test/e2e/e2e-ttl/e2e-ttl-es7/src/docker/es_storage.awk
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/awk -f
+
+BEGIN {
+    in_storage_section=0;
+    in_storage_es_section=0;
+    in_storage_es7_section=0;
+    in_storage_h2_section=0;
+}
+
+{
+    if (in_storage_section == 0) {
+        in_storage_section=$0 ~ /^storage:$/
+    } else {
+        in_storage_section=$0 ~ /^(#|\s{2})/
+    }
+
+    if (in_storage_section == 1) {
+        # in the storage: section now
+        # disable h2 module
+        if (in_storage_es_section == 0) {
+            in_storage_es_section=$0 ~ /^#?\s+elasticsearch:$/
+        } else {
+            in_storage_es_section=$0 ~ /^#?\s{4}/
+        }
+        if (in_storage_es7_section == 0) {
+            in_storage_es7_section=$0 ~ /^#?\s+elasticsearch7:$/
+        } else {
+            in_storage_es7_section=$0 ~ /^#?\s{4}/
+        }
+        if (in_storage_h2_section == 0) {
+            in_storage_h2_section=$0 ~ /^#?\s+h2:$/
+        } else {
+            in_storage_h2_section=$0 ~ /^#?\s{4}/
+        }
+        if (in_storage_es7_section == 1) {
+            # in the storage.elasticsearch section now
+            # uncomment es config
+            gsub("^#", "", $0)
+            print
+        } else if (in_storage_h2_section == 1) {
+            # comment out h2 config
+            if ($0 !~ /^#/) {
+                print "#" $0
+            } else {
+                print
+            }
+        } else if (in_storage_es_section == 1) {
+            # comment out es config
+            if ($0 !~ /^#/) {
+                print "#" $0
+            } else {
+                print
+            }
+        } else {
+            print
+        }
+    } else {
+        print
+    }
+}
+

--- a/test/e2e/e2e-ttl/e2e-ttl-es7/src/docker/rc.d/rc0-prepare.sh
+++ b/test/e2e/e2e-ttl/e2e-ttl-es7/src/docker/rc.d/rc0-prepare.sh
@@ -1,0 +1,28 @@
+# Licensed to the SkyAPM under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+original_wd=$(pwd)
+
+# substitute application.yml to be capable of es mode
+cd ${SW_HOME}/config \
+    && awk -f /es_storage.awk application.yml > es_storage_app.yml \
+    && mv es_storage_app.yml application.yml \
+    && sed '/<Loggers>/a<logger name="org.apache.skywalking.oap.server.storage" level="DEBUG"/>' log4j2.xml > log4j2debuggable.xml \
+    && mv log4j2debuggable.xml log4j2.xml
+
+cd ${original_wd}

--- a/test/e2e/e2e-ttl/e2e-ttl-es7/src/docker/rc.d/rc1-startup.sh
+++ b/test/e2e/e2e-ttl/e2e-ttl-es7/src/docker/rc.d/rc1-startup.sh
@@ -1,0 +1,37 @@
+# Licensed to the SkyAPM under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+echo 'starting OAP server...' \
+    && SW_STORAGE_ES_BULK_ACTIONS=1 \
+    SW_CORE_DATA_KEEPER_EXECUTE_PERIOD=1 \
+    SW_STORAGE_ES_MONTH_METRIC_DATA_TTL=4 \
+    SW_STORAGE_ES_OTHER_METRIC_DATA_TTL=5 \
+    SW_STORAGE_ES_FLUSH_INTERVAL=1 \
+    SW_RECEIVER_BUFFER_PATH=/tmp/oap/trace_buffer1 \
+    SW_SERVICE_MESH_BUFFER_PATH=/tmp/oap/mesh_buffer1 \
+    start_oap 'init'
+
+echo 'starting Web app...' \
+    && start_webapp '0.0.0.0' 8081
+
+echo "SkyWalking e2e container is ready for tests"
+
+tail -f ${OAP_LOG_DIR}/* \
+        ${WEBAPP_LOG_DIR}/* \
+        ${ES_HOME}/logs/elasticsearch.log \
+        ${ES_HOME}/logs/stdout.log

--- a/test/e2e/e2e-ttl/e2e-ttl-es7/src/test/java/org/apache/skywalking/e2e/StorageTTLITCase.java
+++ b/test/e2e/e2e-ttl/e2e-ttl-es7/src/test/java/org/apache/skywalking/e2e/StorageTTLITCase.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.e2e;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.internal.DnsNameResolverProvider;
+import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.skywalking.apm.network.common.DetectPoint;
+import org.apache.skywalking.apm.network.servicemesh.MeshProbeDownstream;
+import org.apache.skywalking.apm.network.servicemesh.Protocol;
+import org.apache.skywalking.apm.network.servicemesh.ServiceMeshMetric;
+import org.apache.skywalking.apm.network.servicemesh.ServiceMeshMetricServiceGrpc;
+import org.apache.skywalking.e2e.metrics.AllOfMetricsMatcher;
+import org.apache.skywalking.e2e.metrics.AtLeastOneOfMetricsMatcher;
+import org.apache.skywalking.e2e.metrics.Metrics;
+import org.apache.skywalking.e2e.metrics.MetricsQuery;
+import org.apache.skywalking.e2e.metrics.MetricsValueMatcher;
+import org.apache.skywalking.e2e.service.Service;
+import org.apache.skywalking.e2e.service.ServicesQuery;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.apache.skywalking.e2e.metrics.MetricsQuery.SERVICE_P99;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author kezhenxu94
+ */
+@Slf4j
+public class StorageTTLITCase {
+    private static final int SW_STORAGE_ES_MONTH_METRIC_DATA_TTL = 4;
+    private static final int SW_STORAGE_ES_OTHER_METRIC_DATA_TTL = 5;
+
+    private static final int MAX_INBOUND_MESSAGE_SIZE = 1024 * 1024 * 50;
+    private static final boolean USE_PLAIN_TEXT = true;
+    private static final boolean SUCCESS = true;
+
+    private SimpleQueryClient queryClient;
+
+    private ServiceMeshMetricServiceGrpc.ServiceMeshMetricServiceStub grpcStub;
+
+    @Before
+    public void setUp() {
+
+        final String swWebappHost = System.getProperty("sw.webapp.host", "127.0.0.1");
+        final String swWebappPort = System.getProperty("sw.webapp.port", "32789");
+        final String oapPort = System.getProperty("oap.port", "32788");
+        queryClient = new SimpleQueryClient(swWebappHost, swWebappPort);
+
+        final ManagedChannelBuilder builder =
+            NettyChannelBuilder.forAddress("127.0.0.1", Integer.parseInt(oapPort))
+                .nameResolverFactory(new DnsNameResolverProvider())
+                .maxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE)
+                .usePlaintext(USE_PLAIN_TEXT);
+
+        final ManagedChannel channel = builder.build();
+
+        grpcStub = ServiceMeshMetricServiceGrpc.newStub(channel);
+    }
+
+    @Test(timeout = 360000)
+    public void dayMetricsDataShouldBeRemovedAfterTTL() throws Exception {
+
+        final ServiceMeshMetric.Builder builder = ServiceMeshMetric
+            .newBuilder()
+            .setSourceServiceName("e2e-test-source-service")
+            .setSourceServiceInstance("e2e-test-source-service-instance")
+            .setDestServiceName("e2e-test-dest-service")
+            .setDestServiceInstance("e2e-test-dest-service-instance")
+            .setEndpoint("e2e/test")
+            .setLatency(2000)
+            .setResponseCode(200)
+            .setStatus(SUCCESS)
+            .setProtocol(Protocol.HTTP)
+            .setDetectPoint(DetectPoint.server);
+
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDateTime startTime = now.minusDays(SW_STORAGE_ES_OTHER_METRIC_DATA_TTL + 1);
+        final LocalDateTime endTime = startTime.plusMinutes(1);
+
+        final LocalDateTime queryStart = startTime;
+        final LocalDateTime queryEnd = now.minusDays(SW_STORAGE_ES_OTHER_METRIC_DATA_TTL);
+
+        ensureSendingMetricsWorks(
+            builder,
+            startTime.toEpochSecond(ZoneOffset.UTC) * 1000,
+            endTime.toEpochSecond(ZoneOffset.UTC) * 1000,
+            queryStart,
+            queryEnd,
+            "DAY"
+        );
+
+        shouldBeEmptyBetweenTimeRange(queryStart, queryEnd, "DAY");
+    }
+
+    @Test(timeout = 360000)
+    public void monthMetricsDataShouldBeRemovedAfterTTL() throws Exception {
+
+        final ServiceMeshMetric.Builder builder = ServiceMeshMetric
+            .newBuilder()
+            .setSourceServiceName("e2e-test-source-service")
+            .setSourceServiceInstance("e2e-test-source-service-instance")
+            .setDestServiceName("e2e-test-dest-service")
+            .setDestServiceInstance("e2e-test-dest-service-instance")
+            .setEndpoint("e2e/test")
+            .setLatency(2000)
+            .setResponseCode(200)
+            .setStatus(SUCCESS)
+            .setProtocol(Protocol.HTTP)
+            .setDetectPoint(DetectPoint.server);
+
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDateTime startTime = now.minusMonths(SW_STORAGE_ES_MONTH_METRIC_DATA_TTL + 1);
+        final LocalDateTime endTime = startTime.plusMinutes(1);
+
+        final LocalDateTime queryStart = startTime;
+        final LocalDateTime queryEnd = now.minusMonths(SW_STORAGE_ES_MONTH_METRIC_DATA_TTL);
+
+        ensureSendingMetricsWorks(
+            builder,
+            startTime.toEpochSecond(ZoneOffset.UTC) * 1000,
+            endTime.toEpochSecond(ZoneOffset.UTC) * 1000,
+            queryStart,
+            queryEnd,
+            "MONTH"
+        );
+
+        shouldBeEmptyBetweenTimeRange(queryStart, queryEnd, "MONTH");
+    }
+
+    private void shouldBeEmptyBetweenTimeRange(
+        final LocalDateTime queryStart,
+        final LocalDateTime queryEnd,
+        final String step
+    ) throws InterruptedException {
+
+        boolean valid = false;
+        for (int i = 0; i < 10 && !valid; i++) {
+            try {
+                final Metrics serviceMetrics = queryMetrics(queryStart, queryEnd, step);
+
+                log.info("ServiceMetrics: {}", serviceMetrics);
+
+                AllOfMetricsMatcher instanceRespTimeMatcher = new AllOfMetricsMatcher();
+                MetricsValueMatcher equalsZero = new MetricsValueMatcher();
+                equalsZero.setValue("eq 0");
+                instanceRespTimeMatcher.setValue(equalsZero);
+                try {
+                    instanceRespTimeMatcher.verify(serviceMetrics);
+                    valid = true;
+                } catch (Throwable t) {
+                    log.warn("History metrics data are not deleted yet, {}", t.getMessage());
+                    Thread.sleep(60000);
+                }
+            } catch (Throwable t) {
+                log.warn("History metrics data are not deleted yet", t);
+                Thread.sleep(60000);
+            }
+        }
+    }
+
+    private void ensureSendingMetricsWorks(
+        final ServiceMeshMetric.Builder builder,
+        final long startTime,
+        final long endTime,
+        final LocalDateTime queryStart,
+        final LocalDateTime queryEnd,
+        final String step
+    ) throws Exception {
+
+        boolean prepared = false;
+        while (!prepared) {
+            sendMetrics(
+                builder
+                    .setStartTime(startTime)
+                    .setEndTime(endTime)
+                    .build()
+            );
+
+            final Metrics serviceMetrics = queryMetrics(queryStart, queryEnd, step);
+            final AtLeastOneOfMetricsMatcher instanceRespTimeMatcher = new AtLeastOneOfMetricsMatcher();
+            final MetricsValueMatcher greaterThanZero = new MetricsValueMatcher();
+            greaterThanZero.setValue("gt 0");
+            instanceRespTimeMatcher.setValue(greaterThanZero);
+            try {
+                instanceRespTimeMatcher.verify(serviceMetrics);
+                prepared = true;
+            } catch (Throwable ignored) {
+                sendMetrics(
+                    builder
+                        .setStartTime(startTime)
+                        .setEndTime(endTime)
+                        .build()
+                );
+                Thread.sleep(10000);
+            }
+        }
+    }
+
+    private Metrics queryMetrics(
+        final LocalDateTime queryStart,
+        final LocalDateTime queryEnd,
+        final String step
+    ) throws Exception {
+        for (int i = 0; i < 10; i++) {
+            try {
+                final List<Service> services = queryClient.services(
+                    new ServicesQuery()
+                        .start(LocalDateTime.now().minusDays(SW_STORAGE_ES_OTHER_METRIC_DATA_TTL))
+                        .end(LocalDateTime.now())
+                );
+
+                log.info("Services: {}", services);
+
+                assertThat(services).isNotEmpty();
+
+                String serviceId = services.stream().filter(it -> "e2e-test-dest-service".equals(it.getLabel())).findFirst().get().getKey();
+
+                return queryClient.metrics(
+                    new MetricsQuery()
+                        .id(serviceId)
+                        .metricsName(SERVICE_P99)
+                        .step(step)
+                        .start(queryStart)
+                        .end(queryEnd)
+                );
+            } catch (Throwable ignored) {
+                Thread.sleep(10000);
+            }
+        }
+        return null;
+    }
+
+    private void sendMetrics(final ServiceMeshMetric metrics) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        StreamObserver<ServiceMeshMetric> collect = grpcStub.collect(new StreamObserver<MeshProbeDownstream>() {
+            @Override
+            public void onNext(final MeshProbeDownstream meshProbeDownstream) {
+
+            }
+
+            @Override
+            public void onError(final Throwable throwable) {
+                throwable.printStackTrace();
+                latch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                latch.countDown();
+            }
+        });
+
+        collect.onNext(metrics);
+
+        collect.onCompleted();
+
+        latch.await();
+    }
+}

--- a/test/e2e/e2e-ttl/pom.xml
+++ b/test/e2e/e2e-ttl/pom.xml
@@ -31,6 +31,7 @@
     <packaging>pom</packaging>
     <modules>
         <module>e2e-ttl-es</module>
+        <module>e2e-ttl-es7</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

There're many users asking for support to ES7, #3047 #3187 #3000 #2529 , this PR tries to make the OAP backend work with ES7, without breaking the capabilities of ES6.

There're some breaking changes in ES7, since we are (and will) still using ES6-java-client, all the efforts are made by lower level REST client of ES.

In this PR, we don't use high level REST client to ES7, which is more convenient and is used in ES6 storage plugin, by using low level client, we can pass some parameters that ES6 doesn't support, such as `if_seq_no`, etc.

Some of the parameters are deprecated in ES7, but according to the upgrade strategy of ES, the deprecated parameters should work at least in all the minor versions under a major version, so there may be warnings in the log, but it does no harm, that's as was expected.

@wu-sheng Although the E2E tests passed (locally, and should be the same in Infra Jenkins), I'll propose to mark this as **Experimental** in the documentation for now, and invite some users to try and if the feedback is positive, we can make it **Stable** in the future version, documentations should be added later after fully discussed.

Anyone who wants to review this PR, please pay special attention to the ES6 storage plugin, this PR should not break the ES6 plugin in any aspect, thanks.