### PR TITLE
Fix GraphQL profile queried error when cannot matches any snapshot

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profile/analyze/ProfileAnalyzer.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profile/analyze/ProfileAnalyzer.java
@@ -88,7 +88,10 @@ public class ProfileAnalyzer {
         }).flatMap(Collection::stream).map(ProfileStack::deserialize).distinct().collect(Collectors.toList());
 
         // analyze
-        analyzation.getTrees().addAll(analyze(stacks));
+        final List<ProfileStackTree> trees = analyze(stacks);
+        if (trees != null) {
+            analyzation.getTrees().addAll(trees);
+        }
 
         return analyzation;
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profile/analyze/ProfileAnalyzer.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profile/analyze/ProfileAnalyzer.java
@@ -88,7 +88,7 @@ public class ProfileAnalyzer {
         }).flatMap(Collection::stream).map(ProfileStack::deserialize).distinct().collect(Collectors.toList());
 
         // analyze
-        analyzation.setTrees(analyze(stacks));
+        analyzation.getTrees().addAll(analyze(stacks));
 
         return analyzation;
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/entity/ProfileAnalyzation.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/entity/ProfileAnalyzation.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.query.entity;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -33,4 +34,7 @@ public class ProfileAnalyzation {
     // thread stack dump analyze trees
     private List<ProfileStackTree> trees;
 
+    public ProfileAnalyzation() {
+        this.trees = new ArrayList<>();
+    }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- GraphQL query profile analyzation without matches any snapshot. Use ArrayList to return trees. Not using `null`.
