### PR TITLE
[Agent] Add JDK13, JDK14 to build matrix

### DIFF
--- a/.github/workflows/e2e.jdk-versions.yaml
+++ b/.github/workflows/e2e.jdk-versions.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [8, 9, 10, 11, 12]
+        jdk: [8, 9, 10, 11, 12, 13, 14]
     env:
       SW_SIMPLE_CASE: jdk
       SW_AGENT_JDK_VERSION: ${{ matrix.jdk }}

--- a/docs/en/setup/service-agent/java-agent/README.md
+++ b/docs/en/setup/service-agent/java-agent/README.md
@@ -1,5 +1,5 @@
 # Setup java agent
-1. Agent is available for JDK 8 - 12 in 7.x releases. JDK 1.6 - JDK 12 are supported in all 6.x releases [NOTICE¹](#notice)
+1. Agent is available for JDK 8 - 14 in 7.x releases. JDK 1.6 - JDK 12 are supported in all 6.x releases [NOTICE¹](#notice)
 1. Find `agent` folder in SkyWalking release package
 1. Set `agent.service_name` in `config/agent.config`. Could be any String in English.
 1. Set `collector.backend_service` in `config/agent.config`. Default point to `127.0.0.1:11800`, only works for local backend.


### PR DESCRIPTION
Motivation:

Guarantee that the agent supports JDK13 and JDK14

Modifications:

Add JDK13 and JDK14 to build matrix

Result:

Build with JDK13 and JDK14
