### PR TITLE
fix ServiceInstanceInventory.Builder#map2Data NPE.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/ServiceInstanceInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/ServiceInstanceInventoryRegister.java
@@ -63,6 +63,7 @@ public class ServiceInstanceInventoryRegister implements IServiceInstanceInvento
         if (serviceInstanceId == Const.NONE) {
             ServiceInstanceInventory serviceInstanceInventory = new ServiceInstanceInventory();
             serviceInstanceInventory.setServiceId(serviceId);
+            serviceInstanceInventory.setServiceInstanceNodeType(NodeType.Unknown);
             serviceInstanceInventory.setName(serviceInstanceName);
             serviceInstanceInventory.setInstanceUUID(uuid);
             serviceInstanceInventory.setIsAddress(BooleanUtils.FALSE);
@@ -89,6 +90,7 @@ public class ServiceInstanceInventoryRegister implements IServiceInstanceInvento
         if (serviceInstanceId == Const.NONE) {
             ServiceInstanceInventory serviceInstanceInventory = new ServiceInstanceInventory();
             serviceInstanceInventory.setServiceId(serviceId);
+            serviceInstanceInventory.setServiceInstanceNodeType(NodeType.Unknown);
             serviceInstanceInventory.setName(serviceInstanceName);
             serviceInstanceInventory.setIsAddress(BooleanUtils.TRUE);
             serviceInstanceInventory.setAddressId(addressId);


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

https://github.com/apache/skywalking/blob/master/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInstanceInventory.java#L153  causes NPE when https://github.com/apache/skywalking/blob/master/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInstanceInventoryCacheDAO.java#L55 method invoked. 

And this exception caused by not set `NodeType` during ServiceInstanceRegister.

- How to fix?
Set default `NodeType` when serviceInstanceInventory first  time be created.

___
### New feature or improvement
- Describe the details and related test reports.
