### PR TITLE
ignore kryo ".reflectasm." class

### DIFF
--- a/apm-sniffer/apm-agent/src/main/java/org/apache/skywalking/apm/agent/SkyWalkingAgent.java
+++ b/apm-sniffer/apm-agent/src/main/java/org/apache/skywalking/apm/agent/SkyWalkingAgent.java
@@ -93,6 +93,7 @@ public class SkyWalkingAgent {
                     .or(nameStartsWith("org.groovy."))
                     .or(nameContains("javassist"))
                     .or(nameContains(".asm."))
+                    .or(nameContains(".reflectasm."))
                     .or(nameStartsWith("sun.reflect"))
                     .or(allSkyWalkingAgentExcludeToolkit())
                     .or(ElementMatchers.<TypeDescription>isSynthetic()));


### PR DESCRIPTION

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

When using kryo, Byte-buddy occurs exception when match type.

> java.lang.IllegalStateException: Cannot resolve type description for com.esotericsoftware.reflectasm.PublicConstructorAccess

- How to fix?

Config Byte-buddy to ignore ".reflectasm." class

BTW, it seems that as long as asm is involved, it cannot resolve the type description.
___
### New feature or improvement
- Describe the details and related test reports.
