### PR TITLE
Fix NPE of decoding IntKeyLongValuesHashMap

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/IntKeyLongValueHashMap.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/IntKeyLongValueHashMap.java
@@ -17,6 +17,7 @@
 
 package org.apache.skywalking.oap.server.core.analysis.metrics;
 
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -57,6 +58,9 @@ public class IntKeyLongValueHashMap extends HashMap<Integer, IntKeyLongValue> im
 
     @Override
     public void toObject(String data) {
+        if (Strings.isNullOrEmpty(data)) {
+            return;
+        }
         String[] keyValues = data.split(Const.ARRAY_PARSER_SPLIT);
         for (String keyValue : keyValues) {
             IntKeyLongValue value = new IntKeyLongValue();

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentileMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentileMetrics.java
@@ -61,7 +61,7 @@ public abstract class PercentileMetrics extends GroupMetrics implements MultiInt
     private boolean isCalculated;
 
     public PercentileMetrics() {
-        percentileValues = initDataset();
+        percentileValues = new IntKeyLongValueHashMap(RANKS.length);
         dataset = new IntKeyLongValueHashMap(30);
     }
 
@@ -127,13 +127,5 @@ public abstract class PercentileMetrics extends GroupMetrics implements MultiInt
             values[i] = (int) percentileValues.get(i).getValue();
         }
         return values;
-    }
-
-    private IntKeyLongValueHashMap initDataset() {
-        IntKeyLongValueHashMap r = new IntKeyLongValueHashMap(RANKS.length);
-        for (final int rank : RANKS) {
-            r.put(rank, new IntKeyLongValue(rank, 0));
-        }
-        return r;
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentileMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentileMetrics.java
@@ -61,7 +61,7 @@ public abstract class PercentileMetrics extends GroupMetrics implements MultiInt
     private boolean isCalculated;
 
     public PercentileMetrics() {
-        percentileValues = new IntKeyLongValueHashMap(RANKS.length);
+        percentileValues = initDataset();
         dataset = new IntKeyLongValueHashMap(30);
     }
 
@@ -127,5 +127,13 @@ public abstract class PercentileMetrics extends GroupMetrics implements MultiInt
             values[i] = (int) percentileValues.get(i).getValue();
         }
         return values;
+    }
+
+    private IntKeyLongValueHashMap initDataset() {
+        IntKeyLongValueHashMap r = new IntKeyLongValueHashMap(RANKS.length);
+        for (final int rank : RANKS) {
+            r.put(rank, new IntKeyLongValue(rank, 0));
+        }
+        return r;
     }
 }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/IntKeyLongValueHashMapTestCase.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/IntKeyLongValueHashMapTestCase.java
@@ -65,4 +65,12 @@ public class IntKeyLongValueHashMapTestCase {
 
         Assert.assertEquals("1,100|2,200|5,500|6,600|7,700", intKeyLongValueHashMap.toStorageData());
     }
+
+    @Test
+    public void testNull() {
+        IntKeyLongValueHashMap nullHm = new IntKeyLongValueHashMap();
+        IntKeyLongValueHashMap m = new IntKeyLongValueHashMap();
+        m.toObject(nullHm.toStorageData());
+        Assert.assertEquals(m.toStorageData(), "");
+    }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

If IntKeyLongValuesHashMap#toStorageDate generate an empty string,
that usually because there's no any traffic in one minute. When syncing
it to cache, IntKeyLongValuesHashMap#toObject will raise a NPE.

- How to fix?
if an empty string pass into toObject, just return
