### PR TITLE
Replace user wall to typical users in readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,24 @@ Follow this [document](docs/en/guides/How-to-build.md).
 * QQ Group: 392443393(2000/2000, not available), 901167865(available)
 
 # Who Uses SkyWalking?
-A wide variety of companies and organizations use SkyWalking for research, production and commercial product.
-Here is the **User Wall** of SkyWalking.
+Hundreds of companies and organizations use SkyWalking for research, production, and commercial product, including
+1. Alibaba Cloud
+1. China Eastern Airlines
+1. China Merchants Bank
+1. DaoCloud
+1. GOME
+1. guazi.com
+1. Huawei
+1. ke.com
+1. lizhi.fm
+1. tetrate.io
+1. WeBank
+1. Xiaomi
+1. Yonghui Superstores Co., Ltd
+1. zhaopin.com
 
-<img src="http://skywalking.apache.org/assets/users-20190422.png"/>
-
-Users are encouraged to add themselves to the [PoweredBy](docs/powered-by.md) page.
+The [PoweredBy](docs/powered-by.md) page includes more users of the project.
+Users are encouraged to add themselves to there.
 
 # Landscapes
 


### PR DESCRIPTION
With discussion at https://lists.apache.org/thread.html/2845e031a0627ee8e8ee0ee24c45833a600bbfac0833c25e4b8b9e54@%3Cdev.skywalking.apache.org%3E, we are replacing the old user wall, as it is very hard to keep updating. 

Full list only exists in powered by page and keep some typical users in README only.