### PR TITLE
Use more specific ShardingSphere version to avoid compilation error

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-plugin/pom.xml
@@ -45,19 +45,19 @@
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-core-execute</artifactId>
-            <version>[4.0.0-RC1,5.0.0)</version>
+            <version>4.0.0-RC2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-jdbc-core</artifactId>
-            <version>[4.0.0-RC1,5.0.0)</version>
+            <version>4.0.0-RC2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-proxy-frontend-core</artifactId>
-            <version>[4.0.0-RC1,5.0.0)</version>
+            <version>4.0.0-RC2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

### Bug fix
- Bug description.

For now, the ShardingSphere plugin specifies a version range, but the class `org.apache.shardingsphere.core.route.router.sharding.ParsingSQLRouter` is removed in the coming release of ShardingSphere, after that, we'll encounter compilation error (javadoc:javadoc)

- How to fix?

Use more specific version, instead of version ranges

FYI, @tristaZero , the plugin won't support the new ShardingSphere release, and the plugin may need adjustment, welcome to contribute if you want :)