### PR TITLE
Support to use empty string to override existing config.

### DIFF
--- a/apm-commons/apm-util/src/main/java/org/apache/skywalking/apm/util/PropertyPlaceholderHelper.java
+++ b/apm-commons/apm-util/src/main/java/org/apache/skywalking/apm/util/PropertyPlaceholderHelper.java
@@ -31,7 +31,11 @@ import java.util.Set;
  */
 public enum PropertyPlaceholderHelper {
 
-    INSTANCE(PlaceholderConfigurerSupport.DEFAULT_PLACEHOLDER_PREFIX, PlaceholderConfigurerSupport.DEFAULT_PLACEHOLDER_SUFFIX, PlaceholderConfigurerSupport.DEFAULT_VALUE_SEPARATOR, true);
+    INSTANCE(
+        PlaceholderConfigurerSupport.DEFAULT_PLACEHOLDER_PREFIX,
+        PlaceholderConfigurerSupport.DEFAULT_PLACEHOLDER_SUFFIX, PlaceholderConfigurerSupport.DEFAULT_VALUE_SEPARATOR,
+        true
+    );
 
     private final String placeholderPrefix;
 
@@ -54,7 +58,7 @@ public enum PropertyPlaceholderHelper {
      *                                       true}) or cause an exception ({@code false})
      */
     PropertyPlaceholderHelper(String placeholderPrefix, String placeholderSuffix, String valueSeparator,
-        boolean ignoreUnresolvablePlaceholders) {
+                              boolean ignoreUnresolvablePlaceholders) {
         if (StringUtil.isEmpty(placeholderPrefix) || StringUtil.isEmpty(placeholderSuffix)) {
             throw new UnsupportedOperationException("'placeholderPrefix or placeholderSuffix' must not be null");
         }
@@ -89,17 +93,17 @@ public enum PropertyPlaceholderHelper {
         return replacePlaceholders(value, new PlaceholderResolver() {
             @Override
             public String resolvePlaceholder(String placeholderName) {
-                return PropertyPlaceholderHelper.this.getConfigValue(placeholderName, properties);
+                return getConfigValue(placeholderName, properties);
             }
         });
     }
 
     private String getConfigValue(String key, final Properties properties) {
         String value = System.getProperty(key);
-        if (StringUtil.isEmpty(value)) {
+        if (value == null) {
             value = System.getenv(key);
         }
-        if (StringUtil.isEmpty(value)) {
+        if (value == null) {
             value = properties.getProperty(key);
         }
         return value;
@@ -118,7 +122,7 @@ public enum PropertyPlaceholderHelper {
     }
 
     protected String parseStringValue(String value, PlaceholderResolver placeholderResolver,
-        Set<String> visitedPlaceholders) {
+                                      Set<String> visitedPlaceholders) {
 
         StringBuilder result = new StringBuilder(value);
 
@@ -129,7 +133,8 @@ public enum PropertyPlaceholderHelper {
                 String placeholder = result.substring(startIndex + this.placeholderPrefix.length(), endIndex);
                 String originalPlaceholder = placeholder;
                 if (!visitedPlaceholders.add(originalPlaceholder)) {
-                    throw new IllegalArgumentException("Circular placeholder reference '" + originalPlaceholder + "' in property definitions");
+                    throw new IllegalArgumentException(
+                        "Circular placeholder reference '" + originalPlaceholder + "' in property definitions");
                 }
                 // Recursive invocation, parsing placeholders contained in the placeholder key.
                 placeholder = parseStringValue(placeholder, placeholderResolver, visitedPlaceholders);
@@ -156,7 +161,8 @@ public enum PropertyPlaceholderHelper {
                     // Proceed with unprocessed value.
                     startIndex = result.indexOf(this.placeholderPrefix, endIndex + this.placeholderSuffix.length());
                 } else {
-                    throw new IllegalArgumentException("Could not resolve placeholder '" + placeholder + "'" + " in value \"" + value + "\"");
+                    throw new IllegalArgumentException(
+                        "Could not resolve placeholder '" + placeholder + "'" + " in value \"" + value + "\"");
                 }
                 visitedPlaceholders.remove(originalPlaceholder);
             } else {

--- a/oap-server/server-bootstrap/src/main/resources/application.yml
+++ b/oap-server/server-bootstrap/src/main/resources/application.yml
@@ -92,8 +92,8 @@ storage:
     nameSpace: ${SW_NAMESPACE:""}
     clusterNodes: ${SW_STORAGE_ES_CLUSTER_NODES:localhost:9200}
     protocol: ${SW_STORAGE_ES_HTTP_PROTOCOL:"http"}
-    trustStorePath: ${SW_SW_STORAGE_ES_SSL_JKS_PATH:""}
-    trustStorePass: ${SW_SW_STORAGE_ES_SSL_JKS_PASS:""}
+    trustStorePath: ${SW_STORAGE_ES_SSL_JKS_PATH:""}
+    trustStorePass: ${SW_STORAGE_ES_SSL_JKS_PASS:""}
     user: ${SW_ES_USER:""}
     password: ${SW_ES_PASSWORD:""}
     secretsManagementFile: ${SW_ES_SECRETS_MANAGEMENT_FILE:""} # Secrets management file in the properties format includes the username, password, which are managed by 3rd party tool.
@@ -113,8 +113,8 @@ storage:
     nameSpace: ${SW_NAMESPACE:""}
     clusterNodes: ${SW_STORAGE_ES_CLUSTER_NODES:localhost:9200}
     protocol: ${SW_STORAGE_ES_HTTP_PROTOCOL:"http"}
-    trustStorePath: ${SW_SW_STORAGE_ES_SSL_JKS_PATH:"../es_keystore.jks"}
-    trustStorePass: ${SW_SW_STORAGE_ES_SSL_JKS_PASS:""}
+    trustStorePath: ${SW_STORAGE_ES_SSL_JKS_PATH:""}
+    trustStorePass: ${SW_STORAGE_ES_SSL_JKS_PASS:""}
     dayStep: ${SW_STORAGE_DAY_STEP:1} # Represent the number of days in the one minute/hour/day index.
     user: ${SW_ES_USER:""}
     password: ${SW_ES_PASSWORD:""}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchConfig.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchConfig.java
@@ -89,37 +89,6 @@ public class StorageModuleElasticsearchConfig extends ModuleConfig {
     @Setter
     private int profileTaskQueryMaxSize = 200;
     @Setter
-    private int recordDataTTL = 7;
-    @Setter
-    private int minuteMetricsDataTTL = 2;
-    @Setter
-    private int hourMetricsDataTTL = 2;
-    @Setter
-    private int dayMetricsDataTTL = 2;
-    private int otherMetricsDataTTL = 0;
-    @Setter
-    private int monthMetricsDataTTL = 18;
-    @Setter
     private String advanced;
 
-    public int getMinuteMetricsDataTTL() {
-        if (otherMetricsDataTTL > 0) {
-            return otherMetricsDataTTL;
-        }
-        return minuteMetricsDataTTL;
-    }
-
-    public int getHourMetricsDataTTL() {
-        if (otherMetricsDataTTL > 0) {
-            return otherMetricsDataTTL;
-        }
-        return hourMetricsDataTTL;
-    }
-
-    public int getDayMetricsDataTTL() {
-        if (otherMetricsDataTTL > 0) {
-            return otherMetricsDataTTL;
-        }
-        return dayMetricsDataTTL;
-    }
 }


### PR DESCRIPTION
Resolves #4613

This PR fixed an override bug. When the default value is not empty string, but the user want to override it with empty value, it is always failure. Report from https://github.com/apache/skywalking/issues/4613#issuecomment-611939794 by @lianghuiyuan

Also, fixing 3 things.
1. Wrong system env names, duplicated `SW_`.
1. `trustStorePath` should not have default path in the official distribution YAML.
1. TTL config in the ElasticSearch providers have not been deleted by my previous PR.

@hanahmily @innerpeacez The env name changes don't require change at helm side, right?