### PR TITLE
Fix otherMetricsDataTTL config not working

### DIFF
--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchConfig.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchConfig.java
@@ -95,6 +95,7 @@ public class StorageModuleElasticsearchConfig extends ModuleConfig {
     private int hourMetricsDataTTL = 2;
     @Setter
     private int dayMetricsDataTTL = 2;
+    @Setter
     private int otherMetricsDataTTL = 0;
     @Setter
     private int monthMetricsDataTTL = 18;


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
There is no setter of otherMetricsDataTTL method in StorageModuleElasticsearchConfig.This can lead to dayMetrics only stored 2 days default.
See #4388
- How to fix?
Add setter annotation.
___
### New feature or improvement
- Describe the details and related test reports.
