### PR TITLE
improve TimeBucket class getTimeBucket method.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/TimeBucket.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/TimeBucket.java
@@ -17,13 +17,17 @@
 
 package org.apache.skywalking.oap.server.core.analysis;
 
-import java.util.Calendar;
 import org.apache.skywalking.oap.server.core.UnexpectedException;
 
 /**
  * @author peng-yongsheng
  */
 public class TimeBucket {
+
+    public static final int SECOND_BUCKET = 60;
+    public static final int HOUR_BUCKET = 60 * 60;
+    public static final int DAY_BUCKET = 60 * 60 * 24;
+    public static final int MONTH_BUCKET = 60 * 60 * 24 * 30;
 
     /**
      * Record time bucket format in Second Unit.
@@ -40,27 +44,17 @@ public class TimeBucket {
     }
 
     public static long getTimeBucket(long time, Downsampling downsampling) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTimeInMillis(time);
-
-        long year = calendar.get(Calendar.YEAR);
-        long month = calendar.get(Calendar.MONTH) + 1;
-        long day = calendar.get(Calendar.DAY_OF_MONTH);
-        long hour = calendar.get(Calendar.HOUR_OF_DAY);
-        long minute = calendar.get(Calendar.MINUTE);
-        long second = calendar.get(Calendar.SECOND);
-
         switch (downsampling) {
             case Second:
-                return year * 10000000000L + month * 100000000 + day * 1000000 + hour * 10000 + minute * 100 + second;
+                return time;
             case Minute:
-                return year * 100000000 + month * 1000000 + day * 10000 + hour * 100 + minute;
+                return time / SECOND_BUCKET;
             case Hour:
-                return year * 1000000 + month * 10000 + day * 100 + hour;
+                return time / HOUR_BUCKET;
             case Day:
-                return year * 10000 + month * 100 + day;
+                return time / DAY_BUCKET;
             case Month:
-                return year * 100 + month;
+                return time / MONTH_BUCKET;
             default:
                 throw new UnexpectedException("Unknown downsampling value.");
         }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

`
    
    @Benchmark
    @BenchmarkMode(Mode.AverageTime)
    @OutputTimeUnit(TimeUnit.MICROSECONDS)
    public long testOldBucket() throws UnexpectedException {
        Calendar calendar = Calendar.getInstance();
        calendar.setTimeInMillis(time);

        long year = calendar.get(Calendar.YEAR);
        long month = calendar.get(Calendar.MONTH) + 1;
        long day = calendar.get(Calendar.DAY_OF_MONTH);
        long hour = calendar.get(Calendar.HOUR_OF_DAY);
        long minute = calendar.get(Calendar.MINUTE);
        long second = calendar.get(Calendar.SECOND);

        switch (downsampling) {
            case Second:
                return year * 10000000000L + month * 100000000 + day * 1000000 + hour * 10000 + minute * 100 + second;
            case Minute:
                return year * 100000000 + month * 1000000 + day * 10000 + hour * 100 + minute;
            case Hour:
                return year * 1000000 + month * 10000 + day * 100 + hour;
            case Day:
                return year * 10000 + month * 100 + day;
            case Month:
                return year * 100 + month;
            default:
                throw new UnexpectedException("Unknown downsampling value.");
        }
    }

    @Benchmark
    @BenchmarkMode(Mode.AverageTime)
    @OutputTimeUnit(TimeUnit.MICROSECONDS)
    public long testNewBucket() throws UnexpectedException {
        switch (downsampling) {
            case Second:
                return time;
            case Minute:
                return time / 60;
            case Hour:
                return time / (60*60);
            case Day:
                return time / (60*60*24);
            case Month:
                return time / (60*60*24*30);
            default:
                throw new UnexpectedException("Unknown downsampling value.");
        }
    }
`


<img width="636" alt="WX20200109-111940@2x" src="https://user-images.githubusercontent.com/2892433/72035034-ad950680-32d1-11ea-9a52-7e49f26d6183.png">
