### PR TITLE
Makes the scope of alarm message more semantic.

### DIFF
--- a/docs/en/setup/backend/backend-alarm.md
+++ b/docs/en/setup/backend/backend-alarm.md
@@ -69,6 +69,7 @@ Webhook requires the peer is a web container. The alarm message will send throug
 - **name**. Target scope entity name.
 - **id0**. The ID of scope entity, matched the name.
 - **id1**. Not used today.
+- **ruleName**. The rule name you configured in `alarm-settings.yml`.
 - **alarmMessage**. Alarm text message.
 - **startTime**. Alarm time measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
 
@@ -80,7 +81,7 @@ Example as following
         "name": "serviceA", 
 	"id0": 12,  
 	"id1": 0,  
-    "ruleName": "service_resp_time_rule",
+        "ruleName": "service_resp_time_rule",
 	"alarmMessage": "alarmMessage xxxx",
 	"startTime": 1560524171000
 }, {
@@ -89,7 +90,7 @@ Example as following
         "name": "serviceB",
 	"id0": 23,
 	"id1": 0,
-    "ruleName": "service_resp_time_rule",
+        "ruleName": "service_resp_time_rule",
 	"alarmMessage": "alarmMessage yyy",
 	"startTime": 1560524171000
 }]

--- a/docs/en/setup/backend/backend-alarm.md
+++ b/docs/en/setup/backend/backend-alarm.md
@@ -76,16 +76,16 @@ Example as following
 ```json
 [{
 	"scopeId": 1, 
-    "scope": "SERVICE",
-    "name": "serviceA", 
+        "scope": "SERVICE",
+        "name": "serviceA", 
 	"id0": 12,  
 	"id1": 0,  
 	"alarmMessage": "alarmMessage xxxx",
 	"startTime": 1560524171000
 }, {
 	"scopeId": 1,
-    "scope": "SERVICE",
-    "name": "serviceB",
+        "scope": "SERVICE",
+        "name": "serviceB",
 	"id0": 23,
 	"id1": 0,
 	"alarmMessage": "alarmMessage yyy",

--- a/docs/en/setup/backend/backend-alarm.md
+++ b/docs/en/setup/backend/backend-alarm.md
@@ -65,7 +65,7 @@ Submit issue or pull request if you want to support any other scope in alarm.
 
 ## Webhook
 Webhook requires the peer is a web container. The alarm message will send through HTTP post by `application/json` content type. The JSON format is based on `List<org.apache.skywalking.oap.server.core.alarm.AlarmMessage` with following key information.
-- **scopeId**. All scopes are defined in org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.
+- **scopeId**, **scope**. All scopes are defined in org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.
 - **name**. Target scope entity name.
 - **id0**. The ID of scope entity, matched the name.
 - **id1**. Not used today.

--- a/docs/en/setup/backend/backend-alarm.md
+++ b/docs/en/setup/backend/backend-alarm.md
@@ -80,6 +80,7 @@ Example as following
         "name": "serviceA", 
 	"id0": 12,  
 	"id1": 0,  
+    "ruleName": "service_resp_time_rule",
 	"alarmMessage": "alarmMessage xxxx",
 	"startTime": 1560524171000
 }, {
@@ -88,6 +89,7 @@ Example as following
         "name": "serviceB",
 	"id0": 23,
 	"id1": 0,
+    "ruleName": "service_resp_time_rule",
 	"alarmMessage": "alarmMessage yyy",
 	"startTime": 1560524171000
 }]

--- a/docs/en/setup/backend/backend-alarm.md
+++ b/docs/en/setup/backend/backend-alarm.md
@@ -76,14 +76,16 @@ Example as following
 ```json
 [{
 	"scopeId": 1, 
-        "name": "serviceA", 
+    "scope": "SERVICE",
+    "name": "serviceA", 
 	"id0": 12,  
 	"id1": 0,  
 	"alarmMessage": "alarmMessage xxxx",
 	"startTime": 1560524171000
 }, {
 	"scopeId": 1,
-        "name": "serviceB",
+    "scope": "SERVICE",
+    "name": "serviceB",
 	"id0": 23,
 	"id1": 0,
 	"alarmMessage": "alarmMessage yyy",

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRule.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRule.java
@@ -152,6 +152,7 @@ public class RunningRule {
                 alarmMessage.setName(meta.getName());
                 alarmMessage.setId0(meta.getId0());
                 alarmMessage.setId1(meta.getId1());
+                alarmMessage.setRuleName(this.ruleName);
                 alarmMessage.setAlarmMessage(formatter.format(meta));
                 alarmMessage.setStartTime(System.currentTimeMillis());
                 alarmMessageList.add(alarmMessage);

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRule.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRule.java
@@ -148,6 +148,7 @@ public class RunningRule {
             AlarmMessage alarmMessage = window.checkAlarm();
             if (alarmMessage != AlarmMessage.NONE) {
                 alarmMessage.setScopeId(meta.getScopeId());
+                alarmMessage.setScope(meta.getScope());
                 alarmMessage.setName(meta.getName());
                 alarmMessage.setId0(meta.getId0());
                 alarmMessage.setId1(meta.getId1());

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmMessageFormatterTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmMessageFormatterTest.java
@@ -27,6 +27,10 @@ public class AlarmMessageFormatterTest {
         AlarmMessageFormatter formatter = new AlarmMessageFormatter("abc words {sdf");
         String message = formatter.format(new MetaInAlarm() {
 
+            @Override public String getScope() {
+                return "SERVICE";
+            }
+
             @Override public int getScopeId() {
                 return -1;
             }
@@ -55,6 +59,10 @@ public class AlarmMessageFormatterTest {
     public void testStringFormatWithArg() {
         AlarmMessageFormatter formatter = new AlarmMessageFormatter("abc} words {name} - {id} .. {");
         String message = formatter.format(new MetaInAlarm() {
+
+            @Override public String getScope() {
+                return "SERVICE";
+            }
 
             @Override public int getScopeId() {
                 return -1;

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandlerTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandlerTest.java
@@ -20,22 +20,44 @@ package org.apache.skywalking.oap.server.core.alarm.provider;
 
 import com.google.common.collect.Lists;
 import org.apache.skywalking.oap.server.core.CoreModule;
-import org.apache.skywalking.oap.server.core.alarm.*;
-import org.apache.skywalking.oap.server.core.analysis.metrics.*;
-import org.apache.skywalking.oap.server.core.cache.*;
-import org.apache.skywalking.oap.server.core.register.*;
+import org.apache.skywalking.oap.server.core.alarm.AlarmMessage;
+import org.apache.skywalking.oap.server.core.alarm.EndpointMetaInAlarm;
+import org.apache.skywalking.oap.server.core.alarm.MetaInAlarm;
+import org.apache.skywalking.oap.server.core.alarm.ServiceInstanceMetaInAlarm;
+import org.apache.skywalking.oap.server.core.alarm.ServiceMetaInAlarm;
+import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
+import org.apache.skywalking.oap.server.core.analysis.metrics.MetricsMetaInfo;
+import org.apache.skywalking.oap.server.core.analysis.metrics.WithMetadata;
+import org.apache.skywalking.oap.server.core.cache.EndpointInventoryCache;
+import org.apache.skywalking.oap.server.core.cache.ServiceInstanceInventoryCache;
+import org.apache.skywalking.oap.server.core.cache.ServiceInventoryCache;
+import org.apache.skywalking.oap.server.core.register.EndpointInventory;
+import org.apache.skywalking.oap.server.core.register.ServiceInstanceInventory;
+import org.apache.skywalking.oap.server.core.register.ServiceInventory;
 import org.apache.skywalking.oap.server.core.source.DefaultScopeDefine;
-import org.apache.skywalking.oap.server.library.module.*;
-import org.junit.*;
+import org.apache.skywalking.oap.server.library.module.ModuleManager;
+import org.apache.skywalking.oap.server.library.module.ModuleProviderHolder;
+import org.apache.skywalking.oap.server.library.module.ModuleServiceHolder;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.*;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
-import static junit.framework.TestCase.*;
-import static org.mockito.Mockito.*;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by dengming, 2019.04.22
@@ -97,6 +119,7 @@ public class NotifyHandlerTest {
 
         assertTrue(metaInAlarm instanceof EndpointMetaInAlarm);
         assertEquals(mockId, metaInAlarm.getId0());
+        assertEquals(DefaultScopeDefine.ENDPOINT_CATALOG_NAME, metaInAlarm.getScope());
         assertEquals(metricsName, metaInAlarm.getMetricsName());
         assertEquals(endpointInventoryName + " in " + serviceInventoryName, metaInAlarm.getName());
         assertEquals(DefaultScopeDefine.ENDPOINT, metaInAlarm.getScopeId());
@@ -129,6 +152,7 @@ public class NotifyHandlerTest {
         assertTrue(metaInAlarm instanceof ServiceInstanceMetaInAlarm);
         assertEquals(metricsName, metaInAlarm.getMetricsName());
         assertEquals(mockId, metaInAlarm.getId0());
+        assertEquals(DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME, metaInAlarm.getScope());
         assertEquals(instanceInventoryName, metaInAlarm.getName());
         assertEquals(DefaultScopeDefine.SERVICE_INSTANCE, metaInAlarm.getScopeId());
     }
@@ -157,6 +181,7 @@ public class NotifyHandlerTest {
         assertTrue(metaInAlarm instanceof ServiceMetaInAlarm);
         assertEquals(metricsName, metaInAlarm.getMetricsName());
         assertEquals(mockId, metaInAlarm.getId0());
+        assertEquals(DefaultScopeDefine.SERVICE_CATALOG_NAME, metaInAlarm.getScope());
         assertEquals(serviceInventoryName, metaInAlarm.getName());
         assertEquals(DefaultScopeDefine.SERVICE, metaInAlarm.getScopeId());
     }

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandlerTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandlerTest.java
@@ -130,7 +130,7 @@ public class NotifyHandlerTest {
         assertTrue(metaInAlarm instanceof ServiceInstanceMetaInAlarm);
         assertEquals(metricsName, metaInAlarm.getMetricsName());
         assertEquals(mockId, metaInAlarm.getId0());
-        assertEquals(DefaultScopeDefine.SERVICE_CATALOG_NAME, metaInAlarm.getScope());
+        assertEquals(DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME, metaInAlarm.getScope());
         assertEquals(instanceInventoryName, metaInAlarm.getName());
         assertEquals(DefaultScopeDefine.SERVICE_INSTANCE, metaInAlarm.getScopeId());
     }
@@ -159,7 +159,7 @@ public class NotifyHandlerTest {
         assertTrue(metaInAlarm instanceof ServiceMetaInAlarm);
         assertEquals(metricsName, metaInAlarm.getMetricsName());
         assertEquals(mockId, metaInAlarm.getId0());
-        assertEquals(DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME, metaInAlarm.getScope());
+        assertEquals(DefaultScopeDefine.SERVICE_CATALOG_NAME, metaInAlarm.getScope());
         assertEquals(serviceInventoryName, metaInAlarm.getName());
         assertEquals(DefaultScopeDefine.SERVICE, metaInAlarm.getScopeId());
     }

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandlerTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandlerTest.java
@@ -20,44 +20,22 @@ package org.apache.skywalking.oap.server.core.alarm.provider;
 
 import com.google.common.collect.Lists;
 import org.apache.skywalking.oap.server.core.CoreModule;
-import org.apache.skywalking.oap.server.core.alarm.AlarmMessage;
-import org.apache.skywalking.oap.server.core.alarm.EndpointMetaInAlarm;
-import org.apache.skywalking.oap.server.core.alarm.MetaInAlarm;
-import org.apache.skywalking.oap.server.core.alarm.ServiceInstanceMetaInAlarm;
-import org.apache.skywalking.oap.server.core.alarm.ServiceMetaInAlarm;
-import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
-import org.apache.skywalking.oap.server.core.analysis.metrics.MetricsMetaInfo;
-import org.apache.skywalking.oap.server.core.analysis.metrics.WithMetadata;
-import org.apache.skywalking.oap.server.core.cache.EndpointInventoryCache;
-import org.apache.skywalking.oap.server.core.cache.ServiceInstanceInventoryCache;
-import org.apache.skywalking.oap.server.core.cache.ServiceInventoryCache;
-import org.apache.skywalking.oap.server.core.register.EndpointInventory;
-import org.apache.skywalking.oap.server.core.register.ServiceInstanceInventory;
-import org.apache.skywalking.oap.server.core.register.ServiceInventory;
+import org.apache.skywalking.oap.server.core.alarm.*;
+import org.apache.skywalking.oap.server.core.analysis.metrics.*;
+import org.apache.skywalking.oap.server.core.cache.*;
+import org.apache.skywalking.oap.server.core.register.*;
 import org.apache.skywalking.oap.server.core.source.DefaultScopeDefine;
-import org.apache.skywalking.oap.server.library.module.ModuleManager;
-import org.apache.skywalking.oap.server.library.module.ModuleProviderHolder;
-import org.apache.skywalking.oap.server.library.module.ModuleServiceHolder;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.skywalking.oap.server.library.module.*;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.*;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static junit.framework.TestCase.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by dengming, 2019.04.22
@@ -152,7 +130,7 @@ public class NotifyHandlerTest {
         assertTrue(metaInAlarm instanceof ServiceInstanceMetaInAlarm);
         assertEquals(metricsName, metaInAlarm.getMetricsName());
         assertEquals(mockId, metaInAlarm.getId0());
-        assertEquals(DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME, metaInAlarm.getScope());
+        assertEquals(DefaultScopeDefine.SERVICE_CATALOG_NAME, metaInAlarm.getScope());
         assertEquals(instanceInventoryName, metaInAlarm.getName());
         assertEquals(DefaultScopeDefine.SERVICE_INSTANCE, metaInAlarm.getScopeId());
     }
@@ -181,7 +159,7 @@ public class NotifyHandlerTest {
         assertTrue(metaInAlarm instanceof ServiceMetaInAlarm);
         assertEquals(metricsName, metaInAlarm.getMetricsName());
         assertEquals(mockId, metaInAlarm.getId0());
-        assertEquals(DefaultScopeDefine.SERVICE_CATALOG_NAME, metaInAlarm.getScope());
+        assertEquals(DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME, metaInAlarm.getScope());
         assertEquals(serviceInventoryName, metaInAlarm.getName());
         assertEquals(DefaultScopeDefine.SERVICE, metaInAlarm.getScopeId());
     }

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRuleTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRuleTest.java
@@ -183,6 +183,10 @@ public class RunningRuleTest {
 
     private MetaInAlarm getMetaInAlarm(int id) {
         return new MetaInAlarm() {
+            @Override public String getScope() {
+                return "SERVICE";
+            }
+
             @Override public int getScopeId() {
                 return DefaultScopeDefine.SERVICE;
             }

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/WebhookCallbackTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/WebhookCallbackTest.java
@@ -87,9 +87,11 @@ public class WebhookCallbackTest implements Servlet {
         List<AlarmMessage> alarmMessages = new ArrayList<>(2);
         AlarmMessage alarmMessage = new AlarmMessage();
         alarmMessage.setScopeId(DefaultScopeDefine.ALL);
+        alarmMessage.setRuleName("service_resp_time_rule");
         alarmMessage.setAlarmMessage("alarmMessage with [DefaultScopeDefine.All]");
         alarmMessages.add(alarmMessage);
         AlarmMessage anotherAlarmMessage = new AlarmMessage();
+        anotherAlarmMessage.setRuleName("service_resp_time_rule_2");
         anotherAlarmMessage.setScopeId(DefaultScopeDefine.ENDPOINT);
         anotherAlarmMessage.setAlarmMessage("anotherAlarmMessage with [DefaultScopeDefine.Endpoint]");
         alarmMessages.add(anotherAlarmMessage);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/AlarmMessage.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/AlarmMessage.java
@@ -32,6 +32,7 @@ public class AlarmMessage {
     public static AlarmMessage NONE = new NoAlarm();
 
     private int scopeId;
+    private String scope;
     private String name;
     private int id0;
     private int id1;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/AlarmMessage.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/AlarmMessage.java
@@ -36,6 +36,7 @@ public class AlarmMessage {
     private String name;
     private int id0;
     private int id1;
+    private String ruleName;
     private String alarmMessage;
     private long startTime;
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/EndpointMetaInAlarm.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/EndpointMetaInAlarm.java
@@ -33,6 +33,10 @@ public class EndpointMetaInAlarm extends MetaInAlarm {
     private String[] tags;
     private String[] properties;
 
+    @Override public String getScope() {
+        return DefaultScopeDefine.ENDPOINT_CATALOG_NAME;
+    }
+
     @Override public int getScopeId() {
         return DefaultScopeDefine.ENDPOINT;
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/MetaInAlarm.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/MetaInAlarm.java
@@ -21,6 +21,9 @@ package org.apache.skywalking.oap.server.core.alarm;
 import java.util.Objects;
 
 public abstract class MetaInAlarm {
+
+    public abstract String getScope();
+
     public abstract int getScopeId();
 
     public abstract String getName();

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/ServiceInstanceMetaInAlarm.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/ServiceInstanceMetaInAlarm.java
@@ -31,6 +31,10 @@ public class ServiceInstanceMetaInAlarm extends MetaInAlarm {
     private String[] tags;
     private String[] properties;
 
+    @Override public String getScope() {
+        return DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
+    }
+
     @Override public int getScopeId() {
         return DefaultScopeDefine.SERVICE_INSTANCE;
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/ServiceMetaInAlarm.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/ServiceMetaInAlarm.java
@@ -31,6 +31,10 @@ public class ServiceMetaInAlarm extends MetaInAlarm {
     private String[] tags;
     private String[] properties;
 
+    @Override public String getScope() {
+        return DefaultScopeDefine.SERVICE_CATALOG_NAME;
+    }
+
     @Override public int getScopeId() {
         return DefaultScopeDefine.SERVICE;
     }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
resolves https://github.com/apache/skywalking/issues/3672
___
### Bug fix
- Bug description.

- How to fix?

```
{
	"scopeId": 1, 
        "scope": "SERVICE",
        "name": "serviceA", 
	"id0": 12,  
	"id1": 0,  
        "ruleName": "service_resp_time_rule",
	"alarmMessage": "alarmMessage xxxx",
	"startTime": 1560524171000
}
```
___
### New feature or improvement
- Describe the details and related test reports.
