### PR TITLE
Reduce footprint via prototype pattern when tagging spans

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/tag/Tags.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/tag/Tags.java
@@ -19,6 +19,9 @@
 
 package org.apache.skywalking.apm.agent.core.context.tag;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * The span tags are supported by sky-walking engine. As default, all tags will be stored, but these ones have
  * particular meanings.
@@ -26,6 +29,8 @@ package org.apache.skywalking.apm.agent.core.context.tag;
  * Created by wusheng on 2017/2/17.
  */
 public final class Tags {
+    private static final Map<String, StringTag> TAG_PROTOTYPES = new ConcurrentHashMap<>();
+
     private Tags() {
     }
 
@@ -78,5 +83,16 @@ public final class Tags {
         public static final StringTag METHOD = new StringTag(10, "http.method");
 
         public static final StringTag PARAMS = new StringTag(11, "http.params");
+    }
+
+    /**
+     * Creates a {@code StringTag} with the given key and cache it,
+     * if it's created before, simply return it without creating a new one.
+     *
+     * @param key the {@code key} of the tag
+     * @return the {@code StringTag}
+     */
+    public static AbstractTag<String> ofKey(final String key) {
+        return TAG_PROTOTYPES.computeIfAbsent(key, StringTag::new);
     }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/AbstractSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/AbstractSpan.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.agent.core.context.trace;
 import java.util.Map;
 import org.apache.skywalking.apm.agent.core.context.AsyncSpan;
 import org.apache.skywalking.apm.agent.core.context.tag.AbstractTag;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.network.trace.component.Component;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 
@@ -53,6 +54,7 @@ public interface AbstractSpan extends AsyncSpan {
      * Set a key:value tag on the Span.
      *
      * @return this Span instance, for chaining
+     * @deprecated use {@link #tag(AbstractTag, String)} in companion with {@link Tags#ofKey(String)} instead
      */
     @Deprecated
     AbstractSpan tag(String key, String value);
@@ -62,7 +64,7 @@ public interface AbstractSpan extends AsyncSpan {
      * @param value
      * @return
      */
-    AbstractSpan tag(AbstractTag tag, String value);
+    AbstractSpan tag(AbstractTag<?> tag, String value);
 
     /**
      * Record an exception event of the current walltime timestamp.

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/AbstractTracingSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/AbstractTracingSpan.java
@@ -102,18 +102,18 @@ public abstract class AbstractTracingSpan implements AbstractSpan {
     /**
      * Set a key:value tag on the Span.
      *
+     * {@inheritDoc}
      * @return this Span instance, for chaining
      */
     @Override
-    @Deprecated
     public AbstractTracingSpan tag(String key, String value) {
-        return tag(new StringTag(key), value);
+        return tag(Tags.ofKey(key), value);
     }
 
     @Override
-    public AbstractTracingSpan tag(AbstractTag tag, String value) {
+    public AbstractTracingSpan tag(AbstractTag<?> tag, String value) {
         if (tags == null) {
-            tags = new ArrayList<TagValuePair>(8);
+            tags = new ArrayList<>(8);
         }
 
         if (tag.isCanOverwrite()) {
@@ -156,7 +156,7 @@ public abstract class AbstractTracingSpan implements AbstractSpan {
     @Override
     public AbstractTracingSpan log(Throwable t) {
         if (logs == null) {
-            logs = new LinkedList<LogDataEntity>();
+            logs = new LinkedList<>();
         }
         logs.add(new LogDataEntity.Builder()
             .add(new KeyValuePair("event", "error"))
@@ -176,7 +176,7 @@ public abstract class AbstractTracingSpan implements AbstractSpan {
     @Override
     public AbstractTracingSpan log(long timestampMicroseconds, Map<String, ?> fields) {
         if (logs == null) {
-            logs = new LinkedList<LogDataEntity>();
+            logs = new LinkedList<>();
         }
         LogDataEntity.Builder builder = new LogDataEntity.Builder();
         for (Map.Entry<String, ?> entry : fields.entrySet()) {
@@ -330,7 +330,7 @@ public abstract class AbstractTracingSpan implements AbstractSpan {
 
     @Override public void ref(TraceSegmentRef ref) {
         if (refs == null) {
-            refs = new LinkedList<TraceSegmentRef>();
+            refs = new LinkedList<>();
         }
         if (!refs.contains(ref)) {
             refs.add(ref);

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitSpan.java
@@ -73,7 +73,7 @@ public class ExitSpan extends StackBasedTracingSpan implements WithPeerInfo {
         return this;
     }
 
-    @Override public AbstractTracingSpan tag(AbstractTag tag, String value) {
+    @Override public AbstractTracingSpan tag(AbstractTag<?> tag, String value) {
         if (stackDepth == 1 || tag.isCanOverwrite()) {
             super.tag(tag, value);
         }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/LocalSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/LocalSpan.java
@@ -36,18 +36,6 @@ public class LocalSpan extends AbstractTracingSpan {
         super(spanId, parentSpanId, operationName, owner);
     }
 
-    @Override
-    public LocalSpan tag(String key, String value) {
-        super.tag(key, value);
-        return this;
-    }
-
-    @Override
-    public LocalSpan log(Throwable t) {
-        super.log(t);
-        return this;
-    }
-
     @Override public boolean isEntry() {
         return false;
     }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/NoopSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/NoopSpan.java
@@ -65,7 +65,7 @@ public class NoopSpan implements AbstractSpan {
         return this;
     }
 
-    @Override public AbstractSpan tag(AbstractTag tag, String value) {
+    @Override public AbstractSpan tag(AbstractTag<?> tag, String value) {
         return this;
     }
 

--- a/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/canal/CanalInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/canal/CanalInterceptor.java
@@ -19,7 +19,9 @@
 package org.apache.skywalking.apm.plugin.canal;
 
 import com.alibaba.otter.canal.client.impl.SimpleCanalConnector;
+import java.util.Objects;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
@@ -42,7 +44,7 @@ public class CanalInterceptor implements InstanceMethodsAroundInterceptor {
         SimpleCanalConnector connector = (SimpleCanalConnector) objInst;
 
         String  url = canalEnhanceInfo.getUrl();
-        if (url == "" || url == null) {
+        if (Objects.equals(url, "") || url == null) {
             InetSocketAddress address = (InetSocketAddress)connector.getNextAddress();
             String runningAddress = address.getAddress().toString() + ":" + address.getPort();
             runningAddress = runningAddress.replace('/',' ');
@@ -62,8 +64,8 @@ public class CanalInterceptor implements InstanceMethodsAroundInterceptor {
         String destination = canalEnhanceInfo.getDestination();
         AbstractSpan activeSpan = ContextManager.createExitSpan("Canal/" + destination,url).start(System.currentTimeMillis());
         activeSpan.setComponent(ComponentsDefine.CANAL);
-        activeSpan.tag("batchSize",batchSize);
-        activeSpan.tag("destination",destination);
+        activeSpan.tag(Tags.ofKey("batchSize"), batchSize);
+        activeSpan.tag(Tags.ofKey("destination"), destination);
 
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/esjob/JobExecutorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/esjob/JobExecutorInterceptor.java
@@ -24,6 +24,7 @@ import com.dangdang.ddframe.job.executor.ShardingContexts;
 import com.google.common.base.Strings;
 import java.lang.reflect.Method;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
@@ -49,7 +50,7 @@ public class JobExecutorInterceptor implements InstanceMethodsAroundInterceptor 
         }
         AbstractSpan span = ContextManager.createLocalSpan(operateName);
         span.setComponent(ComponentsDefine.ELASTIC_JOB);
-        span.tag("sharding_context", shardingContext.toString());
+        span.tag(Tags.ofKey("sharding_context"), shardingContext.toString());
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v5/Constants.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v5/Constants.java
@@ -18,6 +18,9 @@
 
 package org.apache.skywalking.apm.plugin.elasticsearch.v5;
 
+import org.apache.skywalking.apm.agent.core.context.tag.AbstractTag;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+
 /**
  * @author oatiz.
  */
@@ -29,16 +32,16 @@ class Constants {
 
     static final String BASE_FUTURE_METHOD = "actionGet";
 
-    static final String ES_NODE = "node.address";
+    static final AbstractTag<String> ES_NODE = Tags.ofKey("node.address");
 
-    static final String ES_INDEX = "es.indices";
+    static final AbstractTag<String> ES_INDEX = Tags.ofKey("es.indices");
 
-    static final String ES_TYPE = "es.types";
+    static final AbstractTag<String> ES_TYPE = Tags.ofKey("es.types");
 
-    static final String ES_TOOK_MILLIS = "es.took_millis";
+    static final AbstractTag<String> ES_TOOK_MILLIS = Tags.ofKey("es.took_millis");
 
-    static final String ES_TOTAL_HITS = "es.total_hits";
+    static final AbstractTag<String> ES_TOTAL_HITS = Tags.ofKey("es.total_hits");
 
-    static final String ES_INGEST_TOOK_MILLIS = "es.ingest_took_millis";
+    static final AbstractTag<String> ES_INGEST_TOOK_MILLIS = Tags.ofKey("es.ingest_took_millis");
 
 }

--- a/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/src/main/java/org/apache/skywalking/apm/plugin/netty/socketio/NettySocketIOConnectionInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/src/main/java/org/apache/skywalking/apm/plugin/netty/socketio/NettySocketIOConnectionInterceptor.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.plugin.netty.socketio;
 import com.corundumstudio.socketio.SocketIOClient;
 import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
@@ -47,7 +48,7 @@ public class NettySocketIOConnectionInterceptor implements InstanceMethodsAround
         // set client addr
         InetSocketAddress remoteAddress = (InetSocketAddress) client.getRemoteAddress();
         String clientAddress = remoteAddress.getAddress().getHostAddress() + ":" + remoteAddress.getPort();
-        span.tag("from", clientAddress);
+        span.tag(Tags.ofKey("from"), clientAddress);
     }
 
     @Override

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/opentracing/span/ConstructorWithSpanBuilderInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/opentracing/span/ConstructorWithSpanBuilderInterceptor.java
@@ -19,6 +19,7 @@
 
 package org.apache.skywalking.apm.toolkit.activation.opentracing.span;
 
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor;
@@ -43,7 +44,7 @@ public class ConstructorWithSpanBuilderInterceptor implements InstanceConstructo
         }
 
         for (Tag tag : spanBuilder.getTags()) {
-            span.tag(tag.getKey(), tag.getValue());
+            span.tag(Tags.ofKey(tag.getKey()), tag.getValue());
         }
         span.setComponent(spanBuilder.getComponentName());
         if (spanBuilder.isError()) {

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/opentracing/span/SpanSetTagInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/opentracing/span/SpanSetTagInterceptor.java
@@ -46,7 +46,7 @@ public class SpanSetTagInterceptor implements InstanceMethodsAroundInterceptor {
         } else if (Tags.ERROR.getKey().equals(tagKey) && "true".equals(tagValue)) {
             activeSpan.errorOccurred();
         } else {
-            activeSpan.tag(tagKey, tagValue);
+            activeSpan.tag(org.apache.skywalking.apm.agent.core.context.tag.Tags.ofKey(tagKey), tagValue);
         }
         return ret;
     }

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/trace/ActiveSpanTagInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/trace/ActiveSpanTagInterceptor.java
@@ -20,6 +20,7 @@
 package org.apache.skywalking.apm.toolkit.activation.trace;
 
 import java.lang.reflect.Method;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
@@ -28,11 +29,10 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
 public class ActiveSpanTagInterceptor implements StaticMethodsAroundInterceptor {
     @Override public void beforeMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
         MethodInterceptResult result) {
-        AbstractSpan activeSpan = null;
         try {
-            activeSpan = ContextManager.activeSpan();
-            activeSpan.tag(String.valueOf(allArguments[0]), String.valueOf(allArguments[1]));
-        } catch (NullPointerException e) {
+            AbstractSpan activeSpan = ContextManager.activeSpan();
+            activeSpan.tag(Tags.ofKey(String.valueOf(allArguments[0])), String.valueOf(allArguments[1]));
+        } catch (NullPointerException ignored) {
         }
     }
 

--- a/apm-sniffer/optional-plugins/customize-enhance-plugin/src/main/java/org/apache/skywalking/apm/plugin/customize/interceptor/BaseInterceptorMethods.java
+++ b/apm-sniffer/optional-plugins/customize-enhance-plugin/src/main/java/org/apache/skywalking/apm/plugin/customize/interceptor/BaseInterceptorMethods.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.apm.plugin.customize.interceptor;
 
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.plugin.customize.conf.CustomizeConfiguration;
 import org.apache.skywalking.apm.plugin.customize.conf.MethodConfiguration;
@@ -75,7 +76,7 @@ class BaseInterceptorMethods {
                 AbstractSpan span = ContextManager.createLocalSpan(operationName);
                 if (!spanTags.isEmpty()) {
                     for (Map.Entry<String, String> tag : spanTags.entrySet()) {
-                        span.tag(tag.getKey(), tag.getValue());
+                        span.tag(Tags.ofKey(tag.getKey()), tag.getValue());
                     }
                 }
                 if (!spanLogs.isEmpty()) {

--- a/apm-sniffer/optional-plugins/gson-2.8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/gson/GsonFromJsonInterceptor.java
+++ b/apm-sniffer/optional-plugins/gson-2.8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/gson/GsonFromJsonInterceptor.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.apm.plugin.gson;
 
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
@@ -39,8 +40,8 @@ public class GsonFromJsonInterceptor implements InstanceMethodsAroundInterceptor
 
         AbstractSpan span = ContextManager.createLocalSpan("Gson/FromJson");
         span.setComponent(ComponentsDefine.GSON);
-        Integer length = allArguments[0].toString().length();
-        span.tag("length", length.toString());
+        int length = allArguments[0].toString().length();
+        span.tag(Tags.ofKey("length"), Integer.toString(length));
 
     }
 

--- a/apm-sniffer/optional-plugins/gson-2.8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/gson/GsonToJsonInterceptor.java
+++ b/apm-sniffer/optional-plugins/gson-2.8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/gson/GsonToJsonInterceptor.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.apm.plugin.gson;
 
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
@@ -38,8 +39,8 @@ public class GsonToJsonInterceptor implements InstanceMethodsAroundInterceptor {
 
         AbstractSpan span = ContextManager.createLocalSpan("Gson/ToJson");
         span.setComponent(ComponentsDefine.GSON);
-        Integer length = allArguments[0].toString().length();
-        span.tag("length", length.toString());
+        int length = allArguments[0].toString().length();
+        span.tag(Tags.ofKey("length"), Integer.toString(length));
 
     }
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/transaction/context/Constants.java
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/transaction/context/Constants.java
@@ -17,6 +17,9 @@
  */
 package org.apache.skywalking.apm.plugin.spring.transaction.context;
 
+import org.apache.skywalking.apm.agent.core.context.tag.AbstractTag;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+
 /**
  * @author zhaoyuguang
  */
@@ -25,11 +28,11 @@ public interface Constants {
     String OPERATION_NAME_SPRING_TRANSACTION_PREFIX = "TX/";
     String OPERATION_NAME_SPRING_TRANSACTION_GET_TRANSACTION_METHOD = OPERATION_NAME_SPRING_TRANSACTION_PREFIX + "get/";
     String OPERATION_NAME_SPRING_TRANSACTION_NO_TRANSACTION_DEFINITION_GIVEN = OPERATION_NAME_SPRING_TRANSACTION_GET_TRANSACTION_METHOD + "noTransactionDefinitionGiven";
-    String TAG_SPRING_TRANSACTION_ISOLATION_LEVEL = "isolationLevel";
-    String TAG_SPRING_TRANSACTION_PROPAGATION_BEHAVIOR = "propagationBehavior";
-    String TAG_SPRING_TRANSACTION_TIMEOUT = "timeout";
-    String TAG_SPRING_TRANSACTION_IS_NEW_TRANSACTION = "isNewTransaction";
-    String TAG_SPRING_TRANSACTION_HAS_SAVEPOINT = "hasSavepoint";
-    String TAG_SPRING_TRANSACTION_ROLLBACK_ONLY = "rollbackOnly";
-    String TAG_SPRING_TRANSACTION_IS_COMPLETED = "isCompleted";
+    AbstractTag<String> TAG_SPRING_TRANSACTION_ISOLATION_LEVEL = Tags.ofKey("isolationLevel");
+    AbstractTag<String> TAG_SPRING_TRANSACTION_PROPAGATION_BEHAVIOR = Tags.ofKey("propagationBehavior");
+    AbstractTag<String> TAG_SPRING_TRANSACTION_TIMEOUT = Tags.ofKey("timeout");
+    AbstractTag<String> TAG_SPRING_TRANSACTION_IS_NEW_TRANSACTION = Tags.ofKey("isNewTransaction");
+    AbstractTag<String> TAG_SPRING_TRANSACTION_HAS_SAVEPOINT = Tags.ofKey("hasSavepoint");
+    AbstractTag<String> TAG_SPRING_TRANSACTION_ROLLBACK_ONLY = Tags.ofKey("rollbackOnly");
+    AbstractTag<String> TAG_SPRING_TRANSACTION_IS_COMPLETED = Tags.ofKey("isCompleted");
 }

--- a/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/zookeeper/ZooOpt.java
+++ b/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/zookeeper/ZooOpt.java
@@ -19,6 +19,8 @@
 package org.apache.skywalking.apm.plugin.zookeeper;
 
 import org.apache.jute.Record;
+import org.apache.skywalking.apm.agent.core.context.tag.AbstractTag;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.ZooDefs;
@@ -32,12 +34,12 @@ import java.util.Map;
  */
 class ZooOpt {
 
-    private static final Map<Integer, String> OPTS = new HashMap<Integer, String>();
-    private static final String PATH = "path";
-    private static final String VERSION = "version";
-    private static final String WATCH = "watch";
-    private static final String MAX_CHILDREN = "max";
-    private static final String KEEPER_STATE = "state";
+    private static final Map<Integer, String> OPTS = new HashMap<>();
+    private static final AbstractTag<String> PATH = Tags.ofKey("path");
+    private static final AbstractTag<String> VERSION = Tags.ofKey("version");
+    private static final AbstractTag<String> WATCH = Tags.ofKey("watch");
+    private static final AbstractTag<String> MAX_CHILDREN = Tags.ofKey("max");
+    private static final AbstractTag<String> KEEPER_STATE = Tags.ofKey("state");
 
     static {
         OPTS.put(ZooDefs.OpCode.notification, "notification");


### PR DESCRIPTION
### Motivation:

Reduce footprint when tagging spans with the deprecated API: `AbstractSpan#tag(String, String)`.

### Modifications:

- Adopt [prototype pattern](https://en.wikipedia.org/wiki/Prototype_pattern) to create `Tag`, prevent from creating too many `StringTag` instances and `GC`ed, because `AbstractSpan#tag(String, String)` simply `new` a `StringTag` every time and calls `AbstractSpan#tag(AbstractTag, String)`.

- Replace `AbstractSpan#tag(String, String)` with `AbstractSpan#tag(AbstractTag, String)`.

### Result:

- Footprint is reduced.
