### PR TITLE
[CI] Run build jobs on different nodes parallelly

### DIFF
--- a/Jenkinsfile-E2E
+++ b/Jenkinsfile-E2E
@@ -16,134 +16,105 @@
  *
  */
 
-pipeline {
-    agent {
-        label 'skywalking'
+def version = '1.3'
+
+// Test cases for different JDK versions
+def jdk_cases = ['jdk8', 'jdk9', 'jdk11', 'jdk12'].collect {
+    [
+            "name"      : "Single Node Tests(${it.toUpperCase()})",
+            "e2eVersion": "$it-$version",
+            "moduleName": "e2e-single-service"
+    ]
+}
+
+// Test cases for features
+def feature_cases = [
+        [
+                "name"      : "Agent Reboot Tests(JDK8)",
+                "e2eVersion": "jdk8-$version",
+                "moduleName": "e2e-agent-reboot"
+        ], [
+                "name"      : "Cluster Tests (ES6/ZK/JDK8)",
+                "e2eVersion": "jdk8-$version",
+                "moduleName": "e2e-cluster/test-runner"
+        ], [
+                "name"      : "TTL ES Tests(JDK8)",
+                "e2eVersion": "jdk8-$version",
+                "moduleName": "e2e-ttl/e2e-ttl-es"
+        ]
+]
+
+def cases = jdk_cases + feature_cases
+
+node('skywalking') {
+    env.JAVA_HOME = "${tool 'JDK 1.8 (latest)'}"
+    env.MAVEN_OPTS = '-Dmaven.repo.local=.m2/repository -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
+
+    stage('Checkout Source Code') {
+        deleteDir()
+        checkout scm
+        sh 'git submodule update --init'
     }
 
-    options {
-        timestamps()
-        timeout(time: 5, unit: 'HOURS')
+    if (!sh(returnStatus: true, script: 'bash tools/ci/e2e-build-condition.sh')) {
+        echo 'Changed file sets do not match criteria, returning'
+        return
     }
 
-    tools {
-        jdk 'JDK 1.8 (latest)'
+    stage('Prepare Distribution Package') {
+        parallel(
+            'Check Codes': {
+                sh './mvnw -q checkstyle:check apache-rat:check'
+            },
+            'Build Dist Package': {
+                sh './mvnw -q -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests -am clean install'
+            },
+            'Compile Test Codes': {
+                sh './mvnw -q -f test/e2e/pom.xml -pl e2e-base clean install'
+            },
+            failFast: true
+        )
+        stash name: 'stashed', includes: 'dist/**,test/**,.mvn/**,mvnw'
     }
 
-    environment {
-        MAVEN_OPTS = '-Dmaven.repo.local=.m2/repository -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
+    stage('Run End-to-End Tests') {
+        parallel(cases.collectEntries {
+            [(it.name): buildStageOf(it)]
+        })
     }
+}
 
-    stages {
-        stage('Checkout Source Code') {
-            steps {
-                deleteDir()
-                checkout scm
-                sh 'git submodule update --init'
-            }
-        }
-
-        stage('Prepare Distribution Package') {
-            when {
-                expression {
-                    return sh(returnStatus: true, script: 'bash tools/ci/e2e-build-condition.sh')
-                }
-            }
-            steps {
-                // although these checks are done in ci-it, since they are lightweight/cheap
-                // we're using them as a barrier here to filter out some invalid PRs (fast-fail)
-                // thus save unnecessary E2E builds(which is expensive)
-                sh './mvnw checkstyle:check apache-rat:check'
-                sh './mvnw -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests clean install'
-            }
-        }
-
-        stage('Compile Test Codes') {
-            when {
-                expression {
-                    return sh(returnStatus: true, script: 'bash tools/ci/e2e-build-condition.sh')
-                }
-            }
-            steps {
-                sh './mvnw -f test/e2e/pom.xml -pl e2e-base clean install'
-            }
-        }
-
-        stage('Run End-to-End Tests') {
-            when {
-                expression {
-                    return sh(returnStatus: true, script: 'bash tools/ci/e2e-build-condition.sh')
-                }
-            }
-            parallel {
-                stage('Group 1') {
-                    stages {
-                        stage('Single Node Tests(JDK8)') {
-                            steps {
-                                sh 'E2E_VERSION=jdk8-1.3 bash -x test/e2e/run.sh e2e-single-service'
-                            }
-                        }
-
-                        stage('Single Node Tests(JDK9)') {
-                            steps {
-                                sh 'E2E_VERSION=jdk9-1.3 bash -x test/e2e/run.sh e2e-single-service'
-                            }
-                        }
-
-                        stage('Single Node Tests(JDK11)') {
-                            steps {
-                                sh 'E2E_VERSION=jdk11-1.3 bash -x test/e2e/run.sh e2e-single-service'
-                            }
-                        }
-
-                        stage('Single Node Tests(JDK12)') {
-                            steps {
-                                sh 'E2E_VERSION=jdk12-1.3 bash -x test/e2e/run.sh e2e-single-service'
-                            }
-                        }
-
-                        stage('Agent Reboot Tests(JDK8)') {
-                            steps {
-                                sh 'E2E_VERSION=jdk8-1.3 bash -x test/e2e/run.sh e2e-agent-reboot'
-                            }
-                        }
-                    }
-                }
-
-                stage('Group 2') {
-                    stages {
-                        stage('Cluster Tests (ES6/ZK/JDK8)') {
-                            steps {
-                                sh 'E2E_VERSION=jdk8-1.3 bash -x test/e2e/run.sh e2e-cluster/test-runner'
-                            }
-                        }
-
-                        stage('TTL ES Tests(JDK8)') {
-                            steps {
-                                sh 'E2E_VERSION=jdk8-1.3 bash -x test/e2e/run.sh e2e-ttl/e2e-ttl-es'
-                            }
-                        }
+def buildStageOf(testCase) {
+    return {
+        node('skywalking') {
+            stage(testCase.name) {
+                unstash 'stashed'
+                retry(2) {
+                    try {
+                        sh "E2E_VERSION=${testCase.e2eVersion} bash -x test/e2e/run.sh ${testCase.moduleName}"
+                    } finally {
+                        cleanUp(testCase)
                     }
                 }
             }
         }
     }
+}
 
-    post {
-        cleanup {
-            // "Abort old build on update" will interrupt the job completely,
-            // we need to clean up when there are containers started by the e2e tests
-            sh 'docker ps'
-            sh 'docker ps | grep -e "skywalking-e2e-container-${BUILD_ID}" | awk \'{print $1}\' | xargs --no-run-if-empty docker stop'
-            sh 'docker ps | grep -e "skywalking-e2e-container-${BUILD_ID}" | awk \'{print $1}\' | xargs --no-run-if-empty docker rm'
+def cleanUp(testCase) {
+    def testCaseName = testCase.moduleName.replace("/", "-")
+    // "Abort old build on update" will interrupt the job completely,
+    // we need to clean up when there are containers started by the e2e tests
+    sh "docker ps || true"
+    sh "docker stop \$(docker ps -aqf \"name=skywalking-e2e-container-${BUILD_ID}-${testCaseName}\") || true"
+    sh "docker rm   \$(docker ps -aqf \"name=skywalking-e2e-container-${BUILD_ID}-${testCaseName}\") || true"
 
-            // Files created by docker container in the directories that are mounted from the host to
-            // the container can not be deleted by `deleteDir()`, we need to mount it again and delete them
-            // inside the container
-            //
-            // Delete all distribution folder
-            sh 'docker run -v $(pwd):/sw alpine sh -c "sleep 10 && rm -rf /sw/dist-for-cluster/* /sw/dist-for-single-node-service/* /sw/dist-for-agent-reboot/* /sw/dist-for-ttl-es/*"'
-            deleteDir()
-        }
-    }
+    // Files created by docker container in the directories that are mounted from the host to
+    // the container can not be deleted by `deleteDir()`, we need to mount it again and delete them
+    // inside the container
+    //
+    // Delete all distribution folder
+    sh "docker run -v \$(pwd):/sw alpine sh -c \"sleep 10 && rm -rf /sw/${testCase.moduleName}/*\" || true"
+
+    deleteDir()
 }

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -60,7 +60,13 @@ do
   # so we give each test a separate distribution folder here
   mkdir -p "$test_case" && tar -zxf dist/apache-skywalking-apm-bin.tar.gz -C "$test_case"
 
-  ./mvnw -Dbuild.id="${BUILD_ID:-local}" -De2e.container.version="${E2E_VERSION}" -Dsw.home="${base_dir}/$test_case/apache-skywalking-apm-bin" -f test/e2e/pom.xml -pl "$test_case" -am verify
+  ./mvnw -Dbuild.id="${BUILD_ID:-local}" \
+         -De2e.container.version="${E2E_VERSION}" \
+         -Dsw.home="${base_dir}/$test_case/apache-skywalking-apm-bin" \
+         -De2e.container.name.prefix="skywalking-e2e-container-${BUILD_ID:-local}-${test_case////-}" \
+         -f test/e2e/pom.xml \
+         -pl "$test_case" \
+         -am verify
 
   status_code=$?
 


### PR DESCRIPTION
In this patch, I've made it to run multiple jobs parallelly on different Jenkins slave nodes, thus, our build jobs can be distributed more evenly to our VM nodes, and the VM with lower resources can also be scheduled fairly.

In this PR, I also rewrote the Jenkisfile with scripted Pipeline syntax, our previous syntax is DSL, it's much more human readable, but lack of flexibility in our complex scenarios, now we're using scripted syntax, based on Groovy, it provides a programmable ability, and flexibility, to simplify the Jenkinsfile, (from ~200 lines to ~100 lines)

Build time: ~18.5 min down to ~15.5 min, not a big deal, but it takes effects