### PR TITLE
Log harmless exception in DEBUG level

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/ILog.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/ILog.java
@@ -51,10 +51,7 @@ public interface ILog {
 
     void debug(String format, Object... arguments);
 
-    default void debug(Throwable t, String format, Object... arguments) {
-        // Just ignore the throwable by default, to make the compiler happy
-        debug(format, arguments);
-    }
+    void debug(Throwable t, String format, Object... arguments);
 
     void error(String format);
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/ILog.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/ILog.java
@@ -51,5 +51,10 @@ public interface ILog {
 
     void debug(String format, Object... arguments);
 
+    default void debug(Throwable t, String format, Object... arguments) {
+        // Just ignore the throwable by default, to make the compiler happy
+        debug(format, arguments);
+    }
+
     void error(String format);
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/NoopLogger.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/NoopLogger.java
@@ -79,6 +79,11 @@ public enum NoopLogger implements ILog {
     }
 
     @Override
+    public void debug(final Throwable t, final String format, final Object... arguments) {
+
+    }
+
+    @Override
     public void error(String format) {
 
     }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/PatternLogger.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/PatternLogger.java
@@ -184,6 +184,12 @@ public class PatternLogger implements ILog {
         }
     }
 
+    @Override
+    public void debug(final Throwable t, final String format, final Object... arguments) {
+        if (isDebugEnable()) {
+            logger(LogLevel.DEBUG, replaceParam(format, arguments), t);
+        }
+    }
 
     String format(LogLevel level, String message, Throwable t) {
         LogEvent logEvent = new LogEvent(level, message, t, targetClass);

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ProtectiveShieldMatcher.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ProtectiveShieldMatcher.java
@@ -46,7 +46,9 @@ public class ProtectiveShieldMatcher<T> extends ElementMatcher.Junction.Abstract
         try {
             return this.matcher.matches(target);
         } catch (Throwable t) {
-            logger.debug("Byte-buddy occurs exception when match type: {}", t.getMessage());
+            if (logger.isDebugEnable()) {
+                logger.debug(t, "Byte-buddy occurs exception when match type.");
+            }
             return false;
         }
     }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ProtectiveShieldMatcher.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ProtectiveShieldMatcher.java
@@ -46,7 +46,7 @@ public class ProtectiveShieldMatcher<T> extends ElementMatcher.Junction.Abstract
         try {
             return this.matcher.matches(target);
         } catch (Throwable t) {
-            logger.warn(t, "Byte-buddy occurs exception when match type.");
+            logger.debug("Byte-buddy occurs exception when match type: {}", t.getMessage());
             return false;
         }
     }

--- a/apm-sniffer/config/agent.config
+++ b/apm-sniffer/config/agent.config
@@ -48,7 +48,7 @@ collector.backend_service=${SW_AGENT_COLLECTOR_BACKEND_SERVICES:127.0.0.1:11800}
 logging.file_name=${SW_LOGGING_FILE_NAME:skywalking-api.log}
 
 # Logging level
-logging.level=${SW_LOGGING_LEVEL:DEBUG}
+logging.level=${SW_LOGGING_LEVEL:INFO}
 
 # Logging dir
 # logging.dir=${SW_LOGGING_DIR:""}


### PR DESCRIPTION
Yet users can still troubleshoot by looking into the log keywords `ProtectiveShieldMatcher : Byte-buddy occurs exception when match type: Cannot resolve type description for ...`

closes #4155 