### PR TITLE
fix es agent remote peers error when multi host.

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/RemotePeerCache.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/RemotePeerCache.java
@@ -34,7 +34,7 @@ public class RemotePeerCache {
         if (remotePeers.isEmpty()) {
             remotePeers = hostPort;
         } else {
-            remotePeers = "," + hostPort;
+            remotePeers = remotePeers + "," + hostPort;
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientConInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientConInterceptorTest.java
@@ -52,20 +52,15 @@ public class RestHighLevelClientConInterceptorTest {
     @Mock
     private RestClient restClient;
 
-    @Mock
-    private HttpHost httpHost;
-
-
     private Object[] allArguments;
 
     private RestHighLevelClientConInterceptor restHighLevelClientConInterceptor;
 
     @Before
     public void setUp() throws Exception {
-        when(httpHost.getHostName()).thenReturn("127.0.0.1");
-        when(httpHost.getPort()).thenReturn(9200);
         List<Node> nodeList = new ArrayList<Node>();
-        nodeList.add(new Node(httpHost));
+        nodeList.add(new Node(new HttpHost("127.0.0.1", 9200)));
+        nodeList.add(new Node(new HttpHost("127.0.0.1", 9300)));
         restHighLevelClientConInterceptor = new RestHighLevelClientConInterceptor();
         when(restClientBuilder.build()).thenReturn(restClient);
         when(restClient.getNodes()).thenReturn(nodeList);
@@ -91,6 +86,6 @@ public class RestHighLevelClientConInterceptorTest {
         restHighLevelClientConInterceptor.onConstruct(objInst, allArguments);
 
         assertThat(objInst.getSkyWalkingDynamicField() instanceof RestClientEnhanceInfo, is(true));
-        assertThat(((RestClientEnhanceInfo)objInst.getSkyWalkingDynamicField()).getPeers(), is("127.0.0.1:9200"));
+        assertThat(((RestClientEnhanceInfo)objInst.getSkyWalkingDynamicField()).getPeers(), is("127.0.0.1:9200,127.0.0.1:9300"));
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
When connecting to a remote ES cluster with multi-node host, only the last node is displayed in peers  with a comma in front

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
