### PR TITLE
Remove the local/exit span register mechanism in Java agent scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ OALLexer.tokens
 .vscode 
 .checkstyle
 .externalToolBuilders
+/test/plugin/dist
+/test/plugin/workspace

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@ Changes by Version
 ==================
 Release Notes.
 
+6.6.0
+------------------
+TODO
+
+#### Project
+- [**IMPORTANT**] Local span and exit span are not treated as endpoint detected at client and local. Only entry span is the endpoint. Reduce the load of register and memory cost.
+
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/37?closed=1)
+
 6.5.0
 ------------------
 
@@ -73,6 +82,8 @@ Release Notes.
 - Committer vote and set up document. (#3496)
 - Update als setup doc as istio 1.3 released (#3470)
 - Fill faq reply in official document. (#3450)
+
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/36?closed=1)
 
 
 6.4.0

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
@@ -317,11 +317,14 @@ public class Config {
          */
         public static class OPGroup {
             /**
-             * Rules for RestTemplate plugin
+             * Since 6.6.0, exit span is not requesting endpoint register,
+             * this group rule is not required.
+             *
+             * Keep this commented, just as a reminder that, it will be reused in a RPC server side plugin.
              */
-            public static class RestTemplate implements OPGroupDefinition {
-                public static Map<String, String> RULE = new HashMap<String, String>();
-            }
+//            public static class RestTemplate implements OPGroupDefinition {
+//                public static Map<String, String> RULE = new HashMap<String, String>();
+//            }
         }
 
         public static class Light4J {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -167,7 +167,6 @@ public class TracingContext implements AbstractTracerContext {
                  * Since 6.6.0, if first span is not entry span, then this is an internal segment(no RPC),
                  * rather than an endpoint.
                  */
-                carrier.setEntryEndpointId(DictionaryUtil.inexistence());
             }
         } else {
             carrier.setEntryEndpointId(operationId);

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -74,7 +74,7 @@ public class TracingContext implements AbstractTracerContext {
     /**
      * Active spans stored in a Stack, usually called 'ActiveSpanStack'. This {@link LinkedList} is the in-memory
      * storage-structure. <p> I use {@link LinkedList#removeLast()}, {@link LinkedList#addLast(Object)} and {@link
-     * LinkedList#last} instead of {@link #pop()}, {@link #push(AbstractSpan)}, {@link #peek()}
+     * LinkedList#getLast()} instead of {@link #pop()}, {@link #push(AbstractSpan)}, {@link #peek()}
      */
     private LinkedList<AbstractSpan> activeSpanStack = new LinkedList<AbstractSpan>();
 
@@ -131,34 +131,57 @@ public class TracingContext implements AbstractTracerContext {
         } else {
             carrier.setPeerId(peerId);
         }
+
+        AbstractSpan firstSpan = first();
+        String firstSpanOperationName = firstSpan.getOperationName();
+
         List<TraceSegmentRef> refs = this.segment.getRefs();
-        int operationId;
-        String operationName;
+        int operationId = DictionaryUtil.inexistence();
+        String operationName = "";
         int entryApplicationInstanceId;
+
         if (refs != null && refs.size() > 0) {
             TraceSegmentRef ref = refs.get(0);
             operationId = ref.getEntryEndpointId();
             operationName = ref.getEntryEndpointName();
             entryApplicationInstanceId = ref.getEntryServiceInstanceId();
         } else {
-            AbstractSpan firstSpan = first();
-            operationId = firstSpan.getOperationId();
-            operationName = firstSpan.getOperationName();
+            if (firstSpan.isEntry()) {
+                /**
+                 * Since 6.6.0, if first span is not entry span, then this is an internal segment(no RPC),
+                 * this is not an endpoint.
+                 */
+                operationId = firstSpan.getOperationId();
+                operationName = firstSpanOperationName;
+            }
             entryApplicationInstanceId = this.segment.getApplicationInstanceId();
+
         }
         carrier.setEntryServiceInstanceId(entryApplicationInstanceId);
 
         if (operationId == DictionaryUtil.nullValue()) {
             if (!StringUtil.isEmpty(operationName)) {
                 carrier.setEntryEndpointName(operationName);
+            } else {
+                /**
+                 * Since 6.6.0, if first span is not entry span, then this is an internal segment(no RPC),
+                 * this is not an endpoint.
+                 */
             }
         } else {
             carrier.setEntryEndpointId(operationId);
         }
 
-        int parentOperationId = first().getOperationId();
+        int parentOperationId = firstSpan.getOperationId();
         if (parentOperationId == DictionaryUtil.nullValue()) {
-            carrier.setParentEndpointName(first().getOperationName());
+            if (!StringUtil.isEmpty(firstSpanOperationName)) {
+                carrier.setParentEndpointName(firstSpanOperationName);
+            } else {
+                /**
+                 * Since 6.6.0, if first span is not entry span, then this is an internal segment(no RPC),
+                 * this is not an endpoint.
+                 */
+            }
         } else {
             carrier.setParentEndpointId(parentOperationId);
         }
@@ -341,39 +364,13 @@ public class TracingContext implements AbstractTracerContext {
                     new PossibleFound.FoundAndObtain() {
                         @Override
                         public Object doProcess(final int peerId) {
-                            return DictionaryManager.findEndpointSection()
-                                .findOnly(segment.getServiceId(), operationName)
-                                .doInCondition(
-                                    new PossibleFound.FoundAndObtain() {
-                                        @Override
-                                        public Object doProcess(int operationId) {
-                                            return new ExitSpan(spanIdGenerator++, parentSpanId, operationId, peerId);
-                                        }
-                                    }, new PossibleFound.NotFoundAndObtain() {
-                                        @Override
-                                        public Object doProcess() {
-                                            return new ExitSpan(spanIdGenerator++, parentSpanId, operationName, peerId);
-                                        }
-                                    });
+                            return new ExitSpan(spanIdGenerator++, parentSpanId, operationName, peerId);
                         }
                     },
                     new PossibleFound.NotFoundAndObtain() {
                         @Override
                         public Object doProcess() {
-                            return DictionaryManager.findEndpointSection()
-                                .findOnly(segment.getServiceId(), operationName)
-                                .doInCondition(
-                                    new PossibleFound.FoundAndObtain() {
-                                        @Override
-                                        public Object doProcess(int operationId) {
-                                            return new ExitSpan(spanIdGenerator++, parentSpanId, operationId, remotePeer);
-                                        }
-                                    }, new PossibleFound.NotFoundAndObtain() {
-                                        @Override
-                                        public Object doProcess() {
-                                            return new ExitSpan(spanIdGenerator++, parentSpanId, operationName, remotePeer);
-                                        }
-                                    });
+                            return new ExitSpan(spanIdGenerator++, parentSpanId, operationName, remotePeer);
                         }
                     });
             push(exitSpan);

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/dictionary/DictionaryUtil.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/dictionary/DictionaryUtil.java
@@ -30,4 +30,11 @@ public class DictionaryUtil {
     public static boolean isNull(int id) {
         return id == nullValue();
     }
+
+    /**
+     * @return -1 represent the object doesn't exist.
+     */
+    public static int inexistence() {
+        return -1;
+    }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/dictionary/EndpointNameDictionary.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/dictionary/EndpointNameDictionary.java
@@ -37,21 +37,20 @@ public enum EndpointNameDictionary {
     private Map<OperationNameKey, Integer> endpointDictionary = new ConcurrentHashMap<OperationNameKey, Integer>();
     private Set<OperationNameKey> unRegisterEndpoints = new ConcurrentSet<OperationNameKey>();
 
-    public PossibleFound findOrPrepare4Register(int serviceId, String endpointName,
-        boolean isEntry, boolean isExit) {
-        return find0(serviceId, endpointName, isEntry, isExit, true);
+    public PossibleFound findOrPrepare4Register(int serviceId, String endpointName) {
+        return find0(serviceId, endpointName, true);
     }
 
     public PossibleFound findOnly(int serviceId, String endpointName) {
-        return find0(serviceId, endpointName, false, false, false);
+        return find0(serviceId, endpointName, false);
     }
 
     private PossibleFound find0(int serviceId, String endpointName,
-        boolean isEntry, boolean isExit, boolean registerWhenNotFound) {
+        boolean registerWhenNotFound) {
         if (endpointName == null || endpointName.length() == 0) {
             return new NotFound();
         }
-        OperationNameKey key = new OperationNameKey(serviceId, endpointName, isEntry, isExit);
+        OperationNameKey key = new OperationNameKey(serviceId, endpointName);
         Integer operationId = endpointDictionary.get(key);
         if (operationId != null) {
             return new Found(operationId);
@@ -72,7 +71,7 @@ public enum EndpointNameDictionary {
                 Endpoint endpoint = Endpoint.newBuilder()
                     .setServiceId(operationNameKey.getServiceId())
                     .setEndpointName(operationNameKey.getEndpointName())
-                    .setFrom(operationNameKey.getSpanType())
+                    .setFrom(DetectPoint.server)
                     .build();
                 builder.addEndpoints(endpoint);
             }
@@ -81,9 +80,7 @@ public enum EndpointNameDictionary {
                 for (EndpointMappingElement element : serviceNameMappingCollection.getElementsList()) {
                     OperationNameKey key = new OperationNameKey(
                         element.getServiceId(),
-                        element.getEndpointName(),
-                        DetectPoint.server.equals(element.getFrom()),
-                        DetectPoint.client.equals(element.getFrom()));
+                        element.getEndpointName());
                     unRegisterEndpoints.remove(key);
                     endpointDictionary.put(key, element.getEndpointId());
                 }
@@ -98,14 +95,10 @@ public enum EndpointNameDictionary {
     private class OperationNameKey {
         private int serviceId;
         private String endpointName;
-        private boolean isEntry;
-        private boolean isExit;
 
-        public OperationNameKey(int serviceId, String endpointName, boolean isEntry, boolean isExit) {
+        public OperationNameKey(int serviceId, String endpointName) {
             this.serviceId = serviceId;
             this.endpointName = endpointName;
-            this.isEntry = isEntry;
-            this.isExit = isExit;
         }
 
         public int getServiceId() {
@@ -128,8 +121,7 @@ public enum EndpointNameDictionary {
             if (serviceId == key.serviceId && endpointName.equals(key.endpointName)) {
                 isServiceEndpointMatch = true;
             }
-            return isServiceEndpointMatch && isEntry == key.isEntry
-                && isExit == key.isExit;
+            return isServiceEndpointMatch;
         }
 
         @Override public int hashCode() {
@@ -138,30 +130,11 @@ public enum EndpointNameDictionary {
             return result;
         }
 
-        boolean isEntry() {
-            return isEntry;
-        }
-
-        boolean isExit() {
-            return isExit;
-        }
-
-        DetectPoint getSpanType() {
-            if (isEntry) {
-                return DetectPoint.server;
-            } else if (isExit) {
-                return DetectPoint.client;
-            } else {
-                return DetectPoint.UNRECOGNIZED;
-            }
-        }
 
         @Override public String toString() {
             return "OperationNameKey{" +
                 "serviceId=" + serviceId +
                 ", endpointName='" + endpointName + '\'' +
-                ", isEntry=" + isEntry +
-                ", isExit=" + isExit +
                 '}';
         }
     }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/async/RestExecuteInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/async/RestExecuteInterceptor.java
@@ -20,12 +20,9 @@ package org.apache.skywalking.apm.plugin.spring.resttemplate.async;
 
 import java.lang.reflect.Method;
 import java.net.URI;
-import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
-import org.apache.skywalking.apm.agent.core.conf.Config;
 import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
 import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
-import org.apache.skywalking.apm.agent.core.context.OperationNameFormatService;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
@@ -37,8 +34,6 @@ import org.apache.skywalking.apm.plugin.spring.commons.EnhanceCacheObjects;
 import org.springframework.http.HttpMethod;
 
 public class RestExecuteInterceptor implements InstanceMethodsAroundInterceptor {
-    private OperationNameFormatService nameFormatService;
-
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         MethodInterceptResult result) throws Throwable {
@@ -46,13 +41,9 @@ public class RestExecuteInterceptor implements InstanceMethodsAroundInterceptor 
         final HttpMethod httpMethod = (HttpMethod)allArguments[1];
         final ContextCarrier contextCarrier = new ContextCarrier();
 
-        if (nameFormatService == null) {
-            nameFormatService = ServiceManager.INSTANCE.findService(OperationNameFormatService.class);
-        }
-
         String remotePeer = requestURL.getHost() + ":" + (requestURL.getPort() > 0 ? requestURL.getPort() : "https".equalsIgnoreCase(requestURL.getScheme()) ? 443 : 80);
 
-        String formatURIPath = nameFormatService.formatOperationName(Config.Plugin.OPGroup.RestTemplate.class, requestURL.getPath());
+        String formatURIPath = requestURL.getPath();
         AbstractSpan span = ContextManager.createExitSpan(
             formatURIPath,
             contextCarrier, remotePeer);

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/sync/RestExecuteInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/sync/RestExecuteInterceptor.java
@@ -20,23 +20,18 @@ package org.apache.skywalking.apm.plugin.spring.resttemplate.sync;
 
 import java.lang.reflect.Method;
 import java.net.URI;
-import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
-import org.apache.skywalking.apm.agent.core.conf.Config;
 import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
-import org.apache.skywalking.apm.agent.core.context.OperationNameFormatService;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
-import org.apache.skywalking.apm.agent.core.context.ContextManager;
-import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.springframework.http.HttpMethod;
 
 public class RestExecuteInterceptor implements InstanceMethodsAroundInterceptor {
-    private OperationNameFormatService nameFormatService;
-
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         MethodInterceptResult result) throws Throwable {
@@ -44,12 +39,8 @@ public class RestExecuteInterceptor implements InstanceMethodsAroundInterceptor 
         final HttpMethod httpMethod = (HttpMethod)allArguments[1];
         final ContextCarrier contextCarrier = new ContextCarrier();
 
-        if (nameFormatService == null) {
-            nameFormatService = ServiceManager.INSTANCE.findService(OperationNameFormatService.class);
-        }
-
         String remotePeer = requestURL.getHost() + ":" + (requestURL.getPort() > 0 ? requestURL.getPort() : "https".equalsIgnoreCase(requestURL.getScheme()) ? 443 : 80);
-        String formatURIPath = nameFormatService.formatOperationName(Config.Plugin.OPGroup.RestTemplate.class, requestURL.getPath());
+        String formatURIPath = requestURL.getPath();
         AbstractSpan span = ContextManager.createExitSpan(formatURIPath, contextCarrier, remotePeer);
 
         span.setComponent(ComponentsDefine.SPRING_REST_TEMPLATE);

--- a/docs/en/FAQ/README.md
+++ b/docs/en/FAQ/README.md
@@ -18,3 +18,4 @@ These are known and common FAQs. We welcome you to contribute yours.
 * [IllegalStateException when install Java agent on WebSphere 7](install_agent_on_websphere.md)
 * ["FORBIDDEN/12/index read-only / allow delete (api)" appears in the log](https://discuss.elastic.co/t/forbidden-12-index-read-only-allow-delete-api/110282)
 * [No data shown and backend replies with "Variable 'serviceId' has coerced Null value for NonNull type 'ID!'"](time-and-timezone.md)
+* [**Unexpected endpoint register** warning after 6.6.0](Unexpected-endpoint-register.md)

--- a/docs/en/FAQ/Unexpected-endpoint-register.md
+++ b/docs/en/FAQ/Unexpected-endpoint-register.md
@@ -1,0 +1,12 @@
+# Local span and Exit span should not be register
+
+Since 6.6.0, SkyWalking cancelled the local span and exit span register. If old java agent(before 6.6.0) is still running,
+and do register to 6.6.0+ backend, you will face the following warning message.
+```
+class=RegisterServiceHandler, message = Unexpected endpoint register, endpoint isn't detected from server side.
+```
+
+This will not harm the backend or cause any issue. This is a reminder that, your agent or other client should follow the new protocol
+requirements.
+
+You could simply use `log4j2.xml` to filter this warning message out.

--- a/docs/en/guides/Plugin-test.md
+++ b/docs/en/guides/Plugin-test.md
@@ -230,7 +230,7 @@ registryItems:
 | --- | ---
 | applications | The registered service codes. Normally, not 0 should be enough.
 | instances | The number of service instances exists in this test case.
-| operationNames | All endpoint registered in this test case. Also means, the operation names of all entry and exit spans.
+| operationNames | All endpoint registered in this test case. Also means, the operation names of all entry spans.
 
 
 **Segment verify description format**

--- a/docs/en/protocols/Skywalking-Cross-Process-Propagation-Headers-Protocol-v2.md
+++ b/docs/en/protocols/Skywalking-Cross-Process-Propagation-Headers-Protocol-v2.md
@@ -38,6 +38,8 @@ _This value can use exchange/compress collector service to get the id(integer) t
 1. Parent endpoint of the parent service. **String(BASE64 encoded)**. 
 _This value can use exchange/compress collector service to get the id(integer) to represent the string. If you use the string, it must start with `#`, others use integer directly._
 
+endpoint id = -1 and parent endpoint name is empty mean there is no real parent endpoint. Since 6.6.0
+
 ## Sample values
 1. Short version, `1-TRACEID-SEGMENTID-3-5-2-IPPORT`
 1. Complete version, `1-TRACEID-SEGMENTID-3-5-2-IPPORT-ENTRYURI-PARENTURI`

--- a/docs/en/setup/service-agent/java-agent/README.md
+++ b/docs/en/setup/service-agent/java-agent/README.md
@@ -158,6 +158,9 @@ Now, we have the following known bootstrap plugins.
 SkyWalking java agent supports plugin to extend [the supported list](Supported-list.md). Please follow 
 our [Plugin Development Guide](../../../guides/Java-Plugin-Development-Guide.md).
 
+If some RPC framework endpoints(server side) could include parameter, please read [Operation Name Group Rule](op_name_group_rule.md),
+and consider to add this feature.
+
 # Test
 If you are interested in plugin compatible tests or agent performance, see the following reports.
 * [Plugin Test](https://github.com/SkyAPMTest/agent-integration-test-report)

--- a/docs/en/setup/service-agent/java-agent/op_name_group_rule.md
+++ b/docs/en/setup/service-agent/java-agent/op_name_group_rule.md
@@ -4,8 +4,7 @@ Those operation name are also as known endpoint name in most cases.
 Such as /api/checkTicket/tk/{userToken}.
 
 We solved most of these cases, by leverage the parameter pattern path in framework, such as SpringMVC, Webflux, etc. 
-But it is undetected in RPC client side, such as HTTP restful client.
-In this case, we have to ask the users to set the group rule manually.
+In this case, it is undetected in this way, so we have to ask the users to set the group rule manually.
 
 All rules are supported to set through agent.config, system properties and system env, like other agent settings.
 - Config format, `plugin.opgroup.`plugin name`.rule[`rule name`]`=pattern regex expression

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/Const.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/Const.java
@@ -32,6 +32,7 @@ public class Const {
     public static final int USER_SERVICE_ID = 1;
     public static final int USER_INSTANCE_ID = 1;
     public static final int USER_ENDPOINT_ID = 1;
+    public static final int INEXISTENCE_ENDPOINT_ID = -1;
     public static final String USER_CODE = "User";
     public static final String SEGMENT_SPAN_SPLIT = "S";
     public static final String UNKNOWN = "Unknown";

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v6/grpc/RegisterServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v6/grpc/RegisterServiceHandler.java
@@ -163,14 +163,19 @@ public class RegisterServiceHandler extends RegisterGrpc.RegisterImplBase implem
             int serviceId = endpoint.getServiceId();
             String endpointName = endpoint.getEndpointName();
 
-            int endpointId = inventoryService.getOrCreate(serviceId, endpointName, DetectPoint.fromNetworkProtocolDetectPoint(endpoint.getFrom()));
+            DetectPoint detectPoint = DetectPoint.fromNetworkProtocolDetectPoint(endpoint.getFrom());
+            if (DetectPoint.SERVER.equals(detectPoint)) {
+                int endpointId = inventoryService.getOrCreate(serviceId, endpointName, detectPoint);
 
-            if (endpointId != Const.NONE) {
-                builder.addElements(EndpointMappingElement.newBuilder()
-                    .setServiceId(serviceId)
-                    .setEndpointName(endpointName)
-                    .setEndpointId(endpointId)
-                    .setFrom(endpoint.getFrom()));
+                if (endpointId != Const.NONE) {
+                    builder.addElements(EndpointMappingElement.newBuilder()
+                        .setServiceId(serviceId)
+                        .setEndpointName(endpointName)
+                        .setEndpointId(endpointId)
+                        .setFrom(endpoint.getFrom()));
+                }
+            } else {
+                logger.warn("Unexpected endpoint register, endpoint isn't detected from server side. {}", request);
             }
         });
 

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/SegmentParse.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/SegmentParse.java
@@ -141,7 +141,7 @@ public class SegmentParse {
         for (int i = 0; i < segmentDecorator.getSpansCount(); i++) {
             SpanDecorator spanDecorator = segmentDecorator.getSpans(i);
 
-            if (!SpanIdExchanger.getInstance(moduleManager).exchange(spanDecorator, segmentCoreInfo.getServiceId())) {
+            if (!SpanExchanger.getInstance(moduleManager).exchange(spanDecorator, segmentCoreInfo.getServiceId())) {
                 exchanged = false;
             } else {
                 for (int j = 0; j < spanDecorator.getRefsCount(); j++) {

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/SegmentParseV2.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/SegmentParseV2.java
@@ -158,7 +158,7 @@ public class SegmentParseV2 {
         for (int i = 0; i < segmentDecorator.getSpansCount(); i++) {
             SpanDecorator spanDecorator = segmentDecorator.getSpans(i);
 
-            if (!SpanIdExchanger.getInstance(moduleManager).exchange(spanDecorator, segmentCoreInfo.getServiceId())) {
+            if (!SpanExchanger.getInstance(moduleManager).exchange(spanDecorator, segmentCoreInfo.getServiceId())) {
                 exchanged = false;
             } else {
                 for (int j = 0; j < spanDecorator.getRefsCount(); j++) {

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/endpoint/MultiScopesSpanListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/endpoint/MultiScopesSpanListener.java
@@ -106,7 +106,11 @@ public class MultiScopesSpanListener implements EntrySpanListener, ExitSpanListe
             for (int i = 0; i < spanDecorator.getRefsCount(); i++) {
                 ReferenceDecorator reference = spanDecorator.getRefs(i);
                 SourceBuilder sourceBuilder = new SourceBuilder();
-                sourceBuilder.setSourceEndpointId(reference.getParentEndpointId());
+                if (reference.getParentEndpointId() == Const.INEXISTENCE_ENDPOINT_ID) {
+                    sourceBuilder.setSourceEndpointId(Const.USER_ENDPOINT_ID);
+                } else {
+                    sourceBuilder.setSourceEndpointId(reference.getParentEndpointId());
+                }
 
                 final int networkAddressId = reference.getNetworkAddressId();
                 final int serviceIdByPeerId = serviceInventoryCache.getServiceId(networkAddressId);
@@ -161,10 +165,8 @@ public class MultiScopesSpanListener implements EntrySpanListener, ExitSpanListe
         int destInstanceId = instanceInventoryCache.getServiceInstanceId(destServiceId, peerId);
         int mappingServiceInstanceId = instanceInventoryCache.get(destInstanceId).getMappingServiceInstanceId();
 
-        sourceBuilder.setSourceEndpointId(Const.USER_ENDPOINT_ID);
         sourceBuilder.setSourceServiceInstanceId(segmentCoreInfo.getServiceInstanceId());
         sourceBuilder.setSourceServiceId(segmentCoreInfo.getServiceId());
-        sourceBuilder.setDestEndpointId(spanDecorator.getOperationNameId());
         if (Const.NONE == mappingServiceId) {
             sourceBuilder.setDestServiceId(destServiceId);
         } else {
@@ -235,10 +237,14 @@ public class MultiScopesSpanListener implements EntrySpanListener, ExitSpanListe
 
         sourceBuilder.setSourceServiceName(serviceInventoryCache.get(sourceBuilder.getSourceServiceId()).getName());
         sourceBuilder.setSourceServiceInstanceName(instanceInventoryCache.get(sourceBuilder.getSourceServiceInstanceId()).getName());
-        sourceBuilder.setSourceEndpointName(endpointInventoryCache.get(sourceBuilder.getSourceEndpointId()).getName());
+        if (sourceBuilder.getSourceEndpointId() != Const.NONE) {
+            sourceBuilder.setSourceEndpointName(endpointInventoryCache.get(sourceBuilder.getSourceEndpointId()).getName());
+        }
         sourceBuilder.setDestServiceName(serviceInventoryCache.get(sourceBuilder.getDestServiceId()).getName());
         sourceBuilder.setDestServiceInstanceName(instanceInventoryCache.get(sourceBuilder.getDestServiceInstanceId()).getName());
-        sourceBuilder.setDestEndpointName(endpointInventoryCache.get(sourceBuilder.getDestEndpointId()).getName());
+        if (sourceBuilder.getDestEndpointId() != Const.NONE) {
+            sourceBuilder.setDestEndpointName(endpointInventoryCache.get(sourceBuilder.getDestEndpointId()).getName());
+        }
     }
 
     @Override public void build() {
@@ -255,6 +261,9 @@ public class MultiScopesSpanListener implements EntrySpanListener, ExitSpanListe
              * Parent endpoint could be none, because in SkyWalking Cross Process Propagation Headers Protocol v2,
              * endpoint in ref could be empty, based on that, endpoint relation maybe can't be established.
              * So, I am making this source as optional.
+             *
+             * Also, since 6.6.0, source endpoint could be none, if this trace begins by an internal task(local span or exit span), such as Timer,
+             * rather than, normally begin as an entry span, like a RPC server side.
              */
             if (endpointRelation != null) {
                 sourceReceiver.receive(endpointRelation);

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.oap.server.receiver.trace.provider.parser.listener.segment;
 
 import org.apache.skywalking.apm.network.language.agent.UniqueId;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.cache.EndpointInventoryCache;
 import org.apache.skywalking.oap.server.core.source.Segment;
@@ -124,9 +125,11 @@ public class SegmentSpanListener implements FirstSpanListener, EntrySpanListener
             return;
         }
 
-        if (entryEndpointId == 0) {
-            segment.setEndpointId(firstEndpointId);
-            segment.setEndpointName(serviceNameCacheService.get(firstEndpointId).getName());
+        if (entryEndpointId == Const.NONE) {
+            if (firstEndpointId != Const.INEXISTENCE_ENDPOINT_ID) {
+                segment.setEndpointId(firstEndpointId);
+                segment.setEndpointName(serviceNameCacheService.get(firstEndpointId).getName());
+            }
         } else {
             segment.setEndpointId(entryEndpointId);
             segment.setEndpointName(serviceNameCacheService.get(entryEndpointId).getName());

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
@@ -52,6 +52,7 @@ public class SegmentSpanListener implements FirstSpanListener, EntrySpanListener
     private SAMPLE_STATUS sampleStatus = SAMPLE_STATUS.UNKNOWN;
     private int entryEndpointId = 0;
     private int firstEndpointId = 0;
+    private String firstEndpointName = "";
 
     private SegmentSpanListener(ModuleManager moduleManager, TraceSegmentSampler sampler) {
         this.sampler = sampler;
@@ -86,6 +87,7 @@ public class SegmentSpanListener implements FirstSpanListener, EntrySpanListener
         segment.setVersion(segmentCoreInfo.isV2() ? 2 : 1);
 
         firstEndpointId = spanDecorator.getOperationNameId();
+        firstEndpointName = spanDecorator.getOperationName();
     }
 
     @Override public void parseEntry(SpanDecorator spanDecorator, SegmentCoreInfo segmentCoreInfo) {
@@ -132,6 +134,11 @@ public class SegmentSpanListener implements FirstSpanListener, EntrySpanListener
                  */
                 segment.setEndpointId(firstEndpointId);
                 segment.setEndpointName(serviceNameCacheService.get(firstEndpointId).getName());
+            } else {
+                /**
+                 * Only fill first operation name for the trace list query, as no endpoint id.
+                 */
+                segment.setEndpointName(firstEndpointName);
             }
         } else {
             segment.setEndpointId(entryEndpointId);

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
@@ -131,8 +131,10 @@ public class SegmentSpanListener implements FirstSpanListener, EntrySpanListener
                 segment.setEndpointName(serviceNameCacheService.get(firstEndpointId).getName());
             }
         } else {
-            segment.setEndpointId(entryEndpointId);
-            segment.setEndpointName(serviceNameCacheService.get(entryEndpointId).getName());
+            if (entryEndpointId != Const.INEXISTENCE_ENDPOINT_ID) {
+                segment.setEndpointId(entryEndpointId);
+                segment.setEndpointName(serviceNameCacheService.get(entryEndpointId).getName());
+            }
         }
 
         sourceReceiver.receive(segment);

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
@@ -126,15 +126,16 @@ public class SegmentSpanListener implements FirstSpanListener, EntrySpanListener
         }
 
         if (entryEndpointId == Const.NONE) {
-            if (firstEndpointId != Const.INEXISTENCE_ENDPOINT_ID) {
+            if (firstEndpointId != Const.NONE) {
+                /**
+                 * Since 6.6.0, only entry span is treated as an endpoint. Other span's endpoint id == 0.
+                 */
                 segment.setEndpointId(firstEndpointId);
                 segment.setEndpointName(serviceNameCacheService.get(firstEndpointId).getName());
             }
         } else {
-            if (entryEndpointId != Const.INEXISTENCE_ENDPOINT_ID) {
-                segment.setEndpointId(entryEndpointId);
-                segment.setEndpointName(serviceNameCacheService.get(entryEndpointId).getName());
-            }
+            segment.setEndpointId(entryEndpointId);
+            segment.setEndpointName(serviceNameCacheService.get(entryEndpointId).getName());
         }
 
         sourceReceiver.receive(segment);

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/ReferenceIdExchanger.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/ReferenceIdExchanger.java
@@ -70,6 +70,10 @@ public class ReferenceIdExchanger implements IdExchanger<ReferenceDecorator> {
                 standardBuilder.setEntryEndpointId(entryEndpointId);
                 standardBuilder.setEntryEndpointName(Const.EMPTY_STRING);
             }
+        } else {
+            /**
+             * Since 6.6.0, endpoint id could be -1, as it is not an endpoint. Such as local span and exist span.
+             */
         }
 
         if (standardBuilder.getParentEndpointId() == 0) {
@@ -88,6 +92,10 @@ public class ReferenceIdExchanger implements IdExchanger<ReferenceDecorator> {
                 standardBuilder.setParentEndpointId(parentEndpointId);
                 standardBuilder.setParentEndpointName(Const.EMPTY_STRING);
             }
+        } else {
+            /**
+             * Since 6.6.0, endpoint id could be -1, as it is not an endpoint. Such as local span and exist span.
+             */
         }
 
         if (standardBuilder.getNetworkAddressId() == 0 && !Strings.isNullOrEmpty(standardBuilder.getNetworkAddress())) {
@@ -104,16 +112,18 @@ public class ReferenceIdExchanger implements IdExchanger<ReferenceDecorator> {
                 standardBuilder.setNetworkAddressId(networkAddressId);
                 standardBuilder.setNetworkAddress(Const.EMPTY_STRING);
             }
+        } else {
+            /**
+             * Since 6.6.0, endpoint id could be -1, as it is not an endpoint. Such as local span and exist span.
+             */
         }
         return exchanged;
     }
 
     /**
-     * Endpoint in ref could be local or exit span's operation name.
-     * Especially if it is local span operation name,
-     * exchange may not happen at agent, such as Java agent,
-     * then put literal endpoint string in the header,
-     * Need to try to get the id by assuming the endpoint name is detected at server, local or client.
+     * Endpoint in ref could be local or exit span's operation name. Especially if it is local span operation name,
+     * exchange may not happen at agent, such as Java agent, then put literal endpoint string in the header, Need to try
+     * to get the id by assuming the endpoint name is detected at server, local or client.
      *
      * If agent does the exchange, then always use endpoint id.
      */

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/trace/mock/ServiceAMock.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/trace/mock/ServiceAMock.java
@@ -90,11 +90,7 @@ class ServiceAMock {
         span.setParentSpanId(0);
         span.setStartTime(startTimestamp + 100);
         span.setEndTime(startTimestamp + 500);
-        if (isPrepare) {
-            span.setOperationName("org.apache.skywalking.Local.do");
-        } else {
-            span.setOperationNameId(3);
-        }
+        span.setOperationName("org.apache.skywalking.Local.do");
         span.setIsError(false);
         return span;
     }
@@ -108,12 +104,11 @@ class ServiceAMock {
         span.setStartTime(startTimestamp + 120);
         span.setEndTime(startTimestamp + 5800);
         span.setComponentId(ComponentsDefine.DUBBO.getId());
+        span.setOperationName(DUBBO_ENDPOINT);
         if (isPrepare) {
             span.setPeer(DUBBO_ADDRESS);
-            span.setOperationName(DUBBO_ENDPOINT);
         } else {
             span.setPeerId(2);
-            span.setOperationNameId(6);
         }
         span.setIsError(false);
         return span;

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/trace/mock/ServiceBMock.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/trace/mock/ServiceBMock.java
@@ -119,11 +119,10 @@ class ServiceBMock {
         span.addTags(KeyWithStringValue.newBuilder().setKey("db.statement").setValue("select * from database where complex = 1;").build());
         span.addTags(KeyWithStringValue.newBuilder().setKey("db.type").setValue("mongodb").build());
 
+        span.setOperationName("mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]");
         if (isPrepare) {
-            span.setOperationName("mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]");
             span.setPeer("localhost:27017");
         } else {
-            span.setOperationNameId(7);
             span.setPeerId(3);
         }
         return span;
@@ -140,11 +139,10 @@ class ServiceBMock {
         span.setComponentId(ComponentsDefine.ROCKET_MQ_PRODUCER.getId());
         span.setIsError(false);
 
+        span.setOperationName(ROCKET_MQ_ENDPOINT);
         if (isPrepare) {
-            span.setOperationName(ROCKET_MQ_ENDPOINT);
             span.setPeer(ROCKET_MQ_ADDRESS);
         } else {
-            span.setOperationNameId(8);
             span.setPeerId(4);
         }
         return span;

--- a/test/plugin/scenarios/apm-toolkit-trace-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/apm-toolkit-trace-scenario/config/expectedData.yaml
@@ -20,9 +20,8 @@ registryItems:
   instances:
     - {apm-toolkit-trace-scenario: 1}
   operationNames:
-    - apm-toolkit-trace-scenario: [/apm-toolkit-trace-scenario/case/asyncVisit/runnable,
-                                   /case/asyncVisit/runnable, /case/asyncVisit/callable, /apm-toolkit-trace-scenario/case/asyncVisit/callable,
-                                   /case/tool-kit,/apm-toolkit-trace-scenario/case/asyncVisit/supplier,/case/asyncVisit/supplier]
+    - apm-toolkit-trace-scenario: [/case/asyncVisit/runnable, /case/asyncVisit/callable,
+                                   /case/tool-kit, /case/asyncVisit/supplier]
   heartbeat: []
 segmentItems:
   - applicationCode: apm-toolkit-trace-scenario

--- a/test/plugin/scenarios/apm-toolkit-trace-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/apm-toolkit-trace-scenario/config/expectedData.yaml
@@ -162,7 +162,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/apm-toolkit-trace-scenario/case/asyncVisit/callable'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpointId: 0, parentEndpoint: Thread/org.apache.skywalking.apm.toolkit.trace.CallableWrapper/call,
+              - {parentEndpointId: -1, parentEndpoint: '',
                  networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 1,
                  parentTraceSegmentId: not null, parentServiceInstanceId: 1,
                  networkAddress: 'localhost:8080', entryEndpoint: /case/tool-kit, entryServiceInstanceId: 1}
@@ -257,7 +257,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/apm-toolkit-trace-scenario/case/asyncVisit/runnable'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpointId: 0, parentEndpoint: Thread/org.apache.skywalking.apm.toolkit.trace.RunnableWrapper/run,
+              - {parentEndpointId: -1, parentEndpoint: '',
                  networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 1,
                  parentTraceSegmentId: not null, parentServiceInstanceId: 1,
                  networkAddress: 'localhost:8080', entryEndpoint: /case/tool-kit, entryServiceInstanceId: 1}
@@ -316,7 +316,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/apm-toolkit-trace-scenario/case/asyncVisit/supplier'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpointId: 0, parentEndpoint: Thread/org.apache.skywalking.apm.toolkit.trace.SupplierWrapper/get,
+              - {parentEndpointId: -1, parentEndpoint: '',
                  networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 1,
                  parentTraceSegmentId: not null, parentServiceInstanceId: 1,
                  networkAddress: 'localhost:8080', entryEndpoint: /case/tool-kit, entryServiceInstanceId: 1}

--- a/test/plugin/scenarios/canal-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/canal-scenario/config/expectedData.yaml
@@ -19,7 +19,7 @@ registryItems:
   instances:
     - {canal-scenario: 1}
   operationNames:
-    - canal-scenario: [Canal/example, /canal-scenario/case/canal-case]
+    - canal-scenario: [/canal-scenario/case/canal-case]
   heartbeat: []
 segmentItems:
   - applicationCode: canal-scenario

--- a/test/plugin/scenarios/cassandra-java-driver-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/cassandra-java-driver-3.x-scenario/config/expectedData.yaml
@@ -19,7 +19,7 @@ registryItems:
   instances:
     - {cassandra-java-driver-3.x-scenario: 1}
   operationNames:
-    - cassandra-java-driver-3.x-scenario: [Cassandra/execute, Cassandra/executeAsync, /cassandra-java-driver-3.x-scenario/case/cassandra]
+    - cassandra-java-driver-3.x-scenario: [/cassandra-java-driver-3.x-scenario/case/cassandra]
   heartbeat: []
 segmentItems:
   - applicationCode: cassandra-java-driver-3.x-scenario

--- a/test/plugin/scenarios/dubbo-2.5.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/dubbo-2.5.x-scenario/config/expectedData.yaml
@@ -19,30 +19,12 @@ registryItems:
   instances:
     - {dubbo-2.5.x-scenario: 1}
   operationNames:
-    - dubbo-2.5.x-scenario: [/dubbo-2.5.x-scenario/case/healthCheck, /dubbo-2.5.x-scenario/case/dubbo, org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness()]
+    - dubbo-2.5.x-scenario: [/dubbo-2.5.x-scenario/case/dubbo, org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness()]
   heartbeat: []
 segmentItems:
   - applicationCode: dubbo-2.5.x-scenario
     segmentSize: ge 3
     segments:
-      - segmentId: not null
-        spans:
-          - operationName: /dubbo-2.5.x-scenario/case/healthCheck
-            operationId: 0
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 1
-            componentName: ''
-            isError: false
-            spanType: Entry
-            peer: ''
-            peerId: 0
-            tags:
-              - {key: url, value: 'http://localhost:8080/dubbo-2.5.x-scenario/case/healthCheck'}
-              - {key: http.method, value: HEAD}
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness()

--- a/test/plugin/scenarios/dubbo-2.7.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/dubbo-2.7.x-scenario/config/expectedData.yaml
@@ -19,32 +19,13 @@ registryItems:
   instances:
     - {dubbo-2.7.x-scenario: 1}
   operationNames:
-    - dubbo-2.7.x-scenario: [/dubbo-2.7.x-scenario/case/healthCheck,
-                             /dubbo-2.7.x-scenario/case/dubbo,
+    - dubbo-2.7.x-scenario: [/dubbo-2.7.x-scenario/case/dubbo,
                              org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness()]
   heartbeat: []
 segmentItems:
   - applicationCode: dubbo-2.7.x-scenario
     segmentSize: ge 3
     segments:
-      - segmentId: not null
-        spans:
-          - operationName: /dubbo-2.7.x-scenario/case/healthCheck
-            operationId: 0
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 1
-            componentName: ''
-            isError: false
-            spanType: Entry
-            peer: ''
-            peerId: 0
-            tags:
-              - {key: url, value: 'http://localhost:8080/dubbo-2.7.x-scenario/case/healthCheck'}
-              - {key: http.method, value: HEAD}
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness()

--- a/test/plugin/scenarios/ehcache-2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/ehcache-2.x-scenario/config/expectedData.yaml
@@ -19,7 +19,7 @@ registryItems:
   instances:
     - {ehcache-2.x-scenario: 1}
   operationNames:
-    - ehcache-2.x-scenario: [/ehcache-2.x-scenario/case/ehcache, /ehcache-2.x-scenario/healthCheck]
+    - ehcache-2.x-scenario: [/ehcache-2.x-scenario/case/ehcache]
   heartbeat: []
 segmentItems:
   - applicationCode: ehcache-2.x-scenario

--- a/test/plugin/scenarios/elasticsearch-5.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticsearch-5.x-scenario/config/expectedData.yaml
@@ -19,10 +19,7 @@ registryItems:
     instances:
     - {elasticsearch-5.x-scenario: 1}
     operationNames:
-    - elasticsearch-5.x-scenario: [Elasticsearch/IndexRequest, Elasticsearch/GetRequest,
-                                   Elasticsearch/SearchRequest, Elasticsearch/UpdateRequest,
-                                   Elasticsearch/DeleteRequest, Elasticsearch/DeleteIndexRequest,
-                                   /case/elasticsearch]
+    - elasticsearch-5.x-scenario: [/case/elasticsearch]
     heartbeat: []
 segmentItems:
 - applicationCode: elasticsearch-5.x-scenario

--- a/test/plugin/scenarios/elasticsearch-6.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticsearch-6.x-scenario/config/expectedData.yaml
@@ -19,10 +19,7 @@ registryItems:
     instances:
     - {elasticsearch-6.x-scenario: 1}
     operationNames:
-    - elasticsearch-6.x-scenario: [Elasticsearch/CreateRequest, Elasticsearch/IndexRequest,
-                                   Elasticsearch/GetRequest, Elasticsearch/SearchRequest,
-                                   Elasticsearch/UpdateRequest, Elasticsearch/DeleteRequest,
-                                   /elasticsearch-case/case/elasticsearch]
+    - elasticsearch-6.x-scenario: [/elasticsearch-case/case/elasticsearch]
     heartbeat: []
 segmentItems:
 - applicationCode: elasticsearch-6.x-scenario

--- a/test/plugin/scenarios/elasticsearch-7.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticsearch-7.x-scenario/config/expectedData.yaml
@@ -19,10 +19,7 @@ registryItems:
   instances:
   - {elasticsearch-7.x-scenario: 1}
   operationNames:
-  - elasticsearch-7.x-scenario: [Elasticsearch/CreateRequest, Elasticsearch/IndexRequest,
-                                 Elasticsearch/GetRequest, Elasticsearch/SearchRequest,
-                                 Elasticsearch/UpdateRequest, Elasticsearch/DeleteRequest,
-                                 /elasticsearch-case/case/elasticsearch]
+  - elasticsearch-7.x-scenario: [/elasticsearch-case/case/elasticsearch]
   heartbeat: []
 segmentItems:
 - applicationCode: elasticsearch-7.x-scenario

--- a/test/plugin/scenarios/hystrix-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/hystrix-scenario/config/expectedData.yaml
@@ -47,7 +47,7 @@ segmentItems:
         - {key: message, value: not null}
         - {key: stack, value: not null}
       refs:
-      - {parentEndpointId: 0, parentEndpoint: /case/hystrix-scenario, networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: '${hystrix-scenario[2]}', parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/hystrix-scenario, entryServiceInstanceId: nq 0 }
+      - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: '${hystrix-scenario[2]}', parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/hystrix-scenario, entryServiceInstanceId: nq 0 }
   - segmentId: not null
     spans:
     - operationName: Hystrix/TestACommand/Fallback
@@ -64,7 +64,7 @@ segmentItems:
       peer: ''
       peerId: 0
       refs:
-      - {parentEndpointId: 0, parentEndpoint: Hystrix/TestACommand/Execution, networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: '${hystrix-scenario[0]}', parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/hystrix-scenario, entryServiceInstanceId: nq 0}
+      - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: '${hystrix-scenario[0]}', parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/hystrix-scenario, entryServiceInstanceId: nq 0}
   - segmentId: not null
     spans:
     - operationName: Hystrix/TestBCommand/Execution

--- a/test/plugin/scenarios/hystrix-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/hystrix-scenario/config/expectedData.yaml
@@ -47,7 +47,8 @@ segmentItems:
         - {key: message, value: not null}
         - {key: stack, value: not null}
       refs:
-      - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: '${hystrix-scenario[2]}', parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/hystrix-scenario, entryServiceInstanceId: nq 0 }
+      - {parentEndpointId: 0, parentEndpoint: /case/hystrix-scenario, networkAddressId: 0, entryEndpointId: 0, refType: CrossThread,
+         parentSpanId: 0, parentTraceSegmentId: '${hystrix-scenario[2]}', parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/hystrix-scenario, entryServiceInstanceId: nq 0 }
   - segmentId: not null
     spans:
     - operationName: Hystrix/TestACommand/Fallback
@@ -64,7 +65,8 @@ segmentItems:
       peer: ''
       peerId: 0
       refs:
-      - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: '${hystrix-scenario[0]}', parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/hystrix-scenario, entryServiceInstanceId: nq 0}
+      - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 0,
+         parentTraceSegmentId: '${hystrix-scenario[0]}', parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/hystrix-scenario, entryServiceInstanceId: nq 0}
   - segmentId: not null
     spans:
     - operationName: Hystrix/TestBCommand/Execution

--- a/test/plugin/scenarios/jedis-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jedis-scenario/config/expectedData.yaml
@@ -20,8 +20,7 @@ registryItems:
   instances:
     - {jedis-scenario: 1}
   operationNames:
-    - jedis-scenario: [Jedis/set, Jedis/echo, Jedis/del,
-                       Jedis/get, /jedis-scenario/case/jedis-scenario]
+    - jedis-scenario: [/jedis-scenario/case/jedis-scenario]
   heartbeat: []
 segmentItems:
   - applicationCode: jedis-scenario

--- a/test/plugin/scenarios/jetty-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jetty-scenario/config/expectedData.yaml
@@ -22,8 +22,7 @@ registryItems:
   - {jettyclient-scenario: 1}
   operationNames:
   - jettyserver-scenario: [/jettyserver-case/case/receiveContext-0]
-  - jettyclient-scenario: [/jettyserver-case/case/receiveContext-0,
-                           /jettyclient-case/case/jettyclient-case,
+  - jettyclient-scenario: [/jettyclient-case/case/jettyclient-case,
                            /jettyclient-case/case/healthCheck]
 segmentItems:
 - applicationCode: jettyserver-scenario

--- a/test/plugin/scenarios/kafka-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/kafka-scenario/config/expectedData.yaml
@@ -19,31 +19,12 @@ registryItems:
   instances:
     - {kafka-scenario: 1}
   operationNames:
-    - kafka-scenario: [Kafka/test/Producer, Kafka/test/Consumer/testGroup,
-                       /case/healthCheck, /case/kafka-case]
+    - kafka-scenario: [Kafka/test/Consumer/testGroup, /case/kafka-case]
   heartbeat: []
 segmentItems:
   - applicationCode: kafka-scenario
-    segmentSize: gt 4
+    segmentSize: gt 3
     segments:
-      - segmentId: not null
-        spans:
-          - operationName: /case/healthCheck
-            operationId: 0
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 14
-            componentName: ''
-            isError: false
-            spanType: Entry
-            peer: ''
-            peerId: 0
-            tags:
-              - {key: url, value: 'http://localhost:8080/kafka-scenario/case/healthCheck'}
-              - {key: http.method, value: HEAD}
       - segmentId: not null
         spans:
           - operationName: Kafka/Producer/Callback

--- a/test/plugin/scenarios/mongodb-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mongodb-3.x-scenario/config/expectedData.yaml
@@ -20,8 +20,7 @@ registryItems:
   instances:
     - {mongodb-3.x-scenario: 1}
   operationNames:
-    - mongodb-3.x-scenario: [/mongodb-case/case/mongodb, MongoDB/DropDatabaseOperation, MongoDB/FindOperation,
-                             MongoDB/CreateCollectionOperation, MongoDB/MixedBulkWriteOperation]
+    - mongodb-3.x-scenario: [/mongodb-case/case/mongodb]
   heartbeat: []
 
 segmentItems:

--- a/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ registryItems:
   instances:
     - {mysql-scenario: 1}
   operationNames:
-    - mysql-scenario: [Mysql/JDBI/Statement/execute, /mysql-scenario/case/healthCheck,
-                       Mysql/JDBI/PreparedStatement/execute, /mysql-scenario/case/mysql-scenario, Mysql/JDBI/Connection/close]
+    - mysql-scenario: [/mysql-scenario/case/healthCheck, /mysql-scenario/case/mysql-scenario]
 segmentItems:
   - applicationCode: mysql-scenario
     segmentSize: ge 2

--- a/test/plugin/scenarios/netty-socketio-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/netty-socketio-scenario/config/expectedData.yaml
@@ -20,7 +20,7 @@ registryItems:
   instances:
     - {netty-socketio-scenario: 1}
   operationNames:
-    - netty-socketio-scenario: [/netty-socketio-scenario/case/netty-socketio, /socket.io/,
+    - netty-socketio-scenario: [/netty-socketio-scenario/case/netty-socketio,
                                 /netty-socketio-scenario/healthCheck, SocketIO/onConnect, SocketIO/send_data/receive]
   heartbeat: []
 segmentItems:

--- a/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
@@ -96,7 +96,7 @@ segmentItems:
       - {key: url, value: 'http://127.0.0.1:8080/okhttp-case/case/receiveContext-1'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpointId: 0, parentEndpoint: "/okhttp-case/case/receiveContext-0", networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '127.0.0.1:8080', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
+      - {parentEndpointId: 0, parentEndpoint: /okhttp-case/case/receiveContext-0, networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '127.0.0.1:8080', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
   - segmentId: not null
     spans:
     - operationName: /okhttp-case/case/receiveContext-0

--- a/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
@@ -76,7 +76,9 @@ segmentItems:
       - {key: url, value: 'http://127.0.0.1:8080/okhttp-case/case/receiveContext-0'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpointId: 0, parentEndpoint: /okhttp-case/case/receiveContext-0, networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '127.0.0.1:8080', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
+      - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0,
+         refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '127.0.0.1:8080',
+         entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
   - segmentId: not null
     spans:
     - operationName: /case/receiveContext-1
@@ -96,7 +98,8 @@ segmentItems:
       - {key: url, value: 'http://127.0.0.1:8080/okhttp-case/case/receiveContext-1'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpointId: 0, parentEndpoint: /okhttp-case/case/receiveContext-0, networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '127.0.0.1:8080', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
+      - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 0,
+         parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '127.0.0.1:8080', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
   - segmentId: not null
     spans:
     - operationName: /okhttp-case/case/receiveContext-0
@@ -116,4 +119,5 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://127.0.0.1:8080/okhttp-case/case/receiveContext-0'}
       refs:
-      - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 1, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
+      - {parentEndpointId: 0, parentEndpoint: '/case/okhttp-case', networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 1,
+         parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}

--- a/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
@@ -20,7 +20,7 @@ registryItems:
   instances:
   - {okhttp-scenario: 1}
   operationNames:
-  - okhttp-scenario: [/case/receiveContext-0, /okhttp-case/case/receiveContext-0,/case/healthCheck, /case/okhttp-case, /case/receiveContext-1]
+  - okhttp-scenario: [/case/receiveContext-0, /case/healthCheck, /case/okhttp-case, /case/receiveContext-1]
   heartbeat: []
 segmentItems:
 - applicationCode: okhttp-scenario
@@ -96,7 +96,7 @@ segmentItems:
       - {key: url, value: 'http://127.0.0.1:8080/okhttp-case/case/receiveContext-1'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpointId: 0, parentEndpoint: /okhttp-case/case/receiveContext-0, networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '127.0.0.1:8080', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
+      - {parentEndpointId: 0, parentEndpoint: "/okhttp-case/case/receiveContext-0", networkAddressId: 0, entryEndpointId: 0, refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '127.0.0.1:8080', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
   - segmentId: not null
     spans:
     - operationName: /okhttp-case/case/receiveContext-0

--- a/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
@@ -116,4 +116,4 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://127.0.0.1:8080/okhttp-case/case/receiveContext-0'}
       refs:
-      - {parentEndpointId: 0, parentEndpoint: /case/okhttp-case, networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 1, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}
+      - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 1, parentTraceSegmentId: nq 0, parentServiceInstanceId: nq 0, networkAddress: '', entryEndpoint: /case/okhttp-case, entryServiceInstanceId: nq 0}

--- a/test/plugin/scenarios/oracle-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/oracle-scenario/config/expectedData.yaml
@@ -19,9 +19,7 @@ registryItems:
   instances:
   - {oracle-scenario: 1}
   operationNames:
-  - oracle-scenario: [Oracle/JDBI/Connection/close, Oracle/JDBI/PreparedStatement/executeQuery,
-                      Oracle/JDBI/PreparedStatement/execute, Oracle/JDBI/Statement/execute,
-                      /oracle-scenario/case/oracle]
+  - oracle-scenario: [/oracle-scenario/case/oracle]
 segmentItems:
 - applicationCode: oracle-scenario
   segmentSize: ge 1

--- a/test/plugin/scenarios/postgresql-above9.4.1207-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/postgresql-above9.4.1207-scenario/config/expectedData.yaml
@@ -19,9 +19,7 @@ registryItems:
     instances:
     - {postgresql-above9.4.1207-scenario: 1}
     operationNames:
-    - postgresql-above9.4.1207-scenario: [/postgresql-scenario/case/postgres, PostgreSQL/JDBI/PreparedStatement/executeWithFlags,
-                            PostgreSQL/JDBI/CallableStatement/executeWithFlags, PostgreSQL/JDBI/Statement/execute,
-                            PostgreSQL/JDBI/Connection/close]
+    - postgresql-above9.4.1207-scenario: [/postgresql-scenario/case/postgres]
 segmentItems:
 - applicationCode: postgresql-above9.4.1207-scenario
   segmentSize: ge 1

--- a/test/plugin/scenarios/postgresql-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/postgresql-scenario/config/expectedData.yaml
@@ -19,9 +19,7 @@ registryItems:
     instances:
     - {postgresql-scenario: 1}
     operationNames:
-    - postgresql-scenario: [/postgresql-scenario/case/postgres, PostgreSQL/JDBI/PreparedStatement/execute,
-                            PostgreSQL/JDBI/CallableStatement/execute, PostgreSQL/JDBI/Statement/execute,
-                            PostgreSQL/JDBI/Connection/close]
+    - postgresql-scenario: [/postgresql-scenario/case/postgres]
     heartbeat: []
 segmentItems:
 - applicationCode: postgresql-scenario

--- a/test/plugin/scenarios/pulsar-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/pulsar-scenario/config/expectedData.yaml
@@ -20,7 +20,7 @@ registryItems:
   instances:
   - {pulsar-scenario: nq 0}
   operationNames:
-  - pulsar-scenario: [Pulsar/test/Producer, /case/pulsar-case, Pulsar/test/Consumer/test]
+  - pulsar-scenario: [/case/pulsar-case, Pulsar/test/Consumer/test]
 segmentItems:
 - applicationCode: pulsar-scenario
   segmentSize: ge 3

--- a/test/plugin/scenarios/rabbitmq-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/rabbitmq-scenario/config/expectedData.yaml
@@ -19,7 +19,7 @@ registryItems:
   instances:
   - {rabbitmq-scenario: 1}
   operationNames:
-  - rabbitmq-scenario: [/rabbitmq-scenario/case/rabbitmq,RabbitMQ/Topic/Queue/test/Producer,RabbitMQ/Topic/Queue/test/Consumer]
+  - rabbitmq-scenario: [/rabbitmq-scenario/case/rabbitmq, RabbitMQ/Topic/Queue/test/Consumer]
 segmentItems:
 - applicationCode: rabbitmq-scenario
   segmentSize: gt 2

--- a/test/plugin/scenarios/redisson-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/redisson-scenario/config/expectedData.yaml
@@ -20,7 +20,7 @@ registryItems:
   instances:
     - {redisson-scenario: 1}
   operationNames:
-    - redisson-scenario: [/case/healthCheck, Redisson/BATCH_EXECUTE, Redisson/SET, /case/redisson-case]
+    - redisson-scenario: [/case/healthCheck, /case/redisson-case]
   heartbeat: []
 segmentItems:
   - applicationCode: redisson-scenario

--- a/test/plugin/scenarios/solrj-7.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/solrj-7.x-scenario/config/expectedData.yaml
@@ -19,9 +19,7 @@ registryItems:
   instances:
     - {solrj-7.x-scenario: nq 0}
   operationNames:
-    - solrj-7.x-scenario: [/solrj-scenario/case/solrj, solrJ/mycore/update/COMMIT, solrJ/mycore/update/DELETE_BY_IDS,
-                           solrJ/mycore/select, solrJ/mycore/update/DELETE_BY_QUERY, solrJ/mycore/get,
-                           solrJ/mycore/update/OPTIMIZE, solrJ/mycore/update/ADD]
+    - solrj-7.x-scenario: [/solrj-scenario/case/solrj]
   heartbeat: []
 segmentItems:
   - applicationCode: solrj-7.x-scenario

--- a/test/plugin/scenarios/spring-3.1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-3.1.x-scenario/config/expectedData.yaml
@@ -20,9 +20,8 @@ registryItems:
     - {spring-3.1.x-scenario: 1}
   operationNames:
     - spring-3.1.x-scenario: ['{DELETE}/delete/{id}', /case/resttemplate, '{GET}/get/{id}',
-                              /spring-3.1.x-scenario/delete/1, '{POST}/create/', /healthCheck, /case/spring3,
-                              /spring-3.1.x-scenario/case/spring3/, /spring-3.1.x-scenario/update/1, '{PUT}/update/{id}',
-                              /spring-3.1.x-scenario/create/, /spring-3.1.x-scenario/get/1]
+                              '{POST}/create/', /healthCheck, /case/spring3,
+                              '{PUT}/update/{id}']
   heartbeat: []
 segmentItems:
   - applicationCode: spring-3.1.x-scenario

--- a/test/plugin/scenarios/spring-4.1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-4.1.x-scenario/config/expectedData.yaml
@@ -20,9 +20,7 @@ registryItems:
     - {spring-4.1.x-scenario: 1}
   operationNames:
     - spring-4.1.x-scenario: ['{DELETE}/delete/{id}', /case/resttemplate, '{GET}/get/{id}',
-                              /spring-4.1.x-scenario/delete/1, '{POST}/create/', /healthCheck, /case/spring3,
-                              /spring-4.1.x-scenario/case/spring3/, /spring-4.1.x-scenario/update/1, '{PUT}/update/{id}',
-                              /spring-4.1.x-scenario/create/, /spring-4.1.x-scenario/get/1]
+                               '{POST}/create/', /healthCheck, /case/spring3, '{PUT}/update/{id}']
   heartbeat: []
 segmentItems:
   - applicationCode: spring-4.1.x-scenario

--- a/test/plugin/scenarios/spring-4.3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-4.3.x-scenario/config/expectedData.yaml
@@ -20,9 +20,7 @@ registryItems:
     - {spring-4.3.x-scenario: 1}
   operationNames:
     - spring-4.3.x-scenario: [/create/, '/delete/{id}', /inherit/child/test, /healthCheck,
-                              /spring-4.3.x-scenario/case/spring3/, /spring-4.3.x-scenario/create/, /spring-4.3.x-scenario/get/1,
-                              '/get/{id}', '/update/{id}', /case/resttemplate, /spring-4.3.x-scenario/delete/1,
-                              /spring-4.3.x-scenario/inherit/child/test, /spring-4.3.x-scenario/update/1,
+                              '/get/{id}', '/update/{id}', /case/resttemplate,
                               /case/spring3]
   heartbeat: []
 segmentItems:

--- a/test/plugin/scenarios/spring-async-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-async-scenario/config/expectedData.yaml
@@ -63,7 +63,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-async-scenario/case/asyncVisit'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpointId: 0, parentEndpoint: SpringAsync, networkAddressId: 0, entryEndpointId: 0,
+              - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0,
                  refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstanceId: 1, networkAddress: 'localhost:8080', entryEndpoint: /spring-async-scenario/case/spring-async,
                  entryServiceInstanceId: 1}
@@ -86,7 +86,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-async-scenario/case/asyncVisit'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpointId: 0, parentEndpoint: SpringAsync, networkAddressId: 0, entryEndpointId: 0,
+              - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0, entryEndpointId: 0,
                  refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstanceId: 1, networkAddress: 'localhost:8080', entryEndpoint: /spring-async-scenario/case/spring-async,
                  entryServiceInstanceId: 1}

--- a/test/plugin/scenarios/spring-async-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-async-scenario/config/expectedData.yaml
@@ -122,7 +122,7 @@ segmentItems:
             peer: ''
             peerId: 0
             refs:
-              - {parentEndpointId: 0, parentEndpoint: /spring-async-scenario/case/spring-async,
+              - {parentEndpointId: -1, parentEndpoint: '',
                  networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 0,
                  parentTraceSegmentId: not null, parentServiceInstanceId: 1,
                  networkAddress: '', entryEndpoint: /spring-async-scenario/case/spring-async,

--- a/test/plugin/scenarios/spring-async-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-async-scenario/config/expectedData.yaml
@@ -122,7 +122,7 @@ segmentItems:
             peer: ''
             peerId: 0
             refs:
-              - {parentEndpointId: -1, parentEndpoint: '',
+              - {parentEndpointId: 0, parentEndpoint: /spring-async-scenario/case/spring-async,
                  networkAddressId: 0, entryEndpointId: 0, refType: CrossThread, parentSpanId: 0,
                  parentTraceSegmentId: not null, parentServiceInstanceId: 1,
                  networkAddress: '', entryEndpoint: /spring-async-scenario/case/spring-async,

--- a/test/plugin/scenarios/spring-tx-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-tx-scenario/config/expectedData.yaml
@@ -20,9 +20,7 @@ registryItems:
   instances:
     - {spring-tx-scenario: 1}
   operationNames:
-    - spring-tx-scenario: [Mysql/JDBI/Statement/execute, Mysql/JDBI/Connection/commit,
-                           Mysql/JDBI/PreparedStatement/executeUpdate, /case/spring-tx-case, /case/healthCheck,
-                           Mysql/JDBI/Connection/close, Mysql/JDBI/Statement/executeQuery]
+    - spring-tx-scenario: [/case/spring-tx-case, /case/healthCheck]
   heartbeat: []
 segmentItems:
   - applicationCode: spring-tx-scenario

--- a/test/plugin/scenarios/undertow-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/undertow-scenario/config/expectedData.yaml
@@ -64,7 +64,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8081/undertow-routing-scenario/case/undertow'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpointId: 0, parentEndpoint: UndertowDispatch, networkAddressId: 0,
+              - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0,
                  entryEndpointId: 0, refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstanceId: 1, networkAddress: 'localhost:8081', entryEndpoint: /undertow-scenario/case/undertow,
                  entryServiceInstanceId: 1}
@@ -87,7 +87,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/undertow-scenario/case/undertow1'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpointId: 0, parentEndpoint: UndertowDispatch, networkAddressId: 0,
+              - {parentEndpointId: -1, parentEndpoint: '', networkAddressId: 0,
                  entryEndpointId: 0, refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstanceId: 1, networkAddress: 'localhost:8080', entryEndpoint: /undertow-scenario/case/undertow,
                  entryServiceInstanceId: 1}

--- a/test/plugin/scenarios/undertow-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/undertow-scenario/config/expectedData.yaml
@@ -20,7 +20,7 @@ registryItems:
   instances:
     - {undertow-scenario: 1}
   operationNames:
-    - undertow-scenario: [/undertow-scenario/case/undertow1, /undertow-scenario/case/undertow, /undertow-routing-scenario/case/undertow,
+    - undertow-scenario: [/undertow-scenario/case/undertow1, /undertow-scenario/case/undertow,
                           '/undertow-routing-scenario/case/{context}']
   heartbeat: []
 segmentItems:

--- a/test/plugin/scenarios/webflux-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/webflux-scenario/config/expectedData.yaml
@@ -27,9 +27,7 @@ registryItems:
                                   WEBFLUX.handle, org.apache.skywalking.apm.testcase.sc.webflux.projectB.controller.TestAnnotationController.error,
                                   org.apache.skywalking.apm.testcase.sc.webflux.projectB.controller.TestAnnotationController.healthCheck,
                                   RoutingConfiguration.org.apache.skywalking.apm.testcase.sc.webflux.projectB.route.TestHandler]
-    - webflux-projectA-scenario: [/testcase/annotation/mono/hello, /projectA/testcase,
-                                  /testcase/annotation/success, /testcase/annotation/healthCheck, /notFound, /projectA/healthCheck,
-                                  /testcase/route/error, /testcase/route/success, /testcase/annotation/error]
+    - webflux-projectA-scenario: [/projectA/testcase]
   heartbeat: []
 segmentItems:
   - applicationCode: webflux-projectB-scenario

--- a/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/SegmentAssert.java
+++ b/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/SegmentAssert.java
@@ -211,8 +211,8 @@ public class SegmentAssert {
 
     private static boolean simpleSegmentRefEquals(SegmentRef expected, SegmentRef actual) {
         try {
-            ExpressParser.parse(expected.entryServiceName()).assertValue("entry service name", actual.entryServiceName());
-            ExpressParser.parse(expected.parentServiceName()).assertValue("parent service name", actual.parentServiceName());
+            ExpressParser.parse(expected.entryEndpointName()).assertValue("entry service name", actual.entryEndpointName());
+            ExpressParser.parse(expected.parentEndpointName()).assertValue("parent service name", actual.parentEndpointName());
             ExpressParser.parse(expected.refType()).assertValue("ref type", actual.refType());
             return true;
         } catch (ValueAssertFailedException e) {

--- a/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/SegmentRefAssert.java
+++ b/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/SegmentRefAssert.java
@@ -57,15 +57,15 @@ public class SegmentRefAssert {
 
     private static boolean segmentRefEquals(SegmentRef expected, SegmentRef actual) {
         try {
-            ExpressParser.parse(expected.entryServiceName()).assertValue("entry service name", actual.entryServiceName());
+            ExpressParser.parse(expected.entryServiceName()).assertValue("entry endpoint name", actual.entryServiceName());
             ExpressParser.parse(expected.networkAddress()).assertValue("network address", actual.networkAddress());
             ExpressParser.parse(expected.parentTraceSegmentId()).assertValue("parent segment id", actual.parentTraceSegmentId());
             ExpressParser.parse(expected.parentSpanId()).assertValue("span id", actual.parentSpanId());
-            ExpressParser.parse(expected.entryServiceId()).assertValue("entry service id", actual.entryServiceId());
+            ExpressParser.parse(expected.entryServiceId()).assertValue("entry endpoint id", actual.entryServiceId());
             ExpressParser.parse(expected.networkAddressId()).assertValue("network address id", actual.networkAddressId());
             ExpressParser.parse(expected.parentApplicationInstanceId()).assertValue("parent application instance id", actual.parentApplicationInstanceId());
-            ExpressParser.parse(expected.parentServiceId()).assertValue("parent service id", actual.parentServiceId());
-            ExpressParser.parse(expected.parentServiceName()).assertValue("parent service name", actual.parentServiceName());
+            ExpressParser.parse(expected.parentServiceId()).assertValue("parent endpoint id", actual.parentServiceId());
+            ExpressParser.parse(expected.parentServiceName()).assertValue("parent endpoint name", actual.parentServiceName());
             ExpressParser.parse(expected.refType()).assertValue("ref type", actual.refType());
             ExpressParser.parse(expected.entryApplicationInstanceId()).assertValue("entry application instance id", actual.entryApplicationInstanceId());
             return true;

--- a/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/SegmentRefAssert.java
+++ b/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/SegmentRefAssert.java
@@ -57,17 +57,17 @@ public class SegmentRefAssert {
 
     private static boolean segmentRefEquals(SegmentRef expected, SegmentRef actual) {
         try {
-            ExpressParser.parse(expected.entryServiceName()).assertValue("entry endpoint name", actual.entryServiceName());
+            ExpressParser.parse(expected.entryEndpointName()).assertValue("entry endpoint name", actual.entryEndpointName());
             ExpressParser.parse(expected.networkAddress()).assertValue("network address", actual.networkAddress());
             ExpressParser.parse(expected.parentTraceSegmentId()).assertValue("parent segment id", actual.parentTraceSegmentId());
             ExpressParser.parse(expected.parentSpanId()).assertValue("span id", actual.parentSpanId());
-            ExpressParser.parse(expected.entryServiceId()).assertValue("entry endpoint id", actual.entryServiceId());
+            ExpressParser.parse(expected.entryEndpointId()).assertValue("entry endpoint id", actual.entryEndpointId());
             ExpressParser.parse(expected.networkAddressId()).assertValue("network address id", actual.networkAddressId());
-            ExpressParser.parse(expected.parentApplicationInstanceId()).assertValue("parent application instance id", actual.parentApplicationInstanceId());
-            ExpressParser.parse(expected.parentServiceId()).assertValue("parent endpoint id", actual.parentServiceId());
-            ExpressParser.parse(expected.parentServiceName()).assertValue("parent endpoint name", actual.parentServiceName());
+            ExpressParser.parse(expected.parentServiceInstanceId()).assertValue("parent application instance id", actual.parentServiceInstanceId());
+            ExpressParser.parse(expected.parentEndpointId()).assertValue("parent endpoint id", actual.parentEndpointId());
+            ExpressParser.parse(expected.parentEndpointName()).assertValue("parent endpoint name", actual.parentEndpointName());
             ExpressParser.parse(expected.refType()).assertValue("ref type", actual.refType());
-            ExpressParser.parse(expected.entryApplicationInstanceId()).assertValue("entry application instance id", actual.entryApplicationInstanceId());
+            ExpressParser.parse(expected.entryServiceInstanceId()).assertValue("entry application instance id", actual.entryServiceInstanceId());
             return true;
         } catch (ValueAssertFailedException e) {
             throw new SegmentRefAssertFailedException(e, expected, actual);

--- a/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/exception/SegmentRefNotFoundException.java
+++ b/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/exception/SegmentRefNotFoundException.java
@@ -40,9 +40,9 @@ public class SegmentRefNotFoundException extends AssertFailedException {
             String reason = cause.getFailedCause().getCauseMessage();
 
             StringBuilder actualSegmentRef = new StringBuilder(String.format("\nSegmentRef:\t%s\n", reason));
-            actualSegmentRef.append(String.format(" - entryServiceName:\t\t%s\n", actual.entryServiceName()))
+            actualSegmentRef.append(String.format(" - entryServiceName:\t\t%s\n", actual.entryEndpointName()))
                 .append(String.format(" - networkAddress:\t\t\t%s\n", actual.networkAddress()))
-                .append(String.format(" - parentServiceName:\t\t%s\n", actual.parentServiceName()))
+                .append(String.format(" - parentServiceName:\t\t%s\n", actual.parentEndpointName()))
                 .append(String.format(" - parentSpanId:\t\t\t%s\n", actual.parentSpanId()))
                 .append(String.format(" - parentTraceSegmentId:\t%s\n", actual.parentTraceSegmentId()))
                 .append(String.format(" - refType:\t\t\t\t\t%s", actual.refType())).toString();

--- a/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/entity/SegmentForRead.java
+++ b/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/entity/SegmentForRead.java
@@ -110,11 +110,11 @@ public class SegmentForRead implements Segment {
             this.entryServiceInstanceId = entryServiceInstanceId;
         }
 
-        @Override public String parentServiceId() {
+        @Override public String parentEndpointId() {
             return parentEndpointId;
         }
 
-        @Override public String parentServiceName() {
+        @Override public String parentEndpointName() {
             return parentEndpoint;
         }
 
@@ -122,7 +122,7 @@ public class SegmentForRead implements Segment {
             return networkAddressId;
         }
 
-        @Override public String entryServiceId() {
+        @Override public String entryEndpointId() {
             return entryEndpointId;
         }
 
@@ -138,7 +138,7 @@ public class SegmentForRead implements Segment {
             return parentTraceSegmentId;
         }
 
-        @Override public String parentApplicationInstanceId() {
+        @Override public String parentServiceInstanceId() {
             return parentServiceInstanceId;
         }
 
@@ -146,7 +146,7 @@ public class SegmentForRead implements Segment {
             return networkAddress;
         }
 
-        @Override public String entryServiceName() {
+        @Override public String entryEndpointName() {
             return entryEndpoint;
         }
 
@@ -154,15 +154,15 @@ public class SegmentForRead implements Segment {
             this.parentTraceSegmentId = parentTraceSegmentId;
         }
 
-        @Override public String entryApplicationInstanceId() {
+        @Override public String entryServiceInstanceId() {
             return entryServiceInstanceId;
         }
 
         @Override public String toString() {
             StringBuilder actualSegmentRef = new StringBuilder("\nSegmentRef:\n");
-            return actualSegmentRef.append(String.format(" - entryServiceName:\t\t%s\n", entryServiceName()))
+            return actualSegmentRef.append(String.format(" - entryServiceName:\t\t%s\n", entryEndpointName()))
                 .append(String.format(" - networkAddress:\t\t\t%s\n", networkAddress()))
-                .append(String.format(" - parentServiceName:\t\t%s\n", parentServiceName()))
+                .append(String.format(" - parentServiceName:\t\t%s\n", parentEndpointName()))
                 .append(String.format(" - parentSpanId:\t\t\t%s\n", parentSpanId()))
                 .append(String.format(" - parentTraceSegmentId:\t%s\n", parentTraceSegmentId()))
                 .append(String.format(" - refType:\t\t\t\t\t%s", refType())).toString();

--- a/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/entity/SegmentRef.java
+++ b/test/plugin/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/entity/SegmentRef.java
@@ -21,13 +21,13 @@ package org.apache.skywalking.plugin.test.agent.tool.validator.entity;
  */
 public interface SegmentRef {
 
-    String parentServiceId();
+    String parentEndpointId();
 
-    String parentServiceName();
+    String parentEndpointName();
 
     String networkAddressId();
 
-    String entryServiceId();
+    String entryEndpointId();
 
     String refType();
 
@@ -35,13 +35,13 @@ public interface SegmentRef {
 
     String parentTraceSegmentId();
 
-    String parentApplicationInstanceId();
+    String parentServiceInstanceId();
 
     String networkAddress();
 
-    String entryServiceName();
+    String entryEndpointName();
 
     void parentTraceSegmentId(String parentTraceSegmentId);
 
-    String entryApplicationInstanceId();
+    String entryServiceInstanceId();
 }


### PR DESCRIPTION
Resolves #4056

**Key**, reduce the load of register and amount of operation id. Also, reduce the agent memory cost.
At the same time, the local span and exit span plugins will not concern about `parameter in the op name` causing `too many registers` issue.

@kezhenxu94 Could you review and run a test locally? Especially for the plugin you are working on, `Runnable` case I mean. If inside `runnable`, an RPC is called, the endpoint dependency should show that endpoint still depends on the parent endpoint(RPC in the parent thread of the runnable). If no parent thread exist, as this thread is a local task(timer), then the endpoint should depend on the user. Could you verify these two cases? And confirm no local span and exit span register happen, check through
1. No local and exit operation name in the endpoint inventory
1. No warning log, like this `Unexpected endpoint register, endpoint isn't detected from server side. ` ,happens.