### PR TITLE
Move e2e and istio e2e to master and release recheck.

### DIFF
--- a/.github/workflows/ci-it.yaml
+++ b/.github/workflows/ci-it.yaml
@@ -22,7 +22,7 @@ on:
     branches: 
       - master
     tags:
-      - '*'
+      - 'v*'
     
 
 jobs:

--- a/.github/workflows/ci-it.yaml
+++ b/.github/workflows/ci-it.yaml
@@ -21,6 +21,8 @@ on:
   push:
     branches: 
       - master
+    tags:
+      - '*'
     
 
 jobs:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,11 @@
 
 name: E2E
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   Single:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
   Single:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,6 +21,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
 
 jobs:
   Single:

--- a/.github/workflows/istio-mixer-ci.yaml
+++ b/.github/workflows/istio-mixer-ci.yaml
@@ -23,6 +23,7 @@ on:
       - master
     tags:
       - 'v*'
+
 env:
   SCRIPTS_DIR: ./test/e2e-mesh/e2e-istio/scripts
   LOG_DIR: /tmp/skywalking

--- a/.github/workflows/istio-mixer-ci.yaml
+++ b/.github/workflows/istio-mixer-ci.yaml
@@ -22,7 +22,7 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - 'v*'
 env:
   SCRIPTS_DIR: ./test/e2e-mesh/e2e-istio/scripts
   LOG_DIR: /tmp/skywalking

--- a/.github/workflows/istio-mixer-ci.yaml
+++ b/.github/workflows/istio-mixer-ci.yaml
@@ -16,7 +16,11 @@
 
 name: istio-mixer-ci
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 env:
   SCRIPTS_DIR: ./test/e2e-mesh/e2e-istio/scripts
   LOG_DIR: /tmp/skywalking

--- a/.github/workflows/istio-mixer-ci.yaml
+++ b/.github/workflows/istio-mixer-ci.yaml
@@ -21,6 +21,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
 env:
   SCRIPTS_DIR: ./test/e2e-mesh/e2e-istio/scripts
   LOG_DIR: /tmp/skywalking


### PR DESCRIPTION
These important tests should be done after the merge, in case some unexpected scenarios happen. 
Also, with tag supports, the release check has been added.

This is release check when I push the `v6.5-test` tag, even it is not on master branch(most today's release tag is not on master branch), still tests are triggered.
![image](https://user-images.githubusercontent.com/5441976/70760189-d7ffac80-1d83-11ea-9209-7455138081bc.png)
