### PR TITLE
[hotfix]Make kafka-scenario stable

### DIFF
--- a/test/plugin/containers/jvm-container/docker/run.sh
+++ b/test/plugin/containers/jvm-container/docker/run.sh
@@ -64,7 +64,7 @@ healthCheck http://localhost:12800/receiveData
 # start applications
 export agent_opts="-javaagent:${SCENARIO_HOME}/agent/skywalking-agent.jar
     -Dskywalking.collector.grpc_channel_check_interval=2
-    -Dskywalking.collector.app_and_service_register_check_interval=2
+    -Dskywalking.collector.app_and_service_register_check_interval=1
     -Dskywalking.collector.discovery_check_interval=2
     -Dskywalking.collector.backend_service=localhost:19876
     -Dskywalking.agent.service_name=${SCENARIO_NAME}

--- a/test/plugin/containers/tomcat-container/docker/catalina.sh
+++ b/test/plugin/containers/tomcat-container/docker/catalina.sh
@@ -109,7 +109,7 @@ echo "${AGENT_FILE_PATH}/skywalking-agent.jar"
 if [ -f "${AGENT_FILE_PATH}/skywalking-agent.jar" ]; then
     CATALINA_OPTS="$CATALINA_OPTS -javaagent:${AGENT_FILE_PATH}/skywalking-agent.jar
     -Dskywalking.collector.grpc_channel_check_interval=2
-    -Dskywalking.collector.app_and_service_register_check_interval=2
+    -Dskywalking.collector.app_and_service_register_check_interval=1
     -Dskywalking.collector.discovery_check_interval=2
     -Dskywalking.collector.backend_service=localhost:19876
     -Dskywalking.agent.service_name=${SCENARIO_NAME}

--- a/test/plugin/scenarios/kafka-scenario/configuration.yml
+++ b/test/plugin/scenarios/kafka-scenario/configuration.yml
@@ -36,5 +36,6 @@ dependencies:
       - KAFKA_BROKER_ID=1
       - ALLOW_PLAINTEXT_LISTENER=yes
       - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092
+      - KAFKA_CFG_LOG_FLUSH_INTERVAL_MS=1000
     depends_on:
       - zookeeper-server


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance


We found some ```kafka-scenario``` that failed due to the lack of ```operationNames```, so we try to shorten the refresh interval to solve this problem.

[failure-case1](https://builds.apache.org/blue/organizations/jenkins/skywalking-agent-test-workload-4/detail/skywalking-agent-test-workload-4/168/pipeline/113)
[failure-case2](https://builds.apache.org/blue/organizations/jenkins/skywalking-agent-test-workload-4/detail/skywalking-agent-test-workload-4/166/pipeline/113)
