### PR TITLE
Fix non-atomic operations on volatile variables

### DIFF
--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/MultipleChannelsConsumer.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/MultipleChannelsConsumer.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.apm.commons.datacarrier.consumer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.Channels;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.QueueBuffer;
 
@@ -30,12 +31,13 @@ import org.apache.skywalking.apm.commons.datacarrier.buffer.QueueBuffer;
 public class MultipleChannelsConsumer extends Thread {
     private volatile boolean running;
     private volatile ArrayList<Group> consumeTargets;
-    private volatile long size;
+    private final AtomicLong size;
     private final long consumeCycle;
 
     public MultipleChannelsConsumer(String threadName, long consumeCycle) {
         super(threadName);
-        this.consumeTargets = new ArrayList<Group>();
+        this.consumeTargets = new ArrayList<>();
+        this.size = new AtomicLong(0);
         this.consumeCycle = consumeCycle;
     }
 
@@ -99,11 +101,11 @@ public class MultipleChannelsConsumer extends Thread {
         }
         newList.add(group);
         consumeTargets = newList;
-        size += channels.size();
+        size.addAndGet(channels.size());
     }
 
     public long size() {
-        return size;
+        return size.get();
     }
 
     void shutdown() {

--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/partition/SimpleRollingPartitioner.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/partition/SimpleRollingPartitioner.java
@@ -18,15 +18,17 @@
 
 package org.apache.skywalking.apm.commons.datacarrier.partition;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * use normal int to rolling.
  */
 public class SimpleRollingPartitioner<T> implements IDataPartitioner<T> {
-    private volatile int i = 0;
+    private AtomicInteger i = new AtomicInteger(0);
 
     @Override
     public int partition(int total, T data) {
-        return Math.abs(i++ % total);
+        return Math.abs(i.getAndIncrement() % total);
     }
 
     @Override


### PR DESCRIPTION
### Motivation:

Fix non-atomic operations on `volatile` variables.

### Modifications:

Replace `int`, `long` with `AtomicInteger` and `AtomicLong`.

### Result:

No potential threading visibility issues caused by non-atomic operations on `volatile` variables.
