### PR TITLE
Make traces verification loosely, stabilize e2e tests

### DIFF
--- a/.github/workflows/ci-it.yaml
+++ b/.github/workflows/ci-it.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: 'Install & Test'
         run: |
           export MAVEN_OPTS='-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
-          ./mvnw -P"agent,backend,ui,dist,CI-with-IT" clean cobertura:cobertura verify install javadoc:javadoc
+          ./mvnw --batch-mode -P"agent,backend,ui,dist,CI-with-IT" clean cobertura:cobertura verify install javadoc:javadoc
           CODECOV_TOKEN="d2065307-8f01-4637-9715-2781ef096db7" bash <(curl -s https://codecov.io/bash)
       - name: 'Check Dependencies Licenses'
         run: tools/dependencies/check-LICENSE.sh
@@ -61,7 +61,7 @@ jobs:
       - name: 'Install & Test'
         run: |
           set MAVEN_OPTS='-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
-          ./mvnw -P"agent,backend,ui,dist" clean verify install
+          ./mvnw --batch-mode -P"agent,backend,ui,dist" clean verify install
 
 
   CI-on-MacOS:
@@ -79,4 +79,4 @@ jobs:
       - name: 'Install & Test'
         run: |
           export MAVEN_OPTS='-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
-          ./mvnw -P"agent,backend,ui,dist" clean verify install
+          ./mvnw --batch-mode -P"agent,backend,ui,dist" clean verify install

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,9 +35,9 @@ jobs:
         run: export MAVEN_OPTS='-Dmaven.repo.local=~/.m2/repository -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
       - name: Compile & Install Test Codes
         run: |
-          ./mvnw checkstyle:check apache-rat:check
-          ./mvnw -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests clean install
-          ./mvnw -f test/e2e/pom.xml -pl e2e-base clean install
+          ./mvnw --batch-mode checkstyle:check apache-rat:check
+          ./mvnw --batch-mode -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests clean install
+          ./mvnw --batch-mode -f test/e2e/pom.xml -pl e2e-base clean install
       - name: Single Node Tests(JDK8)
         run: export E2E_VERSION=jdk8-1.3 && bash -x test/e2e/run.sh e2e-single-service
       - name: Single Node Tests(MySQL/JDK8)
@@ -67,9 +67,9 @@ jobs:
         run: export MAVEN_OPTS='-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
       - name: Compile & Install Test Codes
         run: |
-          ./mvnw checkstyle:check apache-rat:check
-          ./mvnw -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests clean install
-          ./mvnw -f test/e2e/pom.xml -pl e2e-base clean install
+          ./mvnw --batch-mode checkstyle:check apache-rat:check
+          ./mvnw --batch-mode -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests clean install
+          ./mvnw --batch-mode -f test/e2e/pom.xml -pl e2e-base clean install
       - name: Cluster Tests (ES6/ZK/JDK8)
         run: export E2E_VERSION=jdk8-1.3 && bash -x test/e2e/run.sh e2e-cluster/e2e-cluster-test-runner
       - name: Cluster With Gateway Tests (ES6/ZK/JDK8)
@@ -91,9 +91,9 @@ jobs:
         run: export MAVEN_OPTS='-Dmaven.repo.local=~/.m2/repository -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
       - name: Compile & Install Test Codes
         run: |
-          ./mvnw checkstyle:check apache-rat:check
-          ./mvnw -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests clean install
-          ./mvnw -f test/e2e/pom.xml -pl e2e-base clean install
+          ./mvnw --batch-mode checkstyle:check apache-rat:check
+          ./mvnw --batch-mode -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests clean install
+          ./mvnw --batch-mode -f test/e2e/pom.xml -pl e2e-base clean install
       - name: 6.x Agents & 7.x Backend
         run: export E2E_VERSION=jdk8-1.3 && bash -x test/e2e/run.sh e2e-6.x-agent-7.x-oap-compatibility
 
@@ -107,9 +107,9 @@ jobs:
         run: export MAVEN_OPTS='-Dmaven.repo.local=~/.m2/repository -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
       - name: Compile & Install Test Codes
         run: |
-          ./mvnw checkstyle:check apache-rat:check
-          ./mvnw -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests clean install
-          ./mvnw -f test/e2e/pom.xml -pl e2e-base clean install
+          ./mvnw --batch-mode checkstyle:check apache-rat:check
+          ./mvnw --batch-mode -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -Dmaven.compiler.maxmem=3072 -DskipTests clean install
+          ./mvnw --batch-mode -f test/e2e/pom.xml -pl e2e-base clean install
       - name: Profile Tests H2(JDK8)
         run: export E2E_VERSION=jdk8-1.3 && bash -x test/e2e/run.sh e2e-profile/e2e-profile-test-runner --storage=h2
       - name: Profile Tests MySQL(JDK8)

--- a/.github/workflows/plugins-test.yaml
+++ b/.github/workflows/plugins-test.yaml
@@ -41,9 +41,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run spring-tx 4.x+ (10)
         run: bash test/plugin/run.sh spring-tx-scenario
       - name: Run dubbo 2.5.x-2.6.x (10)
@@ -72,9 +72,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run spring 3.1.x-4.0.x (25)
         run: bash test/plugin/run.sh spring-3.1.x-scenario
       - name: Run spring-cloud-gateway 2.1.x (3)
@@ -103,9 +103,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run apm-toolkit-trace (1)
         run: bash test/plugin/run.sh apm-toolkit-trace-scenario
       - name: Run spring-webflux 2.x (7)
@@ -136,9 +136,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run feign 9.0.0-9.5.1 (8)
         run: bash test/plugin/run.sh feign-scenario
       - name: Run customize (1)
@@ -172,9 +172,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run cassandra 3.7.0-3.7.2 (3)
         run: bash test/plugin/run.sh cassandra-java-driver-3.x-scenario
       - name: Run hystrix 1.4.20-1.5.12 (20)
@@ -203,9 +203,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run spring async 4.3.x-5.1.x (35)
         run: bash test/plugin/run.sh spring-async-scenario
       - name: Run grpc 1.6.0-1.25.0 (22)
@@ -232,9 +232,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run ehcache 2.8.x-2.10.x (19)
         run: bash test/plugin/run.sh ehcache-2.x-scenario
       - name: Run undertow 1.3.0-2.0.27 (23)
@@ -261,9 +261,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run spring 4.1.x-4.2.x (20)
         run: bash test/plugin/run.sh spring-4.1.x-scenario
       - name: Run solrj 7.x (12)
@@ -294,9 +294,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run mongodb 3.4.0-3.11.1 (22)
         run: bash test/plugin/run.sh mongodb-3.x-scenario
 
@@ -319,9 +319,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run redisson 3.x (37)
         run: bash test/plugin/run.sh redisson-scenario
       - name: Run shardingsphere-3.x-scenario 3.0.0 (1)
@@ -352,9 +352,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run spring 4.3.x-5.2.x (54)
         run: bash test/plugin/run.sh spring-4.3.x-scenario
 
@@ -377,9 +377,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run postgresql 9.4.1207+ (62)
         run: bash test/plugin/run.sh postgresql-above9.4.1207-scenario
 
@@ -402,9 +402,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run postgresql 9.2.x-9.4.x (36)
         run: bash test/plugin/run.sh postgresql-scenario
       - name: Run servicecomb 0.x (5)
@@ -431,9 +431,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run jetty 9.x (63)
         run: bash test/plugin/run.sh jetty-scenario
 
@@ -456,9 +456,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run elasticsearch-7.x-scenario 7.0.0-7.5.1 (13)
         run: bash test/plugin/run.sh elasticsearch-7.x-scenario
       - name: Run elasticsearch-6.x-scenario 6.7.1-6.8.4 (7)
@@ -483,13 +483,13 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Run oracle 10.2.0.4.0 (1)
         run: |
           curl -L -o ./skywalking-agent/plugins/apm-oracle-10.x-plugin-1.0.1.jar https://github.com/SkyAPM/java-plugin-extensions/releases/download/1.0.1/apm-oracle-10.x-plugin-1.0.1.jar
           curl -O https://skyapm.github.io/ci-assist/jars/ojdbc14-10.2.0.4.0.jar
-          ./mvnw install:install-file  -Dfile=ojdbc14-10.2.0.4.0.jar  -DgroupId=com.oracle  -DartifactId=ojdbc14 -Dversion=10.2.0.4.0 -Dpackaging=jar
-          ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+          ./mvnw --batch-mode install:install-file  -Dfile=ojdbc14-10.2.0.4.0.jar  -DgroupId=com.oracle  -DartifactId=ojdbc14 -Dversion=10.2.0.4.0 -Dpackaging=jar
+          ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
           bash test/plugin/run.sh oracle-scenario
       - name: Run activemq 5.10.0-5.15.4 (22)
         run: bash test/plugin/run.sh activemq-scenario
@@ -519,9 +519,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run mysql 5.1.2-8.0.15 (53)
         run: bash test/plugin/run.sh mysql-scenario
 
@@ -544,9 +544,9 @@ jobs:
         with:
           java-version: 8
       - name: Build SkyWalking Agent
-        run: ./mvnw clean package -DskipTests -Pagent >/dev/null
+        run: ./mvnw --batch-mode clean package -DskipTests -Pagent >/dev/null
       - name: Build the Docker image
-        run: ./mvnw -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
+        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests docker:build -DBUILD_NO=local >/dev/null
       - name: Run lettuce-scenario 5.x (17)
         run: bash test/plugin/run.sh lettuce-scenario
       - name: Run Play! Framework

--- a/test/e2e/e2e-6.x-agent-7.x-oap-compatibility/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
+++ b/test/e2e/e2e-6.x-agent-7.x-oap-compatibility/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
@@ -327,7 +327,7 @@ public class SampleVerificationITCase {
             new ClassPathResource("expected-data/org.apache.skywalking.e2e.SampleVerificationITCase.traces.yml").getInputStream();
 
         final TracesMatcher tracesMatcher = new Yaml().loadAs(expectedInputStream, TracesMatcher.class);
-        tracesMatcher.verify(traces);
+        tracesMatcher.verifyLoosely(traces);
     }
 
     private void verifyServiceInstanceRelationMetrics(List<Call> calls, final LocalDateTime minutesAgo) throws Exception {

--- a/test/e2e/e2e-agent-auth/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
+++ b/test/e2e/e2e-agent-auth/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
@@ -338,7 +338,7 @@ public class SampleVerificationITCase {
             new ClassPathResource("expected-data/org.apache.skywalking.e2e.SampleVerificationITCase.traces.yml").getInputStream();
 
         final TracesMatcher tracesMatcher = new Yaml().loadAs(expectedInputStream, TracesMatcher.class);
-        tracesMatcher.verify(traces);
+        tracesMatcher.verifyLoosely(traces);
     }
 
     private void verifyServiceInstanceRelationMetrics(List<Call> calls, final LocalDateTime minutesAgo) throws Exception {

--- a/test/e2e/e2e-base/src/main/java/org/apache/skywalking/e2e/trace/TracesMatcher.java
+++ b/test/e2e/e2e-base/src/main/java/org/apache/skywalking/e2e/trace/TracesMatcher.java
@@ -20,13 +20,14 @@ package org.apache.skywalking.e2e.trace;
 
 import java.util.LinkedList;
 import java.util.List;
+import lombok.Data;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author kezhenxu94
  */
+@Data
 public class TracesMatcher {
     private List<TraceMatcher> traces;
 
@@ -34,35 +35,17 @@ public class TracesMatcher {
         this.traces = new LinkedList<>();
     }
 
-    public List<TraceMatcher> getTraces() {
-        return traces;
-    }
-
-    public void setTraces(List<TraceMatcher> traces) {
-        this.traces = traces;
-    }
-
-    public void verify(final List<Trace> traces) {
-        assertThat(traces).hasSameSizeAs(this.traces);
-
-        int size = this.traces.size();
-
-        for (int i = 0; i < size; i++) {
-            this.traces.get(i).verify(traces.get(i));
-        }
-    }
-
     /**
      * Verify the traces in a loose manner
      *
-     * @param traces
+     * @param traces the traces to verify
      */
     public void verifyLoosely(final List<Trace> traces) {
-        for (int i = 0; i < getTraces().size(); i++) {
+        for (final TraceMatcher matcher : getTraces()) {
             boolean matched = false;
-            for (int j = 0; j < traces.size(); j++) {
+            for (final Trace trace : traces) {
                 try {
-                    getTraces().get(i).verify(traces.get(j));
+                    matcher.verify(trace);
                     matched = true;
                 } catch (Throwable ignored) {
                 }
@@ -71,12 +54,5 @@ public class TracesMatcher {
                 fail("Expected: %s\n Actual: %s", getTraces(), traces);
             }
         }
-    }
-
-    @Override
-    public String toString() {
-        return "TracesMatcher{" +
-            "traces=" + traces +
-            '}';
     }
 }

--- a/test/e2e/e2e-mysql/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
+++ b/test/e2e/e2e-mysql/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
@@ -327,7 +327,7 @@ public class SampleVerificationITCase {
             new ClassPathResource("expected-data/org.apache.skywalking.e2e.SampleVerificationITCase.traces.yml").getInputStream();
 
         final TracesMatcher tracesMatcher = new Yaml().loadAs(expectedInputStream, TracesMatcher.class);
-        tracesMatcher.verify(traces);
+        tracesMatcher.verifyLoosely(traces);
     }
 
     private void verifyServiceInstanceRelationMetrics(List<Call> calls, final LocalDateTime minutesAgo) throws Exception {

--- a/test/e2e/e2e-single-service/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
+++ b/test/e2e/e2e-single-service/src/test/java/org/apache/skywalking/e2e/SampleVerificationITCase.java
@@ -327,7 +327,7 @@ public class SampleVerificationITCase {
             new ClassPathResource("expected-data/org.apache.skywalking.e2e.SampleVerificationITCase.traces.yml").getInputStream();
 
         final TracesMatcher tracesMatcher = new Yaml().loadAs(expectedInputStream, TracesMatcher.class);
-        tracesMatcher.verify(traces);
+        tracesMatcher.verifyLoosely(traces);
     }
 
     private void verifyServiceInstanceRelationMetrics(List<Call> calls, final LocalDateTime minutesAgo) throws Exception {

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -55,7 +55,7 @@ done
 
 [[ ${build} -eq 1 ]] \
   && echo 'Building distribution package...' \
-  && ./mvnw --activate-profiles "${profiles}" -q -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -DskipTests -am clean install
+  && ./mvnw --batch-mode --activate-profiles "${profiles}" -q -Dcheckstyle.skip -Drat.skip -T2 -Dmaven.compile.fork -DskipTests -am clean install
 
 echo "Running cases: $(IFS=$' '; echo "${cases[*]}")"
 
@@ -69,7 +69,7 @@ do
   # so we give each test a separate distribution folder here
   mkdir -p "$test_case" && tar -zxf dist/${DIST_PACKAGE} -C "$test_case"
 
-  ./mvnw -Dbuild.id="${BUILD_ID:-local}" \
+  ./mvnw --batch-mode -Dbuild.id="${BUILD_ID:-local}" \
          -De2e.container.version="${E2E_VERSION}" \
          -Delasticsearch.version="${ES_VERSION}" \
          -Dsw.home="${base_dir}/$test_case/${DIST_PACKAGE//.tar.gz/}" \

--- a/test/plugin/run.sh
+++ b/test/plugin/run.sh
@@ -148,9 +148,9 @@ test -z "$scenario_name" && exitWithMessage "Missing value for the scenario argu
 
 if [[ ! -d ${agent_home} ]]; then
     echo "[WARN] SkyWalking Agent not exists"
-    ${mvnw} -f ${home}/../../pom.xml -Pagent -DskipTests clean package
+    ${mvnw} --batch-mode -f ${home}/../../pom.xml -Pagent -DskipTests clean package
 fi
-[[ "$force_build" == "on" ]] && ${mvnw} -f ${home}/pom.xml clean package -DskipTests -DBUILD_NO=${BUILD_NO:=local} docker:build
+[[ "$force_build" == "on" ]] && ${mvnw} --batch-mode -f ${home}/pom.xml clean package -DskipTests -DBUILD_NO=${BUILD_NO:=local} docker:build
 
 workspace="${home}/workspace/${scenario_name}"
 task_state_house="${workspace}/.states"
@@ -198,7 +198,7 @@ do
     cp ./config/expectedData.yaml ${case_work_base}/data
 
     # echo "build ${testcase_name}"
-    ${mvnw} clean package -Dtest.framework.version=${version} && \
+    ${mvnw} --batch-mode clean package -Dtest.framework.version=${version} && \
         mv ./target/${scenario_name}.* ${case_work_base}
 
     java -jar \

--- a/tools/dependencies/check-LICENSE.sh
+++ b/tools/dependencies/check-LICENSE.sh
@@ -21,7 +21,7 @@ tar -zxf dist/apache-skywalking-apm-bin.tar.gz -C dist
 
 # List all modules(jars) that belong to the SkyWalking itself, these will be ignored
 # when checking the dependency licenses
-./mvnw -Pbackend -Dexec.executable='echo' -Dexec.args='${project.artifactId}-${project.version}.jar' exec:exec -q > self-modules.txt
+./mvnw --batch-mode -Pbackend -Dexec.executable='echo' -Dexec.args='${project.artifactId}-${project.version}.jar' exec:exec -q > self-modules.txt
 
 ls dist/apache-skywalking-apm-bin/oap-libs > all-dependencies.txt
 


### PR DESCRIPTION
### Motivation:

Make E2E tests more stable.

### Modifications:

- Verify the traces loosely as other tests, and remove the `verify` method which verifies traces strictly, as we have preparation that also generates traces.
- Add mvn option `--batch-mode` to get rid of the downloading progress.

### Result:

E2E tests are more stable.
