### PR TITLE
Upgrade jackson-databind version to 2.9.10

### DIFF
--- a/apm-webapp/pom.xml
+++ b/apm-webapp/pom.xml
@@ -38,6 +38,7 @@
         <spring-cloud-dependencies.version>Edgware.SR1</spring-cloud-dependencies.version>
         <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
         <logback-classic.version>1.2.3</logback-classic.version>
+        <jackson-version>2.9.10</jackson-version>
 
         <ui.path>${project.parent.basedir}/skywalking-ui</ui.path>
     </properties>
@@ -64,6 +65,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
             <version>${spring.boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- https://www.cvedetails.com/cve/CVE-2019-17267/ -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/dist-material/release-docs/LICENSE
+++ b/dist-material/release-docs/LICENSE
@@ -278,7 +278,7 @@ The text of each license is the standard Apache 2.0 license.
     instrumentation-api 0.4.3: https://github.com/google/instrumentation-java, Apache 2.0
     jackson-annotations 2.8.0: https://github.com/FasterXML/jackson-annotations, Apache 2.0
     jackson-core 2.8.8: https://github.com/FasterXML/jackson-core, Apache 2.0
-    jackson-databind 2.8.8: https://github.com/FasterXML/jackson-databind, Apache 2.0
+    jackson-databind 2.9.10: https://github.com/FasterXML/jackson-databind, Apache 2.0
     jackson-dataformat 2.8.6: https://github.com/FasterXML/jackson-dataformats-binary, Apache 2.0
     jackson-datatype-jdk8 2.8.8: https://github.com/FasterXML/jackson-modules-java8/tree/jackson-modules-java8-2.8.8, Apache 2.0
     jackson-module-kotlin 2.8.8: http://kotlinlang.org, Apache 2.0


### PR DESCRIPTION
Based on the description
> A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2.9.10. It is related to net.sf.ehcache.hibernate.EhcacheJtaTransactionManagerLookup.
Publish Date : 2019-10-06 Last Update Date : 2019-10-10

Link, https://www.cvedetails.com/cve/CVE-2019-17267/

As this is imported by Webapp spring starter, I do the upgrade as less as possible.