### PR TITLE
Keep latest index always present.

### DIFF
--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/HistoryDeleteEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/HistoryDeleteEsDAO.java
@@ -68,7 +68,7 @@ public class HistoryDeleteEsDAO extends EsDAO implements IHistoryDeleteDAO {
         }
         String latestIndex = TimeSeriesUtils.latestWriteIndexName(model);
         if (!leftIndices.contains(latestIndex)) {
-            client.createIndex(latest);
+            client.createIndex(latestIndex);
         }
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/HistoryDeleteEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/HistoryDeleteEsDAO.java
@@ -54,19 +54,21 @@ public class HistoryDeleteEsDAO extends EsDAO implements IHistoryDeleteDAO {
         List<String> indexes = client.retrievalIndexByAliases(model.getName());
 
         List<String> prepareDeleteIndexes = new ArrayList<>();
+        List<String> leftIndices = new ArrayList<>();
         for (String index : indexes) {
             long timeSeries = TimeSeriesUtils.isolateTimeFromIndexName(index);
             if (deadline >= timeSeries) {
                 prepareDeleteIndexes.add(index);
+            } else {
+                leftIndices.add(index);
             }
         }
-
-        if (indexes.size() == prepareDeleteIndexes.size()) {
-            client.createIndex(TimeSeriesUtils.latestWriteIndexName(model));
-        }
-
         for (String prepareDeleteIndex : prepareDeleteIndexes) {
             client.deleteByIndexName(prepareDeleteIndex);
+        }
+        String latestIndex = TimeSeriesUtils.latestWriteIndexName(model);
+        if (!leftIndices.contains(latestIndex)) {
+            client.createIndex(TimeSeriesUtils.timeSeries(model));
         }
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/HistoryDeleteEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/HistoryDeleteEsDAO.java
@@ -68,7 +68,7 @@ public class HistoryDeleteEsDAO extends EsDAO implements IHistoryDeleteDAO {
         }
         String latestIndex = TimeSeriesUtils.latestWriteIndexName(model);
         if (!leftIndices.contains(latestIndex)) {
-            client.createIndex(TimeSeriesUtils.timeSeries(model));
+            client.createIndex(latest);
         }
     }
 }


### PR DESCRIPTION
  * Avoid TTL timer to remove latest index
  * Create a latest index even without any data.

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>

