### PR TITLE
Issue about load balance of gRPC

### DIFF
--- a/.github/workflows/ci-it.yaml
+++ b/.github/workflows/ci-it.yaml
@@ -21,6 +21,7 @@ on:
   push:
     branches: 
       - master
+      - 6.x
     tags:
       - 'v*'
     

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
       - master
+      - 6.x
     tags:
       - 'v*'
 

--- a/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-trace/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-trace/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-trace/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-trace/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/pom.xml
+++ b/apm-application-toolkit/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apm-application-toolkit</artifactId>

--- a/apm-application-toolkit/pom.xml
+++ b/apm-application-toolkit/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apm-application-toolkit</artifactId>

--- a/apm-commons/apm-datacarrier/pom.xml
+++ b/apm-commons/apm-datacarrier/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/apm-datacarrier/pom.xml
+++ b/apm-commons/apm-datacarrier/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/apm-util/pom.xml
+++ b/apm-commons/apm-util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/apm-util/pom.xml
+++ b/apm-commons/apm-util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/pom.xml
+++ b/apm-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/pom.xml
+++ b/apm-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-dist-es7/pom.xml
+++ b/apm-dist-es7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-dist-es7/pom.xml
+++ b/apm-dist-es7/pom.xml
@@ -17,13 +17,11 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-dist/pom.xml
+++ b/apm-dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-dist/pom.xml
+++ b/apm-dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/apm-network/pom.xml
+++ b/apm-protocol/apm-network/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-protocol</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/apm-network/pom.xml
+++ b/apm-protocol/apm-network/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-protocol</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/pom.xml
+++ b/apm-protocol/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/pom.xml
+++ b/apm-protocol/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-agent-core</artifactId>

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent-core</artifactId>

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/StandardChannelBuilder.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/StandardChannelBuilder.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.apm.agent.core.remote;
 
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.internal.DnsNameResolverProvider;
+import io.grpc.util.RoundRobinLoadBalancerFactory;
 
 /**
  * @author zhang xin
@@ -30,6 +31,10 @@ public class StandardChannelBuilder implements ChannelBuilder {
 
     @Override public ManagedChannelBuilder build(ManagedChannelBuilder managedChannelBuilder) throws Exception {
         return managedChannelBuilder.nameResolverFactory(new DnsNameResolverProvider())
+            /**
+             * It seems the code above can only work for low gRPC version.
+             */
+            .loadBalancerFactory(RoundRobinLoadBalancerFactory.getInstance())
             .maxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE)
             .usePlaintext(USE_PLAIN_TEXT);
     }

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-agent</artifactId>

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/armeria-0.84.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/armeria-0.84.x-plugin/pom.xml
@@ -16,13 +16,11 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/armeria-0.84.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/armeria-0.84.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/ehcache-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/ehcache-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/ehcache-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/ehcache-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-grpc-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-grpc-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpClient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-httpClient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-httpasyncclient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpasyncclient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jedis-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jedis-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jedis-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/jedis-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jedis-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-jedis-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jetty-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>jetty-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>light4j-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>light4j-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>light4j-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>light4j-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-mongodb-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-mongodb-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>nutz-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>nutz-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-sdk-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-sdk-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pulsar-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pulsar-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rabbitmq-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rabbitmq-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rabbitmq-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rabbitmq-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-redisson-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-redisson-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>resteasy-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-server-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>resteasy-server-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-0.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-0.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>servicecomb-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-0.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-0.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>servicecomb-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>servicecomb-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>servicecomb-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-jdbc-1.5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-jdbc-1.5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-jdbc-1.5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-jdbc-1.5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-sphere-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-sphere-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-sphere-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-sphere-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>spring-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-cloud</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>netflix-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-cloud</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>netflix-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>netflix-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-cloud-feign-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>netflix-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-spring-cloud-feign-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-cloud</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>spring-cloud</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-spymemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spymemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>undertow-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>undertow-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>undertow-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>undertow-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertx-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>vertx-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>vertx-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>vertx-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-xmemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-xmemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-test-tools/pom.xml
+++ b/apm-sniffer/apm-test-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-test-tools</artifactId>

