### PR TITLE
Move to 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ including
 
 
 # Document
-- [7.x Documentation, dev version](docs/README.md).
+- [8.x Documentation, dev version](docs/README.md).
 - [7.0.0 Documentation](https://github.com/apache/skywalking/blob/v7.0.0/docs/README.md).
 - [6.6 Documentation](https://github.com/apache/skywalking/blob/v6.6.0/docs/README.md).
 - [6.5 Documentation](https://github.com/apache/skywalking/blob/v6.6.0/docs/README.md).

--- a/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-trace/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-trace/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/pom.xml
+++ b/apm-application-toolkit/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apm-application-toolkit</artifactId>

--- a/apm-commons/apm-datacarrier/pom.xml
+++ b/apm-commons/apm-datacarrier/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/apm-util/pom.xml
+++ b/apm-commons/apm-util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/pom.xml
+++ b/apm-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-dist-es7/pom.xml
+++ b/apm-dist-es7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-dist/pom.xml
+++ b/apm-dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/apm-network/pom.xml
+++ b/apm-protocol/apm-network/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-protocol</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/pom.xml
+++ b/apm-protocol/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent-core</artifactId>

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextCarrier.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextCarrier.java
@@ -73,8 +73,8 @@ public class ContextCarrier implements Serializable {
     private CorrelationContext correlationContext = new CorrelationContext();
 
     public CarrierItem items() {
-        SW7CorrelationCarrierItem sw7CorrelationCarrierItem = new SW7CorrelationCarrierItem(correlationContext, null);
-        SW6CarrierItem sw6CarrierItem = new SW6CarrierItem(this, sw7CorrelationCarrierItem);
+        SW8CorrelationCarrierItem sw8CorrelationCarrierItem = new SW8CorrelationCarrierItem(correlationContext, null);
+        SW6CarrierItem sw6CarrierItem = new SW6CarrierItem(this, sw8CorrelationCarrierItem);
         return new CarrierItemHead(sw6CarrierItem);
     }
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/SW8CorrelationCarrierItem.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/SW8CorrelationCarrierItem.java
@@ -17,11 +17,11 @@
 
 package org.apache.skywalking.apm.agent.core.context;
 
-public class SW7CorrelationCarrierItem extends CarrierItem {
-    public static final String HEADER_NAME = "sw7-correlation";
+public class SW8CorrelationCarrierItem extends CarrierItem {
+    public static final String HEADER_NAME = "sw8-correlation";
     private final CorrelationContext correlationContext;
 
-    public SW7CorrelationCarrierItem(CorrelationContext correlationContext, CarrierItem next) {
+    public SW8CorrelationCarrierItem(CorrelationContext correlationContext, CarrierItem next) {
         super(HEADER_NAME, correlationContext.serialize(), next);
         this.correlationContext = correlationContext;
     }

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/ContextCarrierV2HeaderTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/ContextCarrierV2HeaderTest.java
@@ -36,7 +36,7 @@ public class ContextCarrierV2HeaderTest {
             next = next.next();
             if (next.getHeadKey().equals(SW6CarrierItem.HEADER_NAME)) {
                 next.setHeadValue("1-My40LjU=-MS4yLjM=-4-1-1-IzEyNy4wLjAuMTo4MDgw--");
-            } else if (next.getHeadKey().equals(SW7CorrelationCarrierItem.HEADER_NAME)) {
+            } else if (next.getHeadKey().equals(SW8CorrelationCarrierItem.HEADER_NAME)) {
                 next.setHeadValue("dGVzdA==:dHJ1ZQ==");
             } else {
                 throw new IllegalArgumentException("Unknown Header: " + next.getHeadKey());
@@ -73,7 +73,7 @@ public class ContextCarrierV2HeaderTest {
              */
             if (next.getHeadKey().equals(SW6CarrierItem.HEADER_NAME)) {
                 Assert.assertEquals("1-My40LjU=-MS4yLjM=-4-1-1-IzEyNy4wLjAuMTo4MDgw-Iy9wb3J0YWw=-Iy9hcHA=", next.getHeadValue());
-            } else if (next.getHeadKey().equals(SW7CorrelationCarrierItem.HEADER_NAME)) {
+            } else if (next.getHeadKey().equals(SW8CorrelationCarrierItem.HEADER_NAME)) {
                 /**
                  * customKey:customValue
                  *
@@ -90,7 +90,7 @@ public class ContextCarrierV2HeaderTest {
             next = next.next();
             if (next.getHeadKey().equals(SW6CarrierItem.HEADER_NAME)) {
                 Assert.assertEquals("1-My40LjU=-MS4yLjM=-4-1-1-IzEyNy4wLjAuMTo4MDgw-Iy9wb3J0YWw=-Iy9hcHA=", next.getHeadValue());
-            } else if (next.getHeadKey().equals(SW7CorrelationCarrierItem.HEADER_NAME)) {
+            } else if (next.getHeadKey().equals(SW8CorrelationCarrierItem.HEADER_NAME)) {
                 Assert.assertEquals("dGVzdA==:dHJ1ZQ==", next.getHeadValue());
             } else {
                 throw new IllegalArgumentException("Unknown Header: " + next.getHeadKey());
@@ -124,7 +124,7 @@ public class ContextCarrierV2HeaderTest {
             next = next.next();
             if (next.getHeadKey().equals(SW6CarrierItem.HEADER_NAME)) {
                 sw6HeaderValue = next.getHeadValue();
-            } else if (next.getHeadKey().equals(SW7CorrelationCarrierItem.HEADER_NAME)) {
+            } else if (next.getHeadKey().equals(SW8CorrelationCarrierItem.HEADER_NAME)) {
                 correlationHeaderValue = next.getHeadValue();
             } else {
                 throw new IllegalArgumentException("Unknown Header: " + next.getHeadKey());
@@ -137,7 +137,7 @@ public class ContextCarrierV2HeaderTest {
             next = next.next();
             if (next.getHeadKey().equals(SW6CarrierItem.HEADER_NAME)) {
                 next.setHeadValue(sw6HeaderValue);
-            } else if (next.getHeadKey().equals(SW7CorrelationCarrierItem.HEADER_NAME)) {
+            } else if (next.getHeadKey().equals(SW8CorrelationCarrierItem.HEADER_NAME)) {
                 next.setHeadValue(correlationHeaderValue);
             } else {
                 throw new IllegalArgumentException("Unknown Header: " + next.getHeadKey());

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/armeria-0.84.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/armeria-0.84.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/armeria-0.85.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/armeria-0.85.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/avro-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/avro-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/ehcache-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/ehcache-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-grpc-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpClient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpasyncclient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpclient-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-3.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpclient-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jedis-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jedis-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jedis-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jetty-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-lettuce-5.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>light4j-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>light4j-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-mongodb-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>nutz-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/play-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/play-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-play-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-sdk-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pulsar-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rabbitmq-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rabbitmq-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-redisson-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-server-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-0.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-0.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>servicecomb-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>servicecomb-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-jdbc-1.5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-jdbc-1.5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-sphere-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-sphere-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-RC3-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-RC3-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sharding-sphere-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-cloud</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>netflix-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>netflix-plugins</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-cloud-feign-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-cloud</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/spring-cloud-feign-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/spring-cloud-feign-2.x-plugin/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.skywalking</groupId>
     <artifactId>spring-cloud</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apm-spring-cloud-feign-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spymemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>undertow-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>undertow-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertx-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>vertx-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-xmemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-test-tools/pom.xml
+++ b/apm-sniffer/apm-test-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sniffer</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-test-tools</artifactId>

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-gson-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/kotlin-coroutine-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/kotlin-coroutine-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-kotlin-coroutine-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-cloud</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-cloud-gateway-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-plugins</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>optional-spring-cloud</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-zookeeper-3.4.x-plugin</artifactId>

--- a/apm-sniffer/pom.xml
+++ b/apm-sniffer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-webapp/pom.xml
+++ b/apm-webapp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/docs/en/protocols/HTTP-API-Protocol.md
+++ b/docs/en/protocols/HTTP-API-Protocol.md
@@ -5,7 +5,7 @@ HTTP API Protocol defines the API data format, including api request and respons
 ### Do register
 
 Detail information about data format can be found in  [Register service](https://github.com/apache/skywalking-data-collect-protocol/tree/master/register/Register.proto).
-And register steps followings [SkyWalking Trace Data Protocol v2](Trace-Data-Protocol-v2.md).
+And register steps followings [SkyWalking Trace Data Protocol v2](Trace-Data-Protocol-v3.md).
 
 - Service Register
 

--- a/docs/en/protocols/README.md
+++ b/docs/en/protocols/README.md
@@ -23,16 +23,15 @@ with this specific request.
 1. **Trace Data Protocol** is out of wire data, agent/SDK uses this to send traces and metrics to skywalking or other
 compatible backend. 
 
-[Cross Process Propagation Headers Protocol v2](Skywalking-Cross-Process-Propagation-Headers-Protocol-v2.md) is the new protocol for 
-in-wire context propagation, started in 6.0.0-beta release, v1 is no longer supported.
+[Cross Process Propagation Headers Protocol v3](Skywalking-Cross-Process-Propagation-Headers-Protocol-v3.md) is the new protocol for 
+in-wire context propagation, started in 8.0.0 release.
 
 [Cross Process Correlation Headers Protocol v1](Skywalking-Cross-Process-Correlation-Headers-Protocol-v1.md) is a new in-wire context propagation additional and optional protocols. 
 Please read SkyWalking language agents documentations to see whether it is supported. 
 This protocol defines the data format of transporting custom data with `Cross Process Propagation Headers Protocol v2`.
-SkyWalking javaagent begins to support this since 7.1.0.
+SkyWalking javaagent begins to support this since 8.0.0.
 
-Since SkyWalking v7.1.0, SkyWalking agent and backend are using Trace Data Protocol v2.1.
-[SkyWalking Trace Data Protocol v2.1](Trace-Data-Protocol-v2.md) defines the communication way and format between agent and backend.
+[SkyWalking Trace Data Protocol v3](Trace-Data-Protocol-v3.md) defines the communication way and format between agent and backend.
 
 
 ### Service Mesh probe protocol

--- a/docs/en/protocols/Skywalking-Cross-Process-Correlation-Headers-Protocol-v1.md
+++ b/docs/en/protocols/Skywalking-Cross-Process-Correlation-Headers-Protocol-v1.md
@@ -1,7 +1,7 @@
 # SkyWalking Cross Process Correlation Headers Protocol
 * Version 1.0
 
-The Cross Process Correlation Headers Protocol is used to transport custom data by leveraging the capability of [Cross Process Propagation Headers Protocol](Skywalking-Cross-Process-Propagation-Headers-Protocol-v2.md). 
+The Cross Process Correlation Headers Protocol is used to transport custom data by leveraging the capability of [Cross Process Propagation Headers Protocol](Skywalking-Cross-Process-Propagation-Headers-Protocol-v3.md). 
 
 This is an optional and additional protocol for language tracer implementation. All tracer implementation could consider to implement this.
 Cross Process Correlation Header key is `sw7-correlation`. The value is the `encoded(key):encoded(value)` list with elements splitted by `,` such as `base64(string key):base64(string value),base64(string key2):base64(string value2)`.

--- a/docs/en/protocols/Skywalking-Cross-Process-Propagation-Headers-Protocol-v3.md
+++ b/docs/en/protocols/Skywalking-Cross-Process-Propagation-Headers-Protocol-v3.md
@@ -1,5 +1,5 @@
 # SkyWalking Cross Process Propagation Headers Protocol
-* Version 2.1
+* Version 3.0
 
 SkyWalking is more likely an APM system, rather than common distributed tracing system. 
 The Headers is much more complex than them in order to improving analysis performance of collector. 
@@ -9,7 +9,7 @@ You can find many similar mechanism in other commercial APM system. (Some are ev
 SkyWalking Cross Process Propagation Headers Protocol v2 is also named as sw6 protocol, which is for context propagation.
 
 ## Header Item
-* Header Name: `sw6`
+* Header Name: `sw8`
 * Header Value: Split by `-`, the parts are following. The length of header value should be less than 2k(default).
 
 Value format example, `XXXXX-XXXXX-XXXX-XXXX`
@@ -22,23 +22,23 @@ Values include the following segments, all String type values are in BASE64 enco
 1. Trace Id. **String(BASE64 encoded)**. Three Longs split by `.` to represent the unique id of this trace.
 1. Parent trace segment Id. **String(BASE64 encoded)**. Three Longs split by `.` to represent the unique id of parent segment in parent service.
 1. Parent span Id. Integer. Begin with 0. This span id points to the parent span in parent trace segment. 
-1. Parent service instance Id. Integer. The instance ID of parent service.
-1. Entrance service instance Id. Integer. The instance ID of the entrance service. 
+1. Parent service instance Id.  **String(BASE64 encoded)**.
+1. Entrance service instance Id.  **String(BASE64 encoded)**. 
 1. Target address of this request. **String(BASE64 encoded)**. The network address(not must be IP + port) used at client side to access this target
-service. _This value can use exchange/compress collector service to get the id(integer) to represent the string. If you use the string, it must start with `#`, others use integer directly._
+service.
 
 - Optional(s)
 
 Optional values could not exist if the agent/SDK haven't those info or the length of header is over the threshold(2k default).  
-1. Entry endpoint of the trace. Add `#` as the prefix. **String(BASE64 encoded)**. 
-1. Parent endpoint of the parent service. Add `#` as the prefix. **String(BASE64 encoded)**. 
+1. Entry endpoint of the trace. **String(BASE64 encoded)**. 
+1. Parent endpoint of the parent service. **String(BASE64 encoded)**. 
 
 ## Sample values
-1. Short version, `1-TRACEID-SEGMENTID-3-5-2-IPPORT`
+1. Short version, `1-TRACEID-SEGMENTID-3-INSTANCEID-ENTRY_INSTANCE_ID-IPPORT`
 1. Complete version, `1-TRACEID-SEGMENTID-3-5-2-IPPORT-ENTRYURI-PARENTURI`
 
 ## Differences from v2
-The entry and parent endpoints in the header doesn't support ID format. Always use the literal string.
+All ID register mechanism has been removed. Agent keeps using literal string to propagate all necessary information.
 [SkyWalking v2](https://github.com/apache/skywalking/blob/v7.0.0/docs/en/protocols/Trace-Data-Protocol-v2.md) 
 
 ## Differences from v1 

--- a/docs/en/protocols/Trace-Data-Protocol-v3.md
+++ b/docs/en/protocols/Trace-Data-Protocol-v3.md
@@ -7,26 +7,14 @@ Trace data protocol is defined and provided in [gRPC format](https://github.com/
 For each agent/SDK, it needs to register service id and service instance id before reporting any kind of trace 
 or metrics data.
 
-Since SkyWalking v7.x, SkyWalking provided register and uplink trace data through HTTP API way.
+Since SkyWalking v8.x, SkyWalking provided register and uplink trace data through HTTP API way.
 [HTTP API Protocol](HTTP-API-Protocol.md) defined the API data format.
 
-### Step 1. Do register
-[Register service](https://github.com/apache/skywalking-data-collect-protocol/tree/master/register/Register.proto) takes charge of 
-all register methods. At step 1, we need `doServiceRegister`, then `doServiceInstanceRegister`.
+### Report service instance properties 
+Service Instance has more information than a name, once the agent wants to report this, use `ServiceInstanceService#reportProperties` service
+providing a string-key/string-value pair list as the parameter. `language` of target instance is expected at least.
 
-1. First of all, do `doServiceRegister`, input is **serviceName**, which could be declared by any UTF-8 String. The return 
-value is KeyValue pair, **serviceName** as key, **service id** as value. Batch is also supported.
-1. After have **service id**, use `doServiceInstanceRegister` to do instance register. Input is **service id**, **UUID**,
-and **register time**. UUID should be unique in the whole distributed environments. The return value is still KeyValue pair,
-**UUID** as key, **service instance id** as value. Batch is also supported.
-
-For register, the most important notice is that, the process is expected as async in backend, so, the return could be **NULL**.
-In most cases, you need to set a timer to call these services repeated, until you got the response. Suggestion loop cycle, 10s.
-
-Because batch is supported, even for most language agent/SDK, no scenario to do batch register. We suggest to check the  `serviceName`
-and `UUID` in response, and match with your expected value.
-
-### Step 2. Send trace and metrics
+### Send trace and metrics
 After you have service id and service instance id, you could send traces and metrics. Now we
 have 
 1. `TraceSegmentReportService#collect` for skywalking native trace format
@@ -50,7 +38,7 @@ e.g. accessing DB by JDBC, reading Redis/Memcached are cataloged an ExitSpan.
 
 3. Span parent info called Reference, which is included in span. Reference carries more fields besides 
 trace id, parent segment id, span id. Others are **entry service instance id**, **parent service instance id**,
-**entry endpoint**, **parent endpoint** and **network address**. Follow [Cross Process Propagation Headers Protocol v2](Skywalking-Cross-Process-Propagation-Headers-Protocol-v2.md),
+**entry endpoint**, **parent endpoint** and **network address**. Follow [Cross Process Propagation Headers Protocol v2](Skywalking-Cross-Process-Propagation-Headers-Protocol-v3.md),
 you will know how to get all these fields.
 
 4. `segment` in Upstream is the byte array of TraceSegmentObject.

--- a/docs/en/setup/service-agent/java-agent/Namespace.md
+++ b/docs/en/setup/service-agent/java-agent/Namespace.md
@@ -18,7 +18,7 @@ Namespace is the proposal from this.It is used for tracing and monitoring isolat
 The default value of `agent.namespace` is empty. 
 
 **Influence**
-The default header key of SkyWalking is `sw6`, more in this [document](../../../protocols/Skywalking-Cross-Process-Propagation-Headers-Protocol-v2.md).
+The default header key of SkyWalking is `sw6`, more in this [document](../../../protocols/Skywalking-Cross-Process-Propagation-Headers-Protocol-v3.md).
 After `agent.namespace` is set, the key changes to `namespace-sw6`.
 
 The across process propagation chain breaks, when the two sides are using different namespace.

--- a/oap-server/exporter/pom.xml
+++ b/oap-server/exporter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/oal-grammar/pom.xml
+++ b/oap-server/oal-grammar/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/oal-rt/pom.xml
+++ b/oap-server/oal-rt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/pom.xml
+++ b/oap-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-alarm-plugin/pom.xml
+++ b/oap-server/server-alarm-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-bootstrap/pom.xml
+++ b/oap-server/server-bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-consul-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-consul-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-etcd-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-etcd-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-nacos-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-nacos-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-standalone-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-standalone-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-cluster-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>server-cluster-plugin</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-cluster-plugin/pom.xml
+++ b/oap-server/server-cluster-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-api/pom.xml
+++ b/oap-server/server-configuration/configuration-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-apollo/pom.xml
+++ b/oap-server/server-configuration/configuration-apollo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-consul/pom.xml
+++ b/oap-server/server-configuration/configuration-consul/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/oap-server/server-configuration/configuration-etcd/pom.xml
+++ b/oap-server/server-configuration/configuration-etcd/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-nacos/pom.xml
+++ b/oap-server/server-configuration/configuration-nacos/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/configuration-zookeeper/pom.xml
+++ b/oap-server/server-configuration/configuration-zookeeper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/grpc-configuration-sync/pom.xml
+++ b/oap-server/server-configuration/grpc-configuration-sync/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-configuration</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-configuration/pom.xml
+++ b/oap-server/server-configuration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-core/pom.xml
+++ b/oap-server/server-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-buffer/pom.xml
+++ b/oap-server/server-library/library-buffer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-client/pom.xml
+++ b/oap-server/server-library/library-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-module/pom.xml
+++ b/oap-server/server-library/library-module/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-server/pom.xml
+++ b/oap-server/server-library/library-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/library-util/pom.xml
+++ b/oap-server/server-library/library-util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-library/pom.xml
+++ b/oap-server/server-library/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-query-plugin/pom.xml
+++ b/oap-server/server-query-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-query-plugin/query-graphql-plugin/pom.xml
+++ b/oap-server/server-query-plugin/query-graphql-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-query-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/jaeger-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/jaeger-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/receiver-proto/pom.xml
+++ b/oap-server/server-receiver-plugin/receiver-proto/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-istio-telemetry-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-istio-telemetry-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-profile-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-profile-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-so11y-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-so11y-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/pom.xml
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-receiver-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-starter-es7/pom.xml
+++ b/oap-server/server-starter-es7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-starter/pom.xml
+++ b/oap-server/server-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch7-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-elasticsearch7-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/oap-server/server-storage-plugin/storage-influxdb-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-influxdb-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-jaeger-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-jaeger-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-storage-plugin/storage-zipkin-plugin/pom.xml
+++ b/oap-server/server-storage-plugin/storage-zipkin-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-storage-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/pom.xml
+++ b/oap-server/server-telemetry/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/telemetry-api/pom.xml
+++ b/oap-server/server-telemetry/telemetry-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-telemetry</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/telemetry-prometheus/pom.xml
+++ b/oap-server/server-telemetry/telemetry-prometheus/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-telemetry</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-telemetry/telemetry-so11y/pom.xml
+++ b/oap-server/server-telemetry/telemetry-so11y/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>server-telemetry</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-testing/pom.xml
+++ b/oap-server/server-testing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-tools/pom.xml
+++ b/oap-server/server-tools/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>oap-server</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oap-server/server-tools/profile-exporter/pom.xml
+++ b/oap-server/server-tools/profile-exporter/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <artifactId>server-tools</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>profile-exporter</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/oap-server/server-tools/profile-exporter/tool-profile-snapshot-bootstrap/pom.xml
+++ b/oap-server/server-tools/profile-exporter/tool-profile-snapshot-bootstrap/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <artifactId>profile-exporter</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>tool-profile-snapshot-bootstrap</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/oap-server/server-tools/profile-exporter/tool-profile-snapshot-exporter-es7/pom.xml
+++ b/oap-server/server-tools/profile-exporter/tool-profile-snapshot-exporter-es7/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <artifactId>profile-exporter</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>tool-profile-snapshot-exporter-es7</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/oap-server/server-tools/profile-exporter/tool-profile-snapshot-exporter/pom.xml
+++ b/oap-server/server-tools/profile-exporter/tool-profile-snapshot-exporter/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <artifactId>profile-exporter</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>tool-profile-snapshot-exporter</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/oap-server/server-tools/profile-exporter/tool-profile-snapshot-server-mock/pom.xml
+++ b/oap-server/server-tools/profile-exporter/tool-profile-snapshot-server-mock/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <artifactId>profile-exporter</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>tool-profile-snapshot-server-mock</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>apm</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.apache</groupId>


### PR DESCRIPTION
Hi Dev Team

After the experiences of removing endpoint_inventory, I found out this
strategy is successful.
Especially, we totally get rid of register, so I want to do more.

### SkyWalking 8.0.0
First, it is already unexpected for me, we have to move to 8.0.0 so
quickly, but after the discussion with @hanahmily, and thinking about this for several days, I think
we have to.

#### The key chances are following
1. Remove service, service instance, and network address register. The old
register protocols are totally going to be removed.
2. The agent doesn't need to do register anymore. Service name and Service
Instance name are generated by the agent itself, but the extra information,
such as IP, hostname, language, should report to backend separately.
3. Service Traffic should be added just like the endpoint traffic but keep
the time bucket as we need accurate service name in the given duration
4. Service Instance Traffic should be added too, with external information,
such as language, hostname.
5. Trace context propagation context should be changed to accept string in
service instance name, endpoint name and network address. This could ease
the agent logic, but also, requires changes in all language agent and
plugin test tool,
6. Trace report protocol requires to change too, in order to adopt the
string.
7. e2e tests have to ignore PHP and LUA at first, and remove the 6.x
compatibility test(doesn't support anymore). @heyanlong @moonming @dmsolr 

#### The benefits we will get are
1. Don't worry about the inventory(s) that has been deleted randomly by end
users. (We received a lot of issue reports about this)
2. The upgrade could be easier erasing the whole storage and reboot the new
one. (Users don't feel comfortable about upgrade)
3. No hot-reboot case in the agent side
4. No cache of network address register information in the agent.
5. No service and service instance cache in the OAP
6. No register lock in the OAP
7. No file buffer mechanism in the OAP too, same as no register happens.

In my mind, I think this totally break upgrade is super meaningful and will
be good change. Even we break many things, they are easy to follow.
@mrproliu  I think by following this, we need
to change the collaboration header to `sw8` :) As no 7.1.0 release will
happen.

Mail list, https://lists.apache.org/thread.html/rda36fa8d191fc5750fc793993c69e14a917138bf97f9c2a461b72811%40%3Cdev.skywalking.apache.org%3E