### PR TITLE
Support ordered segment list in trace query

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TraceQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TraceQueryService.java
@@ -397,7 +397,7 @@ public class TraceQueryService implements Service {
          * 2. Lost in sampling, agent fail safe, segment lost, even bug.
          * Sorting the segments makes the trace view more readable.
          */
-        rootSpans.sort(Comparator.comparing(span -> new Long(span.getStartTime())));
+        rootSpans.sort(Comparator.comparing(span -> span.getStartTime()));
         return rootSpans;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TraceQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TraceQueryService.java
@@ -19,22 +19,38 @@
 package org.apache.skywalking.oap.server.core.query;
 
 import java.io.IOException;
-import java.util.*;
-import org.apache.skywalking.apm.network.language.agent.*;
-import org.apache.skywalking.apm.network.language.agent.v2.*;
-import org.apache.skywalking.oap.server.core.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.skywalking.apm.network.language.agent.SpanObject;
+import org.apache.skywalking.apm.network.language.agent.TraceSegmentObject;
+import org.apache.skywalking.apm.network.language.agent.UniqueId;
+import org.apache.skywalking.apm.network.language.agent.v2.SegmentObject;
+import org.apache.skywalking.apm.network.language.agent.v2.SpanObjectV2;
+import org.apache.skywalking.oap.server.core.Const;
+import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.manual.segment.SegmentRecord;
-import org.apache.skywalking.oap.server.core.cache.*;
+import org.apache.skywalking.oap.server.core.cache.EndpointInventoryCache;
+import org.apache.skywalking.oap.server.core.cache.NetworkAddressInventoryCache;
+import org.apache.skywalking.oap.server.core.cache.ServiceInventoryCache;
 import org.apache.skywalking.oap.server.core.config.IComponentLibraryCatalogService;
+import org.apache.skywalking.oap.server.core.query.entity.KeyValue;
+import org.apache.skywalking.oap.server.core.query.entity.LogEntity;
+import org.apache.skywalking.oap.server.core.query.entity.Pagination;
+import org.apache.skywalking.oap.server.core.query.entity.QueryOrder;
+import org.apache.skywalking.oap.server.core.query.entity.Ref;
 import org.apache.skywalking.oap.server.core.query.entity.RefType;
+import org.apache.skywalking.oap.server.core.query.entity.Span;
 import org.apache.skywalking.oap.server.core.query.entity.Trace;
-import org.apache.skywalking.oap.server.core.query.entity.*;
+import org.apache.skywalking.oap.server.core.query.entity.TraceBrief;
+import org.apache.skywalking.oap.server.core.query.entity.TraceState;
 import org.apache.skywalking.oap.server.core.register.EndpointInventory;
 import org.apache.skywalking.oap.server.core.register.ServiceInventory;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.query.ITraceQueryDAO;
+import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.module.Service;
-import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
 
 import static java.util.Objects.nonNull;
@@ -374,6 +390,12 @@ public class TraceQueryService implements Service {
                 rootSpans.add(span);
             }
         });
+        /**
+         * In some cases, there are segment fragments, which could not be linked by Ref,
+         * because of sampling, agent fail safe, segment lost, even bug.
+         * Sorting the segments makes the trace view more readable.
+         */
+        rootSpans.sort(Comparator.comparing(span -> new Long(span.getStartTime())));
         return rootSpans;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TraceQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TraceQueryService.java
@@ -392,7 +392,9 @@ public class TraceQueryService implements Service {
         });
         /**
          * In some cases, there are segment fragments, which could not be linked by Ref,
-         * because of sampling, agent fail safe, segment lost, even bug.
+         * because of two kinds of reasons.
+         * 1. Multiple leaf segments have no particular order in the storage.
+         * 2. Lost in sampling, agent fail safe, segment lost, even bug.
          * Sorting the segments makes the trace view more readable.
          */
         rootSpans.sort(Comparator.comparing(span -> new Long(span.getStartTime())));


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
Resolves #3844
___
### Bug fix
- Bug description.
In some cases, there are segment fragments, which could not be linked by Ref,
because of two kinds of reasons.
1. Multiple leaf segments have no particular order in the storage.
2. Lost in sampling, agent fail safe, segment lost, even bug.

- How to fix?
Sorting the segments makes the trace view more readable.

@bnubobby Is this fixing your issue?