--- a/apm-sniffer/apm-test-tools/pom.xml
+++ b/apm-sniffer/apm-test-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-test-tools</artifactId>

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/apm-toolkit-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
@@ -16,12 +16,11 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/armeria-0.85.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/armeria-0.85.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/armeria-0.85.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/armeria-0.85.x-plugin/pom.xml
@@ -16,13 +16,11 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-gson-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-gson-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/lettuce-5.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/lettuce-5.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-lettuce-5.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/lettuce-5.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/lettuce-5.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-lettuce-5.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
 <parent>
     <groupId>org.apache.skywalking</groupId>
     <artifactId>optional-spring-cloud</artifactId>
-    <version>6.6.0</version>
+    <version>6.6.1-SNAPSHOT</version>
 </parent>
 
 <artifactId>apm-spring-cloud-gateway-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
 <parent>
     <groupId>org.apache.skywalking</groupId>
     <artifactId>optional-spring-cloud</artifactId>
-    <version>6.6.0-SNAPSHOT</version>
+    <version>6.6.0</version>
 </parent>
 
 <artifactId>apm-spring-cloud-gateway-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>optional-spring-cloud</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>optional-spring-cloud</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/pom.xml
@@ -17,13 +17,11 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/play-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/play-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-play-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/play-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/play-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-play-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <artifactId>apm-zookeeper-3.4.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-zookeeper-3.4.x-plugin</artifactId>

