### PR TITLE
#4463 FAQ for Maven compilation failure with error like python2 not found

### DIFF
--- a/docs/en/FAQ/README.md
+++ b/docs/en/FAQ/README.md
@@ -7,7 +7,7 @@ These are known and common FAQs. We welcome you to contribute yours.
 ## Compiling
 * [Protoc plugin fails in maven build](Protoc-Plugin-Fails-When-Build.md)
 * [Required items could not be found, when import project into Eclipse](Import-Project-Eclipse-RequireItems-Exception.md)
-* [Maven compilation failure with error like python2 not found](maven-compile-npm-failure.md)
+* [Maven compilation failure with `python2 not found` error](maven-compile-npm-failure.md)
 
 ## Runtime
 * [Why metrics indexes(ElasticSearch) in Hour and Day precisions stop update after upgrade to 7.x?](Hour-Day-Metrics-Stopping.md)

--- a/docs/en/FAQ/README.md
+++ b/docs/en/FAQ/README.md
@@ -7,6 +7,7 @@ These are known and common FAQs. We welcome you to contribute yours.
 ## Compiling
 * [Protoc plugin fails in maven build](Protoc-Plugin-Fails-When-Build.md)
 * [Required items could not be found, when import project into Eclipse](Import-Project-Eclipse-RequireItems-Exception.md)
+* [Maven compilation failure with error like python2 not found](maven-compile-npm-failure.md)
 
 ## Runtime
 * [Why metrics indexes(ElasticSearch) in Hour and Day precisions stop update after upgrade to 7.x?](Hour-Day-Metrics-Stopping.md)

--- a/docs/en/FAQ/maven-compile-npm-failure.md
+++ b/docs/en/FAQ/maven-compile-npm-failure.md
@@ -1,0 +1,62 @@
+### Problem： Maven compilation failure with error like `Error: not found: python2`
+When you compile the project via maven, it failed at module `apm-webapp and the following error occured.
+
+Pay attention to key words such as `node-sass` and `Error: not found: python2`.
+
+```
+[INFO] > node-sass@4.11.0 postinstall C:\XXX\skywalking\skywalking-ui\node_modules\node-sass
+[INFO] > node scripts/build.js
+
+[ERROR] gyp verb check python checking for Python executable "python2" in the PATH
+[ERROR] gyp verb `which` failed Error: not found: python2
+[ERROR] gyp verb `which` failed     at getNotFoundError (C:\XXX\skywalking\skywalking-ui\node_modules\which\which.js:13:12)
+[ERROR] gyp verb `which` failed     at F (C:\XXX\skywalking\skywalking-ui\node_modules\which\which.js:68:19)
+[ERROR] gyp verb `which` failed     at E (C:\XXX\skywalking\skywalking-ui\node_modules\which\which.js:80:29)
+[ERROR] gyp verb `which` failed     at C:\XXX\skywalking\skywalking-ui\node_modules\which\which.js:89:16
+[ERROR] gyp verb `which` failed     at C:\XXX\skywalking\skywalking-ui\node_modules\isexe\index.js:42:5
+[ERROR] gyp verb `which` failed     at C:\XXX\skywalking\skywalking-ui\node_modules\isexe\windows.js:36:5
+[ERROR] gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21)
+
+[ERROR] gyp verb `which` failed   code: 'ENOENT' }
+[ERROR] gyp verb check python checking for Python executable "python" in the PATH
+[ERROR] gyp verb `which` succeeded python C:\Users\XXX\AppData\Local\Programs\Python\Python37\python.EXE
+[ERROR] gyp ERR! configure error 
+[ERROR] gyp ERR! stack Error: Command failed: C:\Users\XXX\AppData\Local\Programs\Python\Python37\python.EXE -c import sys; print "%s.%s.%s" % sys.version_info[:3];
+[ERROR] gyp ERR! stack   File "<string>", line 1
+[ERROR] gyp ERR! stack     import sys; print "%s.%s.%s" % sys.version_info[:3];
+[ERROR] gyp ERR! stack                                ^
+[ERROR] gyp ERR! stack SyntaxError: invalid syntax
+[ERROR] gyp ERR! stack 
+[ERROR] gyp ERR! stack     at ChildProcess.exithandler (child_process.js:275:12)
+[ERROR] gyp ERR! stack     at emitTwo (events.js:126:13)
+[ERROR] gyp ERR! stack     at ChildProcess.emit (events.js:214:7)
+[ERROR] gyp ERR! stack     at maybeClose (internal/child_process.js:925:16)
+[ERROR] gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
+[ERROR] gyp ERR! System Windows_NT 10.0.17134
+......
+[INFO] server-starter-es7 ................................. SUCCESS [ 11.657 s]
+[INFO] apm-webapp ......................................... FAILURE [ 25.857 s]
+[INFO] apache-skywalking-apm .............................. SKIPPED
+[INFO] apache-skywalking-apm-es7 .......................... SKIPPED
+```
+
+### Reason
+
+It has nothing to do with skywalking.   
+According to https://github.com/sass/node-sass/issues/1176, if you live in countries where requesting resources from `github` and `npmjs.org` is very slowly, some precompiled binaries for dependency `node-sass` will fail to be downloaded during `npm install`, then npm will try to compile them itself. That's why `python2` is needed.
+
+### Resolve
+#### 1. If you live in China, please edit `skywalking\apm-webapp\pom.xml`     
+Find
+```
+<configuration>  
+ <arguments>install --registry=https://registry.npmjs.org/</arguments>  
+</configuration>
+```
+Replace it with
+```
+<configuration>  
+ <arguments>install --registry=https://registry.npm.taobao.org/ --sass_binary_site=https://npm.taobao.org/mirrors/node-sass/</arguments>  
+</configuration>
+```
+#### 2. Get an enough powerful VPN

--- a/docs/en/FAQ/maven-compile-npm-failure.md
+++ b/docs/en/FAQ/maven-compile-npm-failure.md
@@ -1,5 +1,5 @@
 ### Problem： Maven compilation failure with error like `Error: not found: python2`
-When you compile the project via maven, it failed at module `apm-webapp and the following error occured.
+When you compile the project via maven, it failed at module `apm-webapp` and the following error occured.
 
 Pay attention to key words such as `node-sass` and `Error: not found: python2`.
 

