### PR TITLE
Fix service instance relationship ID build bug.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceRelation.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceRelation.java
@@ -38,11 +38,11 @@ public class ServiceInstanceRelation extends Source {
         return String.valueOf(sourceServiceInstanceId) + Const.ID_SPLIT + String.valueOf(destServiceInstanceId);
     }
 
-    @Getter @Setter private int sourceServiceInstanceId;
+    @Getter @Setter @ScopeDefaultColumn.DefinedByField(columnName = "source_service_instance_id") private int sourceServiceInstanceId;
     @Getter @Setter @ScopeDefaultColumn.DefinedByField(columnName = "source_service_id") private int sourceServiceId;
     @Getter @Setter private String sourceServiceName;
     @Getter @Setter private String sourceServiceInstanceName;
-    @Getter @Setter private int destServiceInstanceId;
+    @Getter @Setter @ScopeDefaultColumn.DefinedByField(columnName = "dest_service_instance_id") private int destServiceInstanceId;
     @Getter @Setter @ScopeDefaultColumn.DefinedByField(columnName = "dest_service_id") private int destServiceId;
     @Getter @Setter private String destServiceName;
     @Getter @Setter private String destServiceInstanceName;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceRelation.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceRelation.java
@@ -35,7 +35,7 @@ public class ServiceInstanceRelation extends Source {
     }
 
     @Override public String getEntityId() {
-        return String.valueOf(sourceServiceInstanceId) + Const.ID_SPLIT + String.valueOf(destServiceInstanceId) + Const.ID_SPLIT + String.valueOf(componentId);
+        return String.valueOf(sourceServiceInstanceId) + Const.ID_SPLIT + String.valueOf(destServiceInstanceId);
     }
 
     @Getter @Setter private int sourceServiceInstanceId;


### PR DESCRIPTION
The existing and unused logic of service instance relationship ID includes the component ID, which is not suitable for today's topology logic. But as this is never used before now, it isn't been found.

This causes all metrics related to `service instance relationship`, includes the component id in the entity ID too. Then UI can't use the source+target IDs to get the metrics result.