### PR TITLE
Forward compatibility for DCS

### DIFF
--- a/oap-server/server-configuration/grpc-configuration-sync/src/main/java/org/apache/skywalking/oap/server/configuration/grpc/GRPCConfigWatcherRegister.java
+++ b/oap-server/server-configuration/grpc-configuration-sync/src/main/java/org/apache/skywalking/oap/server/configuration/grpc/GRPCConfigWatcherRegister.java
@@ -57,7 +57,7 @@ public class GRPCConfigWatcherRegister extends ConfigWatcherRegister {
             }
             ConfigurationResponse response = stub.call(builder.build());
             String responseUuid = response.getUuid();
-            if (Objects.equals(uuid, responseUuid)) {
+            if (responseUuid != null && Objects.equals(uuid, responseUuid)) {
                 // If UUID matched, the config table is expected as empty.
                 return Optional.empty();
             }


### PR DESCRIPTION
In the old implementation of DCS, the old one will not response UUID, which could make the update not work. 

This make the forward compatibility for DCS, enhance #4438