### PR TITLE
Support ref endpoint name register

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/EndpointInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/EndpointInventoryRegister.java
@@ -69,8 +69,8 @@ public class EndpointInventoryRegister implements IEndpointInventoryRegister {
     }
 
     @Override
-    public int get(int serviceId, String endpointName, int detectPoint) {
-        return getCacheService().getEndpointId(serviceId, endpointName, detectPoint);
+    public int get(int serviceId, String endpointName, DetectPoint detectPoint) {
+        return getCacheService().getEndpointId(serviceId, endpointName, detectPoint.ordinal());
     }
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/IEndpointInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/IEndpointInventoryRegister.java
@@ -25,7 +25,7 @@ public interface IEndpointInventoryRegister extends Service {
 
     int getOrCreate(int serviceId, String endpointName, DetectPoint detectPoint);
 
-    int get(int serviceId, String endpointName, int detectPoint);
+    int get(int serviceId, String endpointName, DetectPoint detectPoint);
 
     void heartbeat(int endpointId, long heartBeatTime);
 }


### PR DESCRIPTION
The ref exchange is changing since we apply the change in 6.6.0

* Since 6.6.0 The endpoint in the ref should be server endpoint only. The agent will/should use `-1`, when it can't find the endpoint of entry span in the current tracing context when build the ref.
* Since 5.0 Endpoint in ref could be local or exit span's operation name. Especially if it is local span operation name, * exchange may not happen at agent, such as Java agent, then put literal endpoint string in the header, Need to try * to get the id by assuming the endpoint name is detected at server, local or client. If agent does the exchange, then always use endpoint id.