### PR TITLE
[CI] Add IT/E2E check statuses to index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ microservices, cloud native and container-based (Docker, Kubernetes, Mesos) arch
 [![Twitter Follow](https://img.shields.io/twitter/follow/asfskywalking.svg?style=for-the-badge&label=Follow&logo=twitter)](https://twitter.com/AsfSkyWalking)
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.skywalking/apache-skywalking-apm.svg)](http://skywalking.apache.org/downloads/)
+[![CI/IT Tests](https://github.com/apache/skywalking/workflows/CI%20AND%20IT/badge.svg?branch=master)](https://github.com/apache/skywalking/actions?query=branch%3Amaster+event%3Apush+workflow%3A%22CI+AND+IT%22)
+[![E2E Tests](https://github.com/apache/skywalking/workflows/E2E/badge.svg?branch=master)](https://github.com/apache/skywalking/actions?query=branch%3Amaster+event%3Apush+workflow%3AE2E)
 
 # Abstract
 **SkyWalking** is an open source APM system, including monitoring, tracing, diagnosing capabilities for distributed system


### PR DESCRIPTION
I happened to find that several builds on master has failed and just re-run them, this patch exposes the check statues in the main page to make them more easily to be noticed, and recommend committers/PMCs to enable the notifications for the checks in case the master branch is broken by any chances and can be discovered more quickly, hope to find a GitHub Action to send email when builds failed (not found yet)

<img width="761" alt="image" src="https://user-images.githubusercontent.com/15965696/70906282-f5ad6a00-2040-11ea-9b3a-806b3161ebcd.png">
