### PR TITLE
[Agent Core] Support lazy ContextCarrier injection and lazy peer id setting 

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AbstractTracerContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AbstractTracerContext.java
@@ -32,6 +32,15 @@ public interface AbstractTracerContext {
     void inject(ContextCarrier carrier);
 
     /**
+     * Prepare for the cross-process propagation based on the given exit span. The given exit span should belong to the
+     * current context. How to initialize the carrier, depends on the implementation.
+     *
+     * @param carrier  to carry the context for crossing process.
+     * @param exitSpan to represent the scope of current injection.
+     */
+    void _inject(AbstractSpan exitSpan, ContextCarrier carrier);
+
+    /**
      * Build the reference between this segment and a cross-process segment. How to build, depends on the
      * implementation.
      *
@@ -82,7 +91,8 @@ public interface AbstractTracerContext {
      * Create an exit span
      *
      * @param operationName most likely a service name of remote
-     * @param remotePeer    the network id(ip:port, hostname:port or ip1:port1,ip2,port, etc.)
+     * @param remotePeer    the network id(ip:port, hostname:port or ip1:port1,ip2,port, etc.). Remote peer could be set
+     *                      later, but must be before injecting.
      * @return the span represent an exit point of this segment.
      */
     AbstractSpan createExitSpan(String operationName, String remotePeer);

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AbstractTracerContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AbstractTracerContext.java
@@ -19,7 +19,6 @@
 package org.apache.skywalking.apm.agent.core.context;
 
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
-import org.apache.skywalking.apm.agent.core.context.trace.ExitTypeSpan;
 
 /**
  * The <code>AbstractTracerContext</code> represents the tracer context manager.
@@ -31,18 +30,6 @@ public interface AbstractTracerContext {
      * @param carrier to carry the context for crossing process.
      */
     void inject(ContextCarrier carrier);
-
-    /**
-     * Prepare for the cross-process propagation based on the given exit span. The given exit span should belong to the
-     * current context.This method wouldn't be opened in {@link ContextManager} like {@link #inject(ContextCarrier)}, it
-     * is only supported to be called inside the {@link ExitTypeSpan#inject(ContextCarrier)}
-     *
-     * How to initialize the carrier, depends on the implementation.
-     *
-     * @param carrier  to carry the context for crossing process.
-     * @param exitSpan to represent the scope of current injection.
-     */
-    void inject(AbstractSpan exitSpan, ContextCarrier carrier);
 
     /**
      * Build the reference between this segment and a cross-process segment. How to build, depends on the

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AbstractTracerContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/AbstractTracerContext.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.apm.agent.core.context;
 
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.ExitTypeSpan;
 
 /**
  * The <code>AbstractTracerContext</code> represents the tracer context manager.
@@ -33,12 +34,15 @@ public interface AbstractTracerContext {
 
     /**
      * Prepare for the cross-process propagation based on the given exit span. The given exit span should belong to the
-     * current context. How to initialize the carrier, depends on the implementation.
+     * current context.This method wouldn't be opened in {@link ContextManager} like {@link #inject(ContextCarrier)}, it
+     * is only supported to be called inside the {@link ExitTypeSpan#inject(ContextCarrier)}
+     *
+     * How to initialize the carrier, depends on the implementation.
      *
      * @param carrier  to carry the context for crossing process.
      * @param exitSpan to represent the scope of current injection.
      */
-    void _inject(AbstractSpan exitSpan, ContextCarrier carrier);
+    void inject(AbstractSpan exitSpan, ContextCarrier carrier);
 
     /**
      * Build the reference between this segment and a cross-process segment. How to build, depends on the

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
@@ -44,6 +44,11 @@ public class IgnoredTracerContext implements AbstractTracerContext {
     }
 
     @Override
+    public void _inject(final AbstractSpan exitSpan, final ContextCarrier carrier) {
+
+    }
+
+    @Override
     public void extract(ContextCarrier carrier) {
 
     }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
@@ -44,11 +44,6 @@ public class IgnoredTracerContext implements AbstractTracerContext {
     }
 
     @Override
-    public void inject(final AbstractSpan exitSpan, final ContextCarrier carrier) {
-
-    }
-
-    @Override
     public void extract(ContextCarrier carrier) {
 
     }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
@@ -44,7 +44,7 @@ public class IgnoredTracerContext implements AbstractTracerContext {
     }
 
     @Override
-    public void _inject(final AbstractSpan exitSpan, final ContextCarrier carrier) {
+    public void inject(final AbstractSpan exitSpan, final ContextCarrier carrier) {
 
     }
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -29,12 +29,12 @@ import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractTracingSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.EntrySpan;
 import org.apache.skywalking.apm.agent.core.context.trace.ExitSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.ExitTypeSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.LocalSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.NoopExitSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.NoopSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
 import org.apache.skywalking.apm.agent.core.context.trace.TraceSegmentRef;
-import org.apache.skywalking.apm.agent.core.context.trace.WithPeerInfo;
 import org.apache.skywalking.apm.agent.core.dictionary.DictionaryManager;
 import org.apache.skywalking.apm.agent.core.dictionary.DictionaryUtil;
 import org.apache.skywalking.apm.agent.core.logging.api.ILog;
@@ -129,21 +129,39 @@ public class TracingContext implements AbstractTracerContext {
      * Inject the context into the given carrier, only when the active span is an exit one.
      *
      * @param carrier to carry the context for crossing process.
-     * @throws IllegalStateException if the active span isn't an exit one. Ref to {@link AbstractTracerContext#inject(ContextCarrier)}
+     * @throws IllegalStateException if (1) the active span isn't an exit one. (2) doesn't include peer. Ref to {@link
+     *                               AbstractTracerContext#inject(ContextCarrier)}
      */
     @Override
     public void inject(ContextCarrier carrier) {
-        AbstractSpan span = this.activeSpan();
-        if (!span.isExit()) {
+        this._inject(this.activeSpan(), carrier);
+    }
+
+    /**
+     * Inject the context into the given carrier and given span, only when the active span is an exit one. This method
+     * wouldn't be opened in {@link ContextManager} like {@link #inject(ContextCarrier)}, it is only supported to be
+     * called inside the {@link ExitTypeSpan#inject(ContextCarrier)}
+     *
+     * @param carrier  to carry the context for crossing process.
+     * @param exitSpan to represent the scope of current injection.
+     * @throws IllegalStateException if (1) the span isn't an exit one. (2) doesn't include peer. Ref to {@link
+     *                               AbstractTracerContext#_inject(AbstractSpan, ContextCarrier)}
+     */
+    @Override
+    public void _inject(AbstractSpan exitSpan, ContextCarrier carrier) {
+        if (!exitSpan.isExit()) {
             throw new IllegalStateException("Inject can be done only in Exit Span");
         }
 
-        WithPeerInfo spanWithPeer = (WithPeerInfo) span;
+        ExitTypeSpan spanWithPeer = (ExitTypeSpan) exitSpan;
         String peer = spanWithPeer.getPeer();
         int peerId = spanWithPeer.getPeerId();
+        if (StringUtil.isEmpty(peer) && DictionaryUtil.isNull(peerId)) {
+            throw new IllegalStateException("Exit span doesn't include meaningful peer information.");
+        }
 
         carrier.setTraceSegmentId(this.segment.getTraceSegmentId());
-        carrier.setSpanId(span.getSpanId());
+        carrier.setSpanId(exitSpan.getSpanId());
 
         carrier.setParentServiceInstanceId(segment.getApplicationInstanceId());
 
@@ -235,7 +253,8 @@ public class TracingContext implements AbstractTracerContext {
     @Override
     public ContextSnapshot capture() {
         List<TraceSegmentRef> refs = this.segment.getRefs();
-        ContextSnapshot snapshot = new ContextSnapshot(segment.getTraceSegmentId(), activeSpan().getSpanId(), segment.getRelatedGlobalTraces());
+        ContextSnapshot snapshot = new ContextSnapshot(
+            segment.getTraceSegmentId(), activeSpan().getSpanId(), segment.getRelatedGlobalTraces());
         int entryOperationId;
         String entryOperationName = "";
         int entryApplicationInstanceId;
@@ -332,15 +351,23 @@ public class TracingContext implements AbstractTracerContext {
         if (parentSpan != null && parentSpan.isEntry()) {
             entrySpan = (AbstractTracingSpan) DictionaryManager.findEndpointSection()
                                                                .findOnly(segment.getServiceId(), operationName)
-                                                               .doInCondition(parentSpan::setOperationId, () -> parentSpan
-                                                                   .setOperationName(operationName));
+                                                               .doInCondition(
+                                                                   parentSpan::setOperationId, () -> parentSpan
+                                                                       .setOperationName(operationName));
             return entrySpan.start();
         } else {
             entrySpan = (AbstractTracingSpan) DictionaryManager.findEndpointSection()
                                                                .findOnly(segment.getServiceId(), operationName)
-                                                               .doInCondition(operationId -> new EntrySpan(spanIdGenerator++, parentSpanId, operationId, owner), () -> {
-                                                                   return new EntrySpan(spanIdGenerator++, parentSpanId, operationName, owner);
-                                                               });
+                                                               .doInCondition(
+                                                                   operationId -> new EntrySpan(spanIdGenerator++,
+                                                                                                parentSpanId,
+                                                                                                operationId, owner
+                                                                   ), () -> {
+                                                                       return new EntrySpan(
+                                                                           spanIdGenerator++, parentSpanId,
+                                                                           operationName, owner
+                                                                       );
+                                                                   });
             entrySpan.start();
             return push(entrySpan);
         }
@@ -373,7 +400,8 @@ public class TracingContext implements AbstractTracerContext {
      * Create an exit span
      *
      * @param operationName most likely a service name of remote
-     * @param remotePeer    the network id(ip:port, hostname:port or ip1:port1,ip2,port, etc.)
+     * @param remotePeer    the network id(ip:port, hostname:port or ip1:port1,ip2,port, etc.). Remote peer could be set
+     *                      later, but must be before injecting.
      * @return the span represent an exit point of this segment.
      * @see ExitSpan
      */
@@ -391,11 +419,21 @@ public class TracingContext implements AbstractTracerContext {
             exitSpan = parentSpan;
         } else {
             final int parentSpanId = parentSpan == null ? -1 : parentSpan.getSpanId();
-            exitSpan = (AbstractSpan) DictionaryManager.findNetworkAddressSection()
-                                                       .find(remotePeer)
-                                                       .doInCondition(peerId -> new ExitSpan(spanIdGenerator++, parentSpanId, operationName, peerId, owner), () -> {
-                                                           return new ExitSpan(spanIdGenerator++, parentSpanId, operationName, remotePeer, owner);
-                                                       });
+            if (StringUtil.isEmpty(remotePeer)) {
+                exitSpan = new ExitSpan(spanIdGenerator++, parentSpanId, operationName, owner);
+            } else {
+                exitSpan = (AbstractSpan) DictionaryManager.findNetworkAddressSection()
+                                                           .find(remotePeer)
+                                                           .doInCondition(
+                                                               peerId -> new ExitSpan(spanIdGenerator++, parentSpanId,
+                                                                                      operationName, peerId, owner
+                                                               ), () -> {
+                                                                   return new ExitSpan(
+                                                                       spanIdGenerator++, parentSpanId, operationName,
+                                                                       remotePeer, owner
+                                                                   );
+                                                               });
+            }
             push(exitSpan);
         }
         exitSpan.start();
@@ -622,7 +660,10 @@ public class TracingContext implements AbstractTracerContext {
         if (spanIdGenerator >= Config.Agent.SPAN_LIMIT_PER_SEGMENT) {
             long currentTimeMillis = System.currentTimeMillis();
             if (currentTimeMillis - lastWarningTimestamp > 30 * 1000) {
-                logger.warn(new RuntimeException("Shadow tracing context. Thread dump"), "More than {} spans required to create", Config.Agent.SPAN_LIMIT_PER_SEGMENT);
+                logger.warn(
+                    new RuntimeException("Shadow tracing context. Thread dump"),
+                    "More than {} spans required to create", Config.Agent.SPAN_LIMIT_PER_SEGMENT
+                );
                 lastWarningTimestamp = currentTimeMillis;
             }
             return true;

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -134,7 +134,7 @@ public class TracingContext implements AbstractTracerContext {
      */
     @Override
     public void inject(ContextCarrier carrier) {
-        this._inject(this.activeSpan(), carrier);
+        this.inject(this.activeSpan(), carrier);
     }
 
     /**
@@ -145,10 +145,10 @@ public class TracingContext implements AbstractTracerContext {
      * @param carrier  to carry the context for crossing process.
      * @param exitSpan to represent the scope of current injection.
      * @throws IllegalStateException if (1) the span isn't an exit one. (2) doesn't include peer. Ref to {@link
-     *                               AbstractTracerContext#_inject(AbstractSpan, ContextCarrier)}
+     *                               AbstractTracerContext#inject(AbstractSpan, ContextCarrier)}
      */
     @Override
-    public void _inject(AbstractSpan exitSpan, ContextCarrier carrier) {
+    public void inject(AbstractSpan exitSpan, ContextCarrier carrier) {
         if (!exitSpan.isExit()) {
             throw new IllegalStateException("Inject can be done only in Exit Span");
         }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -144,10 +144,8 @@ public class TracingContext implements AbstractTracerContext {
      *
      * @param carrier  to carry the context for crossing process.
      * @param exitSpan to represent the scope of current injection.
-     * @throws IllegalStateException if (1) the span isn't an exit one. (2) doesn't include peer. Ref to {@link
-     *                               AbstractTracerContext#inject(AbstractSpan, ContextCarrier)}
+     * @throws IllegalStateException if (1) the span isn't an exit one. (2) doesn't include peer.
      */
-    @Override
     public void inject(AbstractSpan exitSpan, ContextCarrier carrier) {
         if (!exitSpan.isExit()) {
             throw new IllegalStateException("Inject can be done only in Exit Span");

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitSpan.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.apm.agent.core.context.trace;
 
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.context.TracingContext;
 import org.apache.skywalking.apm.agent.core.context.tag.AbstractTag;
 import org.apache.skywalking.apm.network.trace.component.Component;
@@ -33,22 +34,17 @@ import org.apache.skywalking.apm.network.trace.component.Component;
  * Such as: Dubbox - Apache Httpcomponent - ...(Remote) The <code>ExitSpan</code> represents the Dubbox span, and ignore
  * the httpcomponent span's info.
  */
-public class ExitSpan extends StackBasedTracingSpan implements WithPeerInfo {
-
+public class ExitSpan extends StackBasedTracingSpan implements ExitTypeSpan {
     public ExitSpan(int spanId, int parentSpanId, String operationName, String peer, TracingContext owner) {
         super(spanId, parentSpanId, operationName, peer, owner);
     }
 
-    public ExitSpan(int spanId, int parentSpanId, int operationId, int peerId, TracingContext owner) {
-        super(spanId, parentSpanId, operationId, peerId, owner);
-    }
-
-    public ExitSpan(int spanId, int parentSpanId, int operationId, String peer, TracingContext owner) {
-        super(spanId, parentSpanId, operationId, peer, owner);
-    }
-
     public ExitSpan(int spanId, int parentSpanId, String operationName, int peerId, TracingContext owner) {
         super(spanId, parentSpanId, operationName, peerId, owner);
+    }
+
+    public ExitSpan(int spanId, int parentSpanId, String operationName, TracingContext owner) {
+        super(spanId, parentSpanId, operationName, owner);
     }
 
     /**
@@ -139,6 +135,11 @@ public class ExitSpan extends StackBasedTracingSpan implements WithPeerInfo {
     @Override
     public String getPeer() {
         return peer;
+    }
+
+    @Override
+    public void inject(final ContextCarrier carrier) {
+        this.owner._inject(this, carrier);
     }
 
     @Override

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitSpan.java
@@ -137,8 +137,9 @@ public class ExitSpan extends StackBasedTracingSpan implements ExitTypeSpan {
     }
 
     @Override
-    public void inject(final ContextCarrier carrier) {
-        this.owner._inject(this, carrier);
+    public ExitSpan inject(final ContextCarrier carrier) {
+        this.owner.inject(this, carrier);
+        return this;
     }
 
     @Override

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitSpan.java
@@ -118,13 +118,12 @@ public class ExitSpan extends StackBasedTracingSpan implements ExitTypeSpan {
         }
     }
 
+    /**
+     * Illegal operation. Operation name id is the registered endpoint, only work for entry span.
+     */
     @Override
     public AbstractTracingSpan setOperationId(int operationId) {
-        if (stackDepth == 1) {
-            return super.setOperationId(operationId);
-        } else {
-            return this;
-        }
+        throw new UnsupportedOperationException("Exit span doesn't support operation id");
     }
 
     @Override

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitTypeSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitTypeSpan.java
@@ -28,5 +28,5 @@ public interface ExitTypeSpan {
 
     String getPeer();
 
-    void inject(ContextCarrier carrier);
+    ExitTypeSpan inject(ContextCarrier carrier);
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitTypeSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/ExitTypeSpan.java
@@ -18,8 +18,15 @@
 
 package org.apache.skywalking.apm.agent.core.context.trace;
 
-public interface WithPeerInfo {
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+
+/**
+ * The exit span has some additional behaviours
+ */
+public interface ExitTypeSpan {
     int getPeerId();
 
     String getPeer();
+
+    void inject(ContextCarrier carrier);
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/LocalSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/LocalSpan.java
@@ -47,4 +47,12 @@ public class LocalSpan extends AbstractTracingSpan {
     public AbstractSpan setPeer(String remotePeer) {
         return this;
     }
+
+    /**
+     * Illegal operation. Operation name id is the registered endpoint, only work for entry span.
+     */
+    @Override
+    public AbstractTracingSpan setOperationId(int operationId) {
+        throw new UnsupportedOperationException("Exit span doesn't support operation id");
+    }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/NoopExitSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/NoopExitSpan.java
@@ -18,7 +18,9 @@
 
 package org.apache.skywalking.apm.agent.core.context.trace;
 
-public class NoopExitSpan extends NoopSpan implements WithPeerInfo {
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+
+public class NoopExitSpan extends NoopSpan implements ExitTypeSpan {
 
     private String peer;
     private int peerId;
@@ -39,6 +41,11 @@ public class NoopExitSpan extends NoopSpan implements WithPeerInfo {
     @Override
     public String getPeer() {
         return peer;
+    }
+
+    @Override
+    public void inject(final ContextCarrier carrier) {
+
     }
 
     @Override

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/NoopExitSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/NoopExitSpan.java
@@ -44,8 +44,8 @@ public class NoopExitSpan extends NoopSpan implements ExitTypeSpan {
     }
 
     @Override
-    public void inject(final ContextCarrier carrier) {
-
+    public NoopExitSpan inject(final ContextCarrier carrier) {
+        return this;
     }
 
     @Override


### PR DESCRIPTION
This PR's idea was beginning when I am reviewing @huangyoje 's PR #4441. He did hijacking the ContextCarrier, which is not supposed to happen. After the discussion, I think that plugin has to do lazy injection due to the framework limitation.

Here is the proposal, right now, we officially support
1. Create exit span with `null` as peer, if the user wouldn't do injection.
1. Exit span could do `span#inject` directly, by leverage the span's internal tracing context ref.

FYI @apache/skywalking-committers This would be the first API change(adding) after the async span feature. Please review.

@huangyoje Please cross check this PR change, and give me the feedback whether this PR could remove your hijacking requirements.