### PR TITLE
Fix NullPointerException in Spring interceptor

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/src/main/java/org/apache/skywalking/apm/plugin/spring/patch/GetPropertyDescriptorsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/src/main/java/org/apache/skywalking/apm/plugin/spring/patch/GetPropertyDescriptorsInterceptor.java
@@ -41,7 +41,8 @@ public class GetPropertyDescriptorsInterceptor implements InstanceMethodsAroundI
 
         PropertyDescriptor[] propertyDescriptors = (PropertyDescriptor[])ret;
 
-        if (EnhancedInstance.class.isAssignableFrom(((BeanWrapperImpl)objInst).getRootClass())) {
+        Class<?> rootClass = ((BeanWrapperImpl) objInst).getRootClass();
+        if (rootClass != null && EnhancedInstance.class.isAssignableFrom(rootClass)) {
             List<PropertyDescriptor> newPropertyDescriptors = new ArrayList<PropertyDescriptor>();
             for (PropertyDescriptor descriptor : propertyDescriptors) {
                 if (!"skyWalkingDynamicField".equals(descriptor.getName())) {


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

For some reasons, the Spring plugin throws NPE, after inspecting the source codes of Spring, `org.springframework.beans.BeanWrapperImpl#getRootClass` may indeed return `null`,

```java

public final Class<?> getRootClass() {
	return (this.rootObject != null ? this.rootObject.getClass() : null);
}

```

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/15965696/70847712-7b46e380-1ea2-11ea-9401-651180d20833.png">
