### PR TITLE
Upgrade the bytebuddy to 1.10.7 for J9VM

### DIFF
--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -36,7 +36,7 @@
         <jetty.version>9.4.2.v20170220</jetty.version>
         <grpc.version>1.26.0</grpc.version>
         <guava.version>20.0</guava.version>
-        <bytebuddy.version>1.10.1</bytebuddy.version>
+        <bytebuddy.version>1.10.7</bytebuddy.version>
         <wiremock.version>2.6.0</wiremock.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>


### PR DESCRIPTION
Following 
1. https://twitter.com/rafaelcodes/status/1224692043068379139
1. https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.10.7

Avoid one J9VM issue.