### PR TITLE
[BugFix] Docker so11y cannot be disabled

### DIFF
--- a/docker/oap-es7/docker-entrypoint.sh
+++ b/docker/oap-es7/docker-entrypoint.sh
@@ -384,8 +384,6 @@ receiver-jvm:
   default:
 receiver-clr:
   default:
-receiver-so11y:
-  default:
 service-mesh:
   default:
     bufferPath: \${SW_SERVICE_MESH_BUFFER_PATH:../mesh-buffer/}  # Path to trace buffer files, suggest to use absolute path

--- a/docker/oap/docker-entrypoint.sh
+++ b/docker/oap/docker-entrypoint.sh
@@ -385,8 +385,6 @@ receiver-jvm:
   default:
 receiver-clr:
   default:
-receiver-so11y:
-  default:
 receiver-profile:
   default:
 service-mesh:


### PR DESCRIPTION
### Motivation:

This patch fixes the bug that there's no chance to disable the so11y in docker container.

### Modifications:

- Remove the default so11y section, and only add it when the environment variable exists.

### Result:

- Users can disable so11y by leaving the `SW_TELEMETRY` empty or set it to `none`
