### PR TITLE
Update the latest release commit to the e2e for release verification.

### DIFF
--- a/test/e2e/e2e-http-api-with-nginx-lua/pom.xml
+++ b/test/e2e/e2e-http-api-with-nginx-lua/pom.xml
@@ -110,7 +110,7 @@
 
                             <run>
                                 <env>
-                                    <SKYWALKING_NINGX_LUA_GIT_COMMIT_ID>c6aca516200573a64db7060cefb5d3608c571c3a
+                                    <SKYWALKING_NINGX_LUA_GIT_COMMIT_ID>9cebe51276d9a8a5b360ee1d9897e8bf803bda31
                                     </SKYWALKING_NINGX_LUA_GIT_COMMIT_ID>
                                 </env>
                                 <links>


### PR DESCRIPTION
Based on the commit logs, should be nothing change, only doc. But still do this for re-confirmation.

This is v0.1.0 release commit id.