### PR TITLE
Add missing test for component-libraries.yml

### DIFF
--- a/apm-protocol/apm-network/src/main/java/org/apache/skywalking/apm/network/trace/component/ComponentsDefine.java
+++ b/apm-protocol/apm-network/src/main/java/org/apache/skywalking/apm/network/trace/component/ComponentsDefine.java
@@ -65,7 +65,7 @@ public class ComponentsDefine {
 
     public static final OfficialComponent JEDIS = new OfficialComponent(30, "Jedis");
 
-    public static final OfficialComponent H2_JDBC_DRIVER = new OfficialComponent(32, "jdbc-jdbc-driver");
+    public static final OfficialComponent H2_JDBC_DRIVER = new OfficialComponent(32, "h2-jdbc-driver");
 
     public static final OfficialComponent MYSQL_JDBC_DRIVER = new OfficialComponent(33, "mysql-connector-java");
 
@@ -94,8 +94,6 @@ public class ComponentsDefine {
     public static final OfficialComponent ACTIVEMQ_CONSUMER = new OfficialComponent(46, "activemq-consumer");
 
     public static final OfficialComponent TRANSPORT_CLIENT = new OfficialComponent(48, "transport-client");
-
-    public static final OfficialComponent UNDERTOW = new OfficialComponent(49, "Undertow");
 
     public static final OfficialComponent RABBITMQ_PRODUCER = new OfficialComponent(52, "rabbitmq-producer");
 
@@ -151,7 +149,9 @@ public class ComponentsDefine {
 
     public static final OfficialComponent KT_COROUTINE = new OfficialComponent(81, "KotlinCoroutine");
 
-    public static final OfficialComponent AVRO_SERVER = new OfficialComponent(82, "avro-server");
+    public static final OfficialComponent AVRO_SERVER = new OfficialComponent(82, "AvroServer");
 
-    public static final OfficialComponent AVRO_CLIENT = new OfficialComponent(83, "avro-client");
+    public static final OfficialComponent AVRO_CLIENT = new OfficialComponent(83, "AvroClient");
+
+    public static final OfficialComponent UNDERTOW = new OfficialComponent(84, "Undertow");
 }

--- a/oap-server/server-bootstrap/src/main/resources/component-libraries.yml
+++ b/oap-server/server-bootstrap/src/main/resources/component-libraries.yml
@@ -269,13 +269,18 @@ Armeria:
 JdkThreading:
   id: 80
   languages: Java
+KotlinCoroutine:
+  id: 81
+  languages: Java
 AvroServer:
   id: 82
   languages: Java
 AvroClient:
   id: 83
   languages: Java
-
+Undertow:
+  id: 84
+  languages: Java
 
 # .NET/.NET Core components
 # [3000, 4000) for C#/.NET only

--- a/oap-server/server-bootstrap/src/test/java/org/apache/skywalking/oap/server/starter/TestComponentLibraries.java
+++ b/oap-server/server-bootstrap/src/test/java/org/apache/skywalking/oap/server/starter/TestComponentLibraries.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.starter;
+
+import java.io.Reader;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.apache.commons.collections.map.CaseInsensitiveMap;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.apache.skywalking.apm.network.trace.component.OfficialComponent;
+import org.apache.skywalking.oap.server.library.util.ResourceUtils;
+import org.junit.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Guarantee that the components defined in {@link ComponentsDefine} are in sync with those in file {@code
+ * component-libraries.yml}, note that this test only verifies Java components.
+ */
+@SuppressWarnings("rawtypes")
+public class TestComponentLibraries {
+    @Test
+    public void testComponentsAreInSync() throws Exception {
+        final Reader reader = ResourceUtils.read("component-libraries.yml");
+        final Map map = new Yaml().loadAs(reader, Map.class);
+        final CaseInsensitiveMap caseInsensitiveMap = new CaseInsensitiveMap(map);
+        for (final Field field : ComponentsDefine.class.getFields()) {
+            final OfficialComponent component = (OfficialComponent) field.get(null);
+            final String normalizedComponentName = component.getName().replaceAll("\\.", "");
+            if (!caseInsensitiveMap.containsKey(normalizedComponentName)) {
+                fail("Component " + component.getName() + " is not registered in component-libraries.yml");
+            }
+            final Map componentInMap = (Map) caseInsensitiveMap.get(normalizedComponentName);
+            final int id = (Integer) componentInMap.get("id");
+            assertEquals(
+                "Component id defined in class ComponentsDefine should be the same as that in component-libraries.yml",
+                id, component.getId()
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Motivation:

Add test to guarantee that the components defined in class ComponentsDefine are in sync with those in file component-libraries.yml.

### Modifications:

- Add missing component in component-libraries.yml.

- Add test to verify the class and the yml are in sync.

- Fix wrong component id of Undertow.

### Result:

Components definitions in class ComponentsDefine and yaml are in sync, and will be verified in every pull request.
