### PR TITLE
Parameterize the cache size.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleConfig.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleConfig.java
@@ -58,6 +58,14 @@ public class CoreModuleConfig extends ModuleConfig {
      */
     @Setter private int remoteTimeout = 20;
 
+    /**
+     * Following are cache settings for inventory(s)
+     */
+    private long maxSizeOfServiceInventory = 10_000L;
+    private long maxSizeOfServiceInstanceInventory = 1_000_000L;
+    private long maxSizeOfEndpointInventory = 1_000_000L;
+    private long maxSizeOfNetworkInventory = 1_000_000L;
+
     CoreModuleConfig() {
         this.downsampling = new ArrayList<>();
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
@@ -141,16 +141,16 @@ public class CoreModuleProvider extends ModuleProvider {
         this.registerServiceImplementation(IModelGetter.class, storageModels);
         this.registerServiceImplementation(IModelOverride.class, storageModels);
 
-        this.registerServiceImplementation(ServiceInventoryCache.class, new ServiceInventoryCache(getManager()));
+        this.registerServiceImplementation(ServiceInventoryCache.class, new ServiceInventoryCache(getManager(), moduleConfig));
         this.registerServiceImplementation(IServiceInventoryRegister.class, new ServiceInventoryRegister(getManager()));
 
-        this.registerServiceImplementation(ServiceInstanceInventoryCache.class, new ServiceInstanceInventoryCache(getManager()));
+        this.registerServiceImplementation(ServiceInstanceInventoryCache.class, new ServiceInstanceInventoryCache(getManager(), moduleConfig));
         this.registerServiceImplementation(IServiceInstanceInventoryRegister.class, new ServiceInstanceInventoryRegister(getManager()));
 
-        this.registerServiceImplementation(EndpointInventoryCache.class, new EndpointInventoryCache(getManager()));
+        this.registerServiceImplementation(EndpointInventoryCache.class, new EndpointInventoryCache(getManager(), moduleConfig));
         this.registerServiceImplementation(IEndpointInventoryRegister.class, new EndpointInventoryRegister(getManager()));
 
-        this.registerServiceImplementation(NetworkAddressInventoryCache.class, new NetworkAddressInventoryCache(getManager()));
+        this.registerServiceImplementation(NetworkAddressInventoryCache.class, new NetworkAddressInventoryCache(getManager(), moduleConfig));
         this.registerServiceImplementation(INetworkAddressInventoryRegister.class, new NetworkAddressInventoryRegister(getManager()));
 
         this.registerServiceImplementation(TopologyQueryService.class, new TopologyQueryService(getManager()));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/cache/EndpointInventoryCache.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/cache/EndpointInventoryCache.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.core.cache;
 import com.google.common.cache.*;
 import java.util.Objects;
 import org.apache.skywalking.oap.server.core.Const;
+import org.apache.skywalking.oap.server.core.CoreModuleConfig;
 import org.apache.skywalking.oap.server.core.register.EndpointInventory;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.cache.IEndpointInventoryCacheDAO;
@@ -38,19 +39,24 @@ public class EndpointInventoryCache implements Service {
 
     private final ModuleManager moduleManager;
     private final EndpointInventory userEndpoint;
-    private final Cache<String, Integer> endpointNameCache = CacheBuilder.newBuilder().initialCapacity(5000).maximumSize(100000).build();
-
-    private final Cache<Integer, EndpointInventory> endpointIdCache = CacheBuilder.newBuilder().initialCapacity(5000).maximumSize(100000).build();
+    private final Cache<String, Integer> endpointNameCache;
+    private final Cache<Integer, EndpointInventory> endpointIdCache;
 
     private IEndpointInventoryCacheDAO cacheDAO;
 
-    public EndpointInventoryCache(ModuleManager moduleManager) {
+    public EndpointInventoryCache(ModuleManager moduleManager, CoreModuleConfig moduleConfig) {
         this.moduleManager = moduleManager;
 
         this.userEndpoint = new EndpointInventory();
         this.userEndpoint.setSequence(Const.USER_ENDPOINT_ID);
         this.userEndpoint.setName(Const.USER_CODE);
         this.userEndpoint.setServiceId(Const.USER_SERVICE_ID);
+
+        long initialSize = moduleConfig.getMaxSizeOfEndpointInventory() / 10L;
+        int initialCapacitySize = (int)(initialSize > Integer.MAX_VALUE ? Integer.MAX_VALUE : initialSize);
+
+        endpointNameCache = CacheBuilder.newBuilder().initialCapacity(initialCapacitySize).maximumSize(moduleConfig.getMaxSizeOfEndpointInventory()).build();
+        endpointIdCache = CacheBuilder.newBuilder().initialCapacity(initialCapacitySize).maximumSize(moduleConfig.getMaxSizeOfEndpointInventory()).build();
     }
 
     private IEndpointInventoryCacheDAO getCacheDAO() {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/cache/NetworkAddressInventoryCache.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/cache/NetworkAddressInventoryCache.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.core.cache;
 import com.google.common.cache.*;
 import java.util.Objects;
 import org.apache.skywalking.oap.server.core.Const;
+import org.apache.skywalking.oap.server.core.CoreModuleConfig;
 import org.apache.skywalking.oap.server.core.register.NetworkAddressInventory;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.cache.INetworkAddressInventoryCacheDAO;
@@ -36,14 +37,20 @@ public class NetworkAddressInventoryCache implements Service {
 
     private static final Logger logger = LoggerFactory.getLogger(NetworkAddressInventoryCache.class);
 
-    private final Cache<String, Integer> networkAddressCache = CacheBuilder.newBuilder().initialCapacity(1000).maximumSize(5000).build();
-    private final Cache<Integer, NetworkAddressInventory> addressIdCache = CacheBuilder.newBuilder().initialCapacity(1000).maximumSize(5000).build();
+    private final Cache<String, Integer> networkAddressCache;
+    private final Cache<Integer, NetworkAddressInventory> addressIdCache;
 
     private final ModuleManager moduleManager;
     private INetworkAddressInventoryCacheDAO cacheDAO;
 
-    public NetworkAddressInventoryCache(ModuleManager moduleManager) {
+    public NetworkAddressInventoryCache(ModuleManager moduleManager, CoreModuleConfig moduleConfig) {
         this.moduleManager = moduleManager;
+
+        long initialSize = moduleConfig.getMaxSizeOfNetworkInventory() / 10L;
+        int initialCapacitySize = (int)(initialSize > Integer.MAX_VALUE ? Integer.MAX_VALUE : initialSize);
+
+        networkAddressCache = CacheBuilder.newBuilder().initialCapacity(initialCapacitySize).maximumSize(moduleConfig.getMaxSizeOfNetworkInventory()).build();
+        addressIdCache = CacheBuilder.newBuilder().initialCapacity(initialCapacitySize).maximumSize(moduleConfig.getMaxSizeOfNetworkInventory()).build();
     }
 
     private INetworkAddressInventoryCacheDAO getCacheDAO() {


### PR DESCRIPTION
Get rid of static configurations of multiple caches. The initial size is always set as 1/10 of max size or the MAX value of Integer.