### PR TITLE
Set the trustStorePath default value to empty

### DIFF
--- a/dist-material/application.yml
+++ b/dist-material/application.yml
@@ -92,7 +92,7 @@ storage:
     nameSpace: ${SW_NAMESPACE:""}
     clusterNodes: ${SW_STORAGE_ES_CLUSTER_NODES:localhost:9200}
     protocol: ${SW_STORAGE_ES_HTTP_PROTOCOL:"http"}
-    trustStorePath: ${SW_SW_STORAGE_ES_SSL_JKS_PATH:"../es_keystore.jks"}
+    trustStorePath: ${SW_SW_STORAGE_ES_SSL_JKS_PATH:""}
     trustStorePass: ${SW_SW_STORAGE_ES_SSL_JKS_PASS:""}
     user: ${SW_ES_USER:""}
     password: ${SW_ES_PASSWORD:""}


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
![image](https://user-images.githubusercontent.com/17743739/77720069-d18afd00-7021-11ea-8a1d-45d86c694913.png)

when I set the elastic username & password, but not use ssl connect.

when I review the code,they are all right.
https://github.com/apache/skywalking/blob/c2e2d4182d5715cce49b6f95670f3fae2f44d0ba/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java#L144

https://github.com/apache/skywalking/blob/c2e2d4182d5715cce49b6f95670f3fae2f44d0ba/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchProvider.java#L212



- How to fix?
the problem is the `application.yml` set the  
```
    trustStorePath: ${SW_SW_STORAGE_ES_SSL_JKS_PATH:"../es_keystore.jks"}
```

so you should set the trustStorePath default value empty

```
version: '3.3'
services:
  elasticsearch:
    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.1
    container_name: elasticsearch
    restart: always
    ports:
      - 9200:9200
    environment:
      discovery.type: single-node
      ELASTIC_PASSWORD: test
    ulimits:
      memlock:
        soft: -1
        hard: -1
  oap:
    image: apache/skywalking-oap-server:7.0.0-es6
    container_name: oap
    depends_on:
      - elasticsearch
    links:
      - elasticsearch
    restart: always
    ports:
      - 11800:11800
      - 12800:12800
    environment:
      SW_STORAGE: elasticsearch
      SW_NAMESPACE: sk
      SW_STORAGE_ES_CLUSTER_NODES: elasticsearch:9200
      SW_ES_USER: elastic
      SW_ES_PASSWORD: test
      SW_SW_STORAGE_ES_SSL_JKS_PATH: "" # this not work
    # volumes:
      # - ./application.yml:/skywalking/config/application.yml
  ui:
    image: apache/skywalking-ui:7.0.0
    container_name: ui
    depends_on:
      - oap
    links:
      - oap
    restart: always
    ports:
      - 8080:8080
    environment:
      SW_OAP_ADDRESS: oap:12800
```

Now I modify the `application.yml`  set the trustStorePath default value empty.
```
trustStorePath: ${SW_SW_STORAGE_ES_SSL_JKS_PATH:""}
```

It work.

___
### New feature or improvement
- Describe the details and related test reports.
