### PR TITLE
[BUG]Fix the bug of port identification failure when connecting Oracle with Sid mode (JDBC: Oracle: thin: @ < host >: < port > / < Sid >)

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/OracleURLParser.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/OracleURLParser.java
@@ -94,6 +94,10 @@ public class OracleURLParser extends AbstractURLParser {
         String[] hostSegment = splitDatabaseAddress(host);
         String databaseName = fetchDatabaseNameFromURL();
         if (hostSegment.length == 1) {
+            if (databaseName.contains("/") && databaseName.split("/").length == 2) {
+                String[] portAndDatabaseName = databaseName.split("/");
+                return new ConnectionInfo(ComponentsDefine.OJDBC, DB_TYPE, host, Integer.valueOf(portAndDatabaseName[0]), portAndDatabaseName[1]);
+            }
             return new ConnectionInfo(ComponentsDefine.OJDBC, DB_TYPE, host, DEFAULT_PORT, databaseName);
         } else {
             return new ConnectionInfo(ComponentsDefine.OJDBC, DB_TYPE, hostSegment[0], Integer.valueOf(hostSegment[1]), databaseName);

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/OracleURLParser.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/OracleURLParser.java
@@ -94,10 +94,6 @@ public class OracleURLParser extends AbstractURLParser {
         String[] hostSegment = splitDatabaseAddress(host);
         String databaseName = fetchDatabaseNameFromURL();
         if (hostSegment.length == 1) {
-            if (databaseName.contains("/") && databaseName.split("/").length == 2) {
-                String[] portAndDatabaseName = databaseName.split("/");
-                return new ConnectionInfo(ComponentsDefine.OJDBC, DB_TYPE, host, Integer.valueOf(portAndDatabaseName[0]), portAndDatabaseName[1]);
-            }
             return new ConnectionInfo(ComponentsDefine.OJDBC, DB_TYPE, host, DEFAULT_PORT, databaseName);
         } else {
             return new ConnectionInfo(ComponentsDefine.OJDBC, DB_TYPE, hostSegment[0], Integer.valueOf(hostSegment[1]), databaseName);
@@ -140,6 +136,22 @@ public class OracleURLParser extends AbstractURLParser {
 
     private String[] splitDatabaseAddress(String address) {
         String[] hostSegment = address.split(":");
-        return hostSegment;
+        if (hostSegment.length == 1 && super.fetchDatabaseNameFromURL().contains("/")) {
+            String[] portAndDatabaseName = super.fetchDatabaseNameFromURL().split("/");
+            return new String[]{hostSegment[0], portAndDatabaseName[0]};
+        } else {
+            return hostSegment;
+        }
+    }
+
+    @Override
+    protected String fetchDatabaseNameFromURL() {
+        String databaseName = super.fetchDatabaseNameFromURL();
+        if (databaseName.contains("/")) {
+            String[] portAndDatabaseName = databaseName.split("/");
+            return portAndDatabaseName[1];
+        } else {
+            return databaseName;
+        }
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
@@ -83,6 +83,14 @@ public class URLParserTest {
     }
 
     @Test
+    public void testParseOracleSID() {
+        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:oracle:thin:@localhost:1522/orcl");
+        assertThat(connectionInfo.getDBType(), is("Oracle"));
+        assertThat(connectionInfo.getDatabaseName(), is("orcl"));
+        assertThat(connectionInfo.getDatabasePeer(), is("localhost:1522"));
+    }
+
+    @Test
     public void testParseOracleServiceName() {
         ConnectionInfo connectionInfo = new URLParser().parser("jdbc:oracle:thin:@//localhost:1521/orcl");
         assertThat(connectionInfo.getDBType(), is("Oracle"));


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix

- Related issues

___
### Bug fix
- Bug description.
When some older projects (using Oracle database) access skywalking, we find that the port and database name of Oracle are incorrectly identified. The port is recognized as 1521 by default and the database name is recognized as < port > / < dbname >.
We found that when we cut the Oracle URL, we only recognize the URL of one sid connection mode (jdbc: oracle: thin: @ < host >: < port >: < Sid >); so here I added the recognition of the URL of another sidsid connection mode (jdbc: oracle: thin: @ < host >: < port > / < Sid >).

- How to fix?
An if branch is added before setting the default port.