### PR TITLE
Update committer review and merge guide

### DIFF
--- a/docs/en/guides/asf/committer.md
+++ b/docs/en/guides/asf/committer.md
@@ -121,11 +121,11 @@ Notice, if never got your GitHub invitation? Visit github.com/apache to see if y
 If you want others could see you are in the Apache GitHub org, you need to go to [Apache GitHub org people page](https://github.com/orgs/apache/people), 
 search for yourself, and choose `Organization visibility` to `Public`.
 
-### Committer right, duty and responsibility
+### Committer rights, duties and responsibilities
 SkyWalking project doesn't require the continue contributions after you become a committer, but we hope and truly want you could.
 
 Being a committer, you could
-1. Review and merge the pull request to the master branch in the Apache repo. For new committer, we hope you could request some senior committer to recheck the pull request.
+1. Review and merge the pull request to the master branch in the Apache repo. A pull request often contains multiple commits. Those commits **must be squashed and merged** into a single commit **with explanatory comments**. For new committer, we hope you could request some senior committer to recheck the pull request.
 1. Create and push codes to new branch in the Apache repo.
 1. Follow the [Release process](../How-to-release.md) to process new release. Of course, you need to ask committer team
 to confirm it is the right time to release.


### PR DESCRIPTION
Since we have more and more committers, this patch updates some worth-noted guide when committers are merging pull requests, avoid too many useless commits in Git log, like #4379

@apache/skywalking-committers and @aderm , please take some time to go through the documentation :)