### PR TITLE
Add docker:ulimits config

### DIFF
--- a/test/plugin/runner-helper/src/main/java/org/apache/skywalking/plugin/test/helper/DockerComposeRunningGenerator.java
+++ b/test/plugin/runner-helper/src/main/java/org/apache/skywalking/plugin/test/helper/DockerComposeRunningGenerator.java
@@ -105,6 +105,7 @@ public class DockerComposeRunningGenerator extends AbstractRunningGenerator {
             service.setEntrypoint(dependency.getEntrypoint());
             service.setHealthcheck(dependency.getHealthcheck());
             service.setEnvironment(dependency.getEnvironment());
+            service.setUlimits(dependency.getUlimits());
             services.add(service);
         });
         return services;

--- a/test/plugin/runner-helper/src/main/java/org/apache/skywalking/plugin/test/helper/vo/DependencyComponent.java
+++ b/test/plugin/runner-helper/src/main/java/org/apache/skywalking/plugin/test/helper/vo/DependencyComponent.java
@@ -17,6 +17,7 @@
 package org.apache.skywalking.plugin.test.helper.vo;
 
 import java.util.List;
+import java.util.Map;
 
 public class DependencyComponent {
     private String image;
@@ -28,6 +29,7 @@ public class DependencyComponent {
     private List<String> environment;
     private List<String> depends_on;
     private List<String> healthcheck;
+    private Map<String, Map<String, String>> ulimits;
 
     public String getImage() {
         return image;
@@ -99,5 +101,14 @@ public class DependencyComponent {
 
     public void setHealthcheck(List<String> healthcheck) {
         this.healthcheck = healthcheck;
+    }
+
+    public Map<String, Map<String, String>> getUlimits() {
+        return ulimits;
+    }
+
+    public void setUlimits(
+        Map<String, Map<String, String>> ulimits) {
+        this.ulimits = ulimits;
     }
 }

--- a/test/plugin/runner-helper/src/main/java/org/apache/skywalking/plugin/test/helper/vo/DockerService.java
+++ b/test/plugin/runner-helper/src/main/java/org/apache/skywalking/plugin/test/helper/vo/DockerService.java
@@ -17,6 +17,7 @@
 package org.apache.skywalking.plugin.test.helper.vo;
 
 import java.util.List;
+import java.util.Map;
 
 public class DockerService {
     private String name;
@@ -28,6 +29,7 @@ public class DockerService {
     private List<String> healthcheck;
     private List<String> depends_on;
     private List<String> environment;
+    private Map<String, Map<String, String>> ulimits;
 
     public String getName() {
         return name;
@@ -99,5 +101,14 @@ public class DockerService {
 
     public void setEnvironment(List<String> environment) {
         this.environment = environment;
+    }
+
+    public Map<String, Map<String, String>> getUlimits() {
+        return ulimits;
+    }
+
+    public void setUlimits(
+        Map<String, Map<String, String>> ulimits) {
+        this.ulimits = ulimits;
     }
 }

--- a/test/plugin/runner-helper/src/main/resources/docker-compose.template
+++ b/test/plugin/runner-helper/src/main/resources/docker-compose.template
@@ -69,6 +69,16 @@ services:
             - ${expose}
         </#list>
         </#if>
+        <#if service.ulimits??>
+        ulimits:
+        <#list service.ulimits?keys as key>
+            ${key}:
+                <#list service.ulimits[key]?keys as item>
+                ${item}: ${service.ulimits[key][item]}
+                </#list>
+        </#list>
+        </#if>
+
         <#if service.depends_on??>
         depends_on:
         <#list service.depends_on as item>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Support to configure the ulimit parameter of the Linux environment, such as maximum locked-in-memory address space (KB).
- this conf will be used in elasticsearch-5.x-scenario test.
ulimits:
      memlock:
        soft: -1
        hard: -1
      nofile:
        soft: 65536
        hard: 65536
