### PR TITLE
Fix overlapping time ranges profile analyze error

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profile/analyze/ProfileAnalyzer.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profile/analyze/ProfileAnalyzer.java
@@ -85,7 +85,7 @@ public class ProfileAnalyzer {
                 LOGGER.warn(e.getMessage(), e);
                 return Collections.<ProfileThreadSnapshotRecord>emptyList();
             }
-        }).flatMap(Collection::stream).map(ProfileStack::deserialize).collect(Collectors.toList());
+        }).flatMap(Collection::stream).map(ProfileStack::deserialize).distinct().collect(Collectors.toList());
 
         // analyze
         analyzation.setTrees(analyze(stacks));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profile/analyze/ProfileStack.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profile/analyze/ProfileStack.java
@@ -21,6 +21,8 @@ package org.apache.skywalking.oap.server.core.profile.analyze;
 import com.google.common.primitives.Ints;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.List;
+import java.util.Objects;
+
 import lombok.Data;
 import org.apache.skywalking.apm.network.language.profile.ThreadStack;
 import org.apache.skywalking.oap.server.core.profile.ProfileThreadSnapshotRecord;
@@ -55,5 +57,18 @@ public class ProfileStack implements Comparable<ProfileStack> {
     @Override
     public int compareTo(ProfileStack o) {
         return Ints.compare(sequence, o.sequence);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProfileStack that = (ProfileStack) o;
+        return sequence == that.sequence;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sequence);
     }
 }

--- a/oap-server/server-core/src/test/resources/thread-snapshot.yml
+++ b/oap-server/server-core/src/test/resources/thread-snapshot.yml
@@ -244,3 +244,20 @@ list:
       - code: A
         count: 5
         duration: 30:30
+
+  # case 9(multiple time ranges with overlapping time)
+  - data:
+      limit: 10
+      timeRanges: 0-2,1-3,5-6
+      snapshots:
+        - A
+        - A
+        - A
+        - A
+        - B
+        - A
+        - A
+    expected:
+      - code: A
+        count: 6
+        duration: 40:40


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- When the overlapping time range is selected in profile analysis, it will have overlapping thread snapshot sequences, which will make data errors in the analysis results

- Make distinct the thread snapshots before analyze.