--- a/apm-sniffer/pom.xml
+++ b/apm-sniffer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/pom.xml
+++ b/apm-sniffer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-webapp/pom.xml
+++ b/apm-webapp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-webapp/pom.xml
+++ b/apm-webapp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/exporter/pom.xml
+++ b/oap-server/exporter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/exporter/pom.xml
+++ b/oap-server/exporter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/oal-grammar/pom.xml
+++ b/oap-server/oal-grammar/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/oal-grammar/pom.xml
+++ b/oap-server/oal-grammar/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/oal-rt/pom.xml
+++ b/oap-server/oal-rt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/oal-rt/pom.xml
+++ b/oap-server/oal-rt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/pom.xml
+++ b/oap-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/pom.xml
+++ b/oap-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-alarm-plugin/pom.xml
+++ b/oap-server/server-alarm-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-alarm-plugin/pom.xml
+++ b/oap-server/server-alarm-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-bootstrap/pom.xml
+++ b/oap-server/server-bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-bootstrap/pom.xml
+++ b/oap-server/server-bootstrap/pom.xml
@@ -17,13 +17,11 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-consul-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-consul-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-consul-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-consul-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-etcd-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-etcd-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-etcd-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-etcd-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-nacos-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-nacos-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-nacos-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-nacos-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-standalone-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-standalone-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-standalone-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-standalone-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>server-cluster-plugin</artifactId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>server-cluster-plugin</artifactId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-api/pom.xml
+++ b/oap-server/server-configuration/configuration-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-api/pom.xml
+++ b/oap-server/server-configuration/configuration-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-apollo/pom.xml
+++ b/oap-server/server-configuration/configuration-apollo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-apollo/pom.xml
+++ b/oap-server/server-configuration/configuration-apollo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-consul/pom.xml
+++ b/oap-server/server-configuration/configuration-consul/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/oap-server/server-configuration/configuration-consul/pom.xml
+++ b/oap-server/server-configuration/configuration-consul/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/oap-server/server-configuration/configuration-etcd/pom.xml
+++ b/oap-server/server-configuration/configuration-etcd/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-etcd/pom.xml
+++ b/oap-server/server-configuration/configuration-etcd/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-nacos/pom.xml
+++ b/oap-server/server-configuration/configuration-nacos/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-nacos/pom.xml
+++ b/oap-server/server-configuration/configuration-nacos/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-zookeeper/pom.xml
+++ b/oap-server/server-configuration/configuration-zookeeper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-zookeeper/pom.xml
+++ b/oap-server/server-configuration/configuration-zookeeper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/grpc-configuration-sync/pom.xml
+++ b/oap-server/server-configuration/grpc-configuration-sync/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/grpc-configuration-sync/pom.xml
+++ b/oap-server/server-configuration/grpc-configuration-sync/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/pom.xml
+++ b/oap-server/server-configuration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/pom.xml
+++ b/oap-server/server-configuration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-core/pom.xml
+++ b/oap-server/server-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-core/pom.xml
+++ b/oap-server/server-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-buffer/pom.xml
+++ b/oap-server/server-library/library-buffer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-buffer/pom.xml
+++ b/oap-server/server-library/library-buffer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-client/pom.xml
+++ b/oap-server/server-library/library-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-client/pom.xml
+++ b/oap-server/server-library/library-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-module/pom.xml
+++ b/oap-server/server-library/library-module/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-module/pom.xml
+++ b/oap-server/server-library/library-module/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-server/pom.xml
+++ b/oap-server/server-library/library-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-server/pom.xml
+++ b/oap-server/server-library/library-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-util/pom.xml
+++ b/oap-server/server-library/library-util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-util/pom.xml
+++ b/oap-server/server-library/library-util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/pom.xml
+++ b/oap-server/server-library/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/pom.xml
+++ b/oap-server/server-library/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-query-plugin/pom.xml
+++ b/oap-server/server-query-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-query-plugin/pom.xml
+++ b/oap-server/server-query-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-query-plugin/query-graphql-plugin/pom.xml
+++ b/oap-server/server-query-plugin/query-graphql-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-query-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-query-plugin/query-graphql-plugin/pom.xml
+++ b/oap-server/server-query-plugin/query-graphql-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-query-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/jaeger-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/jaeger-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/jaeger-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/jaeger-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/receiver-proto/pom.xml
+++ b/oap-server/server-receiver-plugin/receiver-proto/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/receiver-proto/pom.xml
+++ b/oap-server/server-receiver-plugin/receiver-proto/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-istio-telemetry-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-istio-telemetry-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-istio-telemetry-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-istio-telemetry-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-so11y-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-so11y-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-so11y-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-so11y-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-starter-es7/pom.xml
+++ b/oap-server/server-starter-es7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-starter-es7/pom.xml
+++ b/oap-server/server-starter-es7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-starter/pom.xml
+++ b/oap-server/server-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-starter/pom.xml
+++ b/oap-server/server-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch7-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-elasticsearch7-plugin/pom.xml
@@ -17,13 +17,11 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/oap-server/server-storage-plugin/storage-elasticsearch7-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-elasticsearch7-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/oap-server/server-storage-plugin/storage-jaeger-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-jaeger-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-jaeger-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-jaeger-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-zipkin-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-zipkin-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-zipkin-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-zipkin-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/pom.xml
+++ b/oap-server/server-telemetry/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/pom.xml
+++ b/oap-server/server-telemetry/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/telemetry-api/pom.xml
+++ b/oap-server/server-telemetry/telemetry-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-telemetry</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/telemetry-api/pom.xml
+++ b/oap-server/server-telemetry/telemetry-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-telemetry</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/telemetry-prometheus/pom.xml
+++ b/oap-server/server-telemetry/telemetry-prometheus/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-telemetry</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/telemetry-prometheus/pom.xml
+++ b/oap-server/server-telemetry/telemetry-prometheus/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-telemetry</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/telemetry-so11y/pom.xml
+++ b/oap-server/server-telemetry/telemetry-so11y/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-telemetry</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/telemetry-so11y/pom.xml
+++ b/oap-server/server-telemetry/telemetry-so11y/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-telemetry</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-testing/pom.xml
+++ b/oap-server/server-testing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0-SNAPSHOT</version>
+        <version>6.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-testing/pom.xml
+++ b/oap-server/server-testing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.6.0</version>
+        <version>6.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>apm</artifactId>
-    <version>6.6.0</version>
+    <version>6.6.1-SNAPSHOT</version>
 
     <parent>
         <groupId>org.apache</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>apm</artifactId>
-    <version>6.6.0-SNAPSHOT</version>
+    <version>6.6.0</version>
 
     <parent>
         <groupId>org.apache</groupId>
@@ -44,7 +44,7 @@
         <url>https://github.com/apache/skywalking</url>
         <connection>scm:git:https://github.com/apache/skywalking.git</connection>
         <developerConnection>scm:git:https://github.com/apache/skywalking.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v6.6.0</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
Fixed issue about loading balance of gRPC on kubenetes via this line of code. If the clients of AGENT deploy on kubernetes and call the OAP service by default cluster IP mode without any technology of service mesh like istio etc. it will occur the issue about traffic load. So for we have resolved this issue via the headless service difination without the clust IP setting and registered multiple A records of DNS for the OAP service on that. Anyway it needs to enhance the code of this class for the defualt behavior of load balance and almost has not any impact if it is out of kubernetes environment. Seems to work smoothly.

Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
