### PR TITLE
Enhance EtcdCoordinator if disconnected from etcd server for a long time

### DIFF
--- a/oap-server/server-cluster-plugin/cluster-etcd-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/etcd/EtcdCoordinator.java
+++ b/oap-server/server-cluster-plugin/cluster-etcd-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/etcd/EtcdCoordinator.java
@@ -34,6 +34,8 @@ import org.apache.skywalking.oap.server.core.cluster.RemoteInstance;
 import org.apache.skywalking.oap.server.core.cluster.ServiceRegisterException;
 import org.apache.skywalking.oap.server.core.remote.client.Address;
 import org.apache.skywalking.oap.server.telemetry.api.TelemetryRelatedContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Alan Lau
@@ -114,7 +116,6 @@ public class EtcdCoordinator implements ClusterRegister, ClusterNodesQuery {
             try {
                 client.refresh(key, KEY_TTL).send().get();
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
                 try {
                     client.put(key, json).ttl(KEY_TTL).send().get();
                 } catch (Exception ee) {

--- a/oap-server/server-cluster-plugin/cluster-etcd-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/etcd/EtcdCoordinator.java
+++ b/oap-server/server-cluster-plugin/cluster-etcd-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/etcd/EtcdCoordinator.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import mousio.client.retry.RetryNTimes;
 import mousio.etcd4j.EtcdClient;
 import mousio.etcd4j.promises.EtcdResponsePromise;
 import mousio.etcd4j.responses.EtcdKeysResponse;
@@ -40,6 +39,7 @@ import org.apache.skywalking.oap.server.telemetry.api.TelemetryRelatedContext;
  * @author Alan Lau
  */
 public class EtcdCoordinator implements ClusterRegister, ClusterNodesQuery {
+    private static final Logger logger = LoggerFactory.getLogger(EtcdCoordinator.class);
 
     private ClusterModuleEtcdConfig config;
 
@@ -114,12 +114,11 @@ public class EtcdCoordinator implements ClusterRegister, ClusterNodesQuery {
             try {
                 client.refresh(key, KEY_TTL).send().get();
             } catch (Exception e) {
+                logger.error(e.getMessage(), e);
                 try {
-                    client.put(key, json).ttl(KEY_TTL)
-                        .setRetryPolicy(new RetryNTimes(1, 10))
-                        .send()
-                        .get();
+                    client.put(key, json).ttl(KEY_TTL).send().get();
                 } catch (Exception ee) {
+                    logger.error(ee.getMessage(), ee);
                 }
             }
         }, 5 * 1000, 30 * 1000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
- Why submit this pull request?

when EtcdCoordinator cannot connect to etcd cluster for a long time, 
the information registered in etcd will expire and refresh() function will not work.

- How to fix?
When refresh() finds that the key does not exist, an exception is thrown, and we catch the exception to rewrite the registration information.

