### PR TITLE
[BugFix] Docker InfluxDB cannot be enabled

### DIFF
--- a/docker/oap-es7/docker-entrypoint.sh
+++ b/docker/oap-es7/docker-entrypoint.sh
@@ -355,6 +355,7 @@ EOT
     elasticsearch) generateStorageElastisearch;;
     h2) generateStorageH2;;
     mysql) generateStorageMySQL;;
+    influxdb) generateStorageInfluxDB;;
     esac
 
     cat <<EOT >> ${var_application_file}

--- a/docker/oap/docker-entrypoint.sh
+++ b/docker/oap/docker-entrypoint.sh
@@ -356,6 +356,7 @@ EOT
     elasticsearch) generateStorageElastisearch;;
     h2) generateStorageH2;;
     mysql) generateStorageMySQL;;
+    influxdb) generateStorageInfluxDB;;
     esac
 
     cat <<EOT >> ${var_application_file}


### PR DESCRIPTION
### Motivation:

This patch fixes the bug that there's no chance to enable the InfluxDB storage in docker container.

### Modifications:

Generate InfluxDB configuration section to enable it.

### Result:

Users can enable InfluxDB by specifying SW_STORAGE=influxdb
