### PR TITLE
Remove client side endpoint register of service mesh

### DIFF
--- a/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/ServiceMeshMetricDataDecorator.java
+++ b/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/ServiceMeshMetricDataDecorator.java
@@ -95,22 +95,13 @@ public class ServiceMeshMetricDataDecorator {
         }
         String endpoint = origin.getEndpoint();
 
+        // Service mesh doesn't register client side endpoint.
         DetectPoint point = origin.getDetectPoint();
-        if (DetectPoint.client.equals(point)) {
-            if (sourceServiceId != Const.NONE) {
-                endpointId = CoreRegisterLinker.getEndpointInventoryRegister().getOrCreate(sourceServiceId, endpoint,
-                    org.apache.skywalking.oap.server.core.source.DetectPoint.fromNetworkProtocolDetectPoint(point));
-            }
-        } else {
+        if (DetectPoint.server.equals(point)) {
             if (destServiceId != Const.NONE) {
                 endpointId = CoreRegisterLinker.getEndpointInventoryRegister().getOrCreate(destServiceId, endpoint,
                     org.apache.skywalking.oap.server.core.source.DetectPoint.fromNetworkProtocolDetectPoint(point));
             }
-        }
-
-        if (endpointId != Const.NONE) {
-        } else {
-            isRegistered = false;
         }
 
         return isRegistered;


### PR DESCRIPTION
Since `TelemetryDataDispatcher#doDispatch` doesn't register client side endpoint, I remove it from `ServiceMeshMetricDataDecorator#tryMetaDataRegister`