--- a/docs/en/FAQ/maven-compile-npm-failure.md
+++ b/docs/en/FAQ/maven-compile-npm-failure.md
@@ -46,7 +46,7 @@ It has nothing to do with SkyWalking.
 According to https://github.com/sass/node-sass/issues/1176, if you live in countries where requesting resources from `GitHub` and `npmjs.org` is very slowly, some precompiled binaries for dependency `node-sass` will fail to be downloaded during `npm install`, then npm will try to compile them itself. That's why `python2` is needed.
 
 ### Resolve
-#### 1. If you live in China, please edit `skywalking\apm-webapp\pom.xml`     
+#### 1. Use mirror. Such as in China, please edit `skywalking\apm-webapp\pom.xml`     
 Find
 ```
 <configuration>  

--- a/docs/en/FAQ/maven-compile-npm-failure.md
+++ b/docs/en/FAQ/maven-compile-npm-failure.md
@@ -42,8 +42,8 @@ Pay attention to key words such as `node-sass` and `Error: not found: python2`.
 
 ### Reason
 
-It has nothing to do with skywalking.   
-According to https://github.com/sass/node-sass/issues/1176, if you live in countries where requesting resources from `github` and `npmjs.org` is very slowly, some precompiled binaries for dependency `node-sass` will fail to be downloaded during `npm install`, then npm will try to compile them itself. That's why `python2` is needed.
+It has nothing to do with SkyWalking.   
+According to https://github.com/sass/node-sass/issues/1176, if you live in countries where requesting resources from `GitHub` and `npmjs.org` is very slowly, some precompiled binaries for dependency `node-sass` will fail to be downloaded during `npm install`, then npm will try to compile them itself. That's why `python2` is needed.
 
 ### Resolve
 #### 1. If you live in China, please edit `skywalking\apm-webapp\pom.xml`     


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues #4463

`skywalking\apm-webapp\pom.xml`  
```
<configuration>  
 <arguments>install --registry=https://registry.npm.taobao.org/ --sass_binary_site=https://npm.taobao.org/mirrors/node-sass/</arguments>  
</configuration>
```
I've tested it with python2 not installed.
```
[INFO] tool-profile-snapshot-exporter ..................... SUCCESS [  2.561 s]
[INFO] server-starter ..................................... SUCCESS [  7.839 s]
[INFO] tool-profile-snapshot-exporter-es7 ................. SUCCESS [  2.667 s]
[INFO] server-starter-es7 ................................. SUCCESS [  4.893 s]
[INFO] apm-webapp ......................................... SUCCESS [01:49 min]
[INFO] apache-skywalking-apm .............................. SUCCESS [ 27.541 s]
[INFO] apache-skywalking-apm-es7 .......................... SUCCESS [ 23.390 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16:12 min
[INFO] Finished at: 2020-03-09T09:38:13+08:00
[INFO] ------------------------------------------------------------------------
```