### PR TITLE
FAQ for backend log4j2.xml

### DIFF
--- a/dist-material/log4j2.xml
+++ b/dist-material/log4j2.xml
@@ -23,11 +23,12 @@
     </Properties>
     <Appenders>
         <RollingFile name="RollingFile" fileName="${log-path}/skywalking-oap-server.log"
-                     filePattern="${log-path}/skywalking-oap-server-%d{yyyy-MM-dd}-%i.log" >
+                     filePattern="${log-path}/skywalking-oap-server-%d{yyyy-MM-dd}-%i.log.gz" >
             <PatternLayout>
                 <pattern>%d - %c - %L [%t] %-5p %x - %m%n</pattern>
             </PatternLayout>
             <Policies>
+              	<TimeBasedTriggeringPolicy />
                 <SizeBasedTriggeringPolicy size="102400KB" />
             </Policies>
             <DefaultRolloverStrategy max="30"/>


### PR DESCRIPTION
- [ ] Improve performance
Too many  larger log files can causes the hard disk to become full    ,add   .gz and TimeBasedTriggeringPolicy  . add the two changes ,the skywalking oap logs will be zipped in .gz file . 
This changes can make the oap server run  longer times .

