### PR TITLE
Support typeOfMetrics query

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModule.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModule.java
@@ -32,6 +32,7 @@ import org.apache.skywalking.oap.server.core.query.AggregationQueryService;
 import org.apache.skywalking.oap.server.core.query.AlarmQueryService;
 import org.apache.skywalking.oap.server.core.query.LogQueryService;
 import org.apache.skywalking.oap.server.core.query.MetadataQueryService;
+import org.apache.skywalking.oap.server.core.query.MetricsMetadataQueryService;
 import org.apache.skywalking.oap.server.core.query.MetricsQueryService;
 import org.apache.skywalking.oap.server.core.query.ProfileTaskQueryService;
 import org.apache.skywalking.oap.server.core.query.TopNRecordsQueryService;
@@ -90,6 +91,7 @@ public class CoreModule extends ModuleDefine {
 
     private void addQueryService(List<Class> classes) {
         classes.add(TopologyQueryService.class);
+        classes.add(MetricsMetadataQueryService.class);
         classes.add(MetricsQueryService.class);
         classes.add(TraceQueryService.class);
         classes.add(LogQueryService.class);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
@@ -48,6 +48,7 @@ import org.apache.skywalking.oap.server.core.query.AggregationQueryService;
 import org.apache.skywalking.oap.server.core.query.AlarmQueryService;
 import org.apache.skywalking.oap.server.core.query.LogQueryService;
 import org.apache.skywalking.oap.server.core.query.MetadataQueryService;
+import org.apache.skywalking.oap.server.core.query.MetricsMetadataQueryService;
 import org.apache.skywalking.oap.server.core.query.MetricsQueryService;
 import org.apache.skywalking.oap.server.core.query.ProfileTaskQueryService;
 import org.apache.skywalking.oap.server.core.query.TopNRecordsQueryService;
@@ -213,6 +214,7 @@ public class CoreModuleProvider extends ModuleProvider {
             NetworkAddressAliasCache.class, new NetworkAddressAliasCache(moduleConfig));
 
         this.registerServiceImplementation(TopologyQueryService.class, new TopologyQueryService(getManager()));
+        this.registerServiceImplementation(MetricsMetadataQueryService.class, new MetricsMetadataQueryService());
         this.registerServiceImplementation(MetricsQueryService.class, new MetricsQueryService(getManager()));
         this.registerServiceImplementation(TraceQueryService.class, new TraceQueryService(getManager()));
         this.registerServiceImplementation(LogQueryService.class, new LogQueryService(getManager()));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetrics.java
@@ -60,7 +60,7 @@ public abstract class ApdexMetrics extends Metrics implements IntValueHolder {
     private int tNum;
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true, function = Function.Avg)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Avg)
     private int value;
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/CPMMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/CPMMetrics.java
@@ -34,7 +34,7 @@ public abstract class CPMMetrics extends Metrics implements LongValueHolder {
 
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true, function = Function.Avg)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Avg)
     private long value;
     @Getter
     @Setter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/CountMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/CountMetrics.java
@@ -33,7 +33,7 @@ public abstract class CountMetrics extends Metrics implements LongValueHolder {
 
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true, function = Function.Sum)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Sum)
     private long value;
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/DoubleAvgMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/DoubleAvgMetrics.java
@@ -44,7 +44,7 @@ public abstract class DoubleAvgMetrics extends Metrics implements DoubleValueHol
     private long count;
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true, function = Function.Avg)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Avg)
     private double value;
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/HistogramMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/HistogramMetrics.java
@@ -39,13 +39,9 @@ public abstract class HistogramMetrics extends Metrics {
 
     public static final String DATASET = "dataset";
 
-    /**
-     * The special case when the column is isValue = true, but storageOnly = true, because it is {@link DataTable} type,
-     * this column can't be query by the aggregation way.
-     */
     @Getter
     @Setter
-    @Column(columnName = DATASET, isValue = true, storageOnly = true)
+    @Column(columnName = DATASET, dataType = Column.ValueDataType.HISTOGRAM, storageOnly = true)
     private DataTable dataset = new DataTable(30);
 
     /**

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/LongAvgMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/LongAvgMetrics.java
@@ -44,7 +44,7 @@ public abstract class LongAvgMetrics extends Metrics implements LongValueHolder 
     private long count;
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true, function = Function.Avg)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Avg)
     private long value;
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/MaxDoubleMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/MaxDoubleMetrics.java
@@ -32,7 +32,7 @@ public abstract class MaxDoubleMetrics extends Metrics implements DoubleValueHol
 
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE)
     private double value;
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/MaxLongMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/MaxLongMetrics.java
@@ -35,7 +35,7 @@ public abstract class MaxLongMetrics extends Metrics implements LongValueHolder 
 
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE)
     private long value;
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/MinDoubleMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/MinDoubleMetrics.java
@@ -32,7 +32,7 @@ public abstract class MinDoubleMetrics extends Metrics implements DoubleValueHol
 
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE)
     private double value = Double.MAX_VALUE;
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/MinLongMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/MinLongMetrics.java
@@ -32,7 +32,7 @@ public abstract class MinLongMetrics extends Metrics implements LongValueHolder 
 
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE)
     private long value = Long.MAX_VALUE;
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentMetrics.java
@@ -38,7 +38,7 @@ public abstract class PercentMetrics extends Metrics implements IntValueHolder {
     private long total;
     @Getter
     @Setter
-    @Column(columnName = PERCENTAGE, isValue = true, function = Function.Avg)
+    @Column(columnName = PERCENTAGE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Avg)
     private int percentage;
     @Getter
     @Setter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentileMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentileMetrics.java
@@ -47,13 +47,9 @@ public abstract class PercentileMetrics extends Metrics implements MultiIntValue
         99
     };
 
-    /**
-     * The special case when the column is isValue = true, but storageOnly = true, because it is {@link DataTable} type,
-     * this column can't be query by the aggregation way.
-     */
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true, storageOnly = true)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.LABELED_VALUE, storageOnly = true)
     private DataTable percentileValues;
     @Getter
     @Setter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PxxMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/PxxMetrics.java
@@ -43,7 +43,7 @@ public abstract class PxxMetrics extends Metrics implements IntValueHolder {
 
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true, function = Function.Avg)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.HISTOGRAM, function = Function.Avg)
     private int value;
     @Getter
     @Setter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/SumMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/SumMetrics.java
@@ -33,7 +33,7 @@ public abstract class SumMetrics extends Metrics implements LongValueHolder {
 
     @Getter
     @Setter
-    @Column(columnName = VALUE, isValue = true, function = Function.Sum)
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Sum)
     private long value;
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/topn/TopN.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/topn/TopN.java
@@ -39,7 +39,7 @@ public abstract class TopN extends Record implements ComparableStorageData {
     private String statement;
     @Getter
     @Setter
-    @Column(columnName = LATENCY)
+    @Column(columnName = LATENCY, dataType = Column.ValueDataType.SAMPLED_RECORD)
     private long latency;
     @Getter
     @Setter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricsMetadataQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricsMetadataQueryService.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.query;
+
+import java.util.Optional;
+import org.apache.skywalking.oap.server.core.query.enumeration.MetricsType;
+import org.apache.skywalking.oap.server.core.storage.annotation.ValueColumnMetadata;
+import org.apache.skywalking.oap.server.library.module.Service;
+
+/**
+ * MetricsMetadataQueryService provides the metadata of metrics to other modules.
+ */
+public class MetricsMetadataQueryService implements Service {
+    public MetricsType typeOfMetrics(String metricsName) {
+        final Optional<ValueColumnMetadata.ValueColumn> valueColumn
+            = ValueColumnMetadata.INSTANCE.readValueColumnDefinition(metricsName);
+        if (valueColumn.isPresent()) {
+            switch (valueColumn.get().getDataType()) {
+                case COMMON_VALUE:
+                    return MetricsType.REGULAR_VALUE;
+                case LABELED_VALUE:
+                    return MetricsType.LABELED_VALUE;
+                case HISTOGRAM:
+                    return MetricsType.HEATMAP;
+                case SAMPLED_RECORD:
+                    return MetricsType.SAMPLED_RECORD;
+                case NOT_VALUE:
+                default:
+                    return MetricsType.UNKNOWN;
+            }
+        } else {
+            return MetricsType.UNKNOWN;
+        }
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TopNRecordsQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TopNRecordsQueryService.java
@@ -24,6 +24,7 @@ import org.apache.skywalking.oap.server.core.query.input.Duration;
 import org.apache.skywalking.oap.server.core.query.input.TopNCondition;
 import org.apache.skywalking.oap.server.core.query.type.SelectedRecord;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
+import org.apache.skywalking.oap.server.core.storage.annotation.ValueColumnMetadata;
 import org.apache.skywalking.oap.server.core.storage.query.ITopNRecordsQueryDAO;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.module.Service;
@@ -46,6 +47,7 @@ public class TopNRecordsQueryService implements Service {
     }
 
     public List<SelectedRecord> readSampledRecords(TopNCondition condition, Duration duration) throws IOException {
-        return getTopNRecordsQueryDAO().readSampledRecords(condition, duration);
+        return getTopNRecordsQueryDAO().readSampledRecords(
+            condition, ValueColumnMetadata.INSTANCE.getValueCName(condition.getName()), duration);
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/Column.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/Column.java
@@ -22,6 +22,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import lombok.Getter;
 import org.apache.skywalking.oap.server.core.query.sql.Function;
 import org.apache.skywalking.oap.server.core.storage.model.IModelOverride;
 
@@ -38,17 +39,12 @@ public @interface Column {
     String columnName();
 
     /**
-     * The column value is used in metrics value query.
-     */
-    boolean isValue() default false;
-
-    /**
      * The function is used in aggregation query.
      */
     Function function() default Function.None;
 
     /**
-     * The default value of this column, when its {@link #isValue()} == true.
+     * The default value of this column, when its {@link #dataType()} != {@link ValueDataType#NOT_VALUE}.
      */
     int defaultValue() default 0;
 
@@ -68,4 +64,47 @@ public @interface Column {
      * @since 7.1.0
      */
     int length() default 200;
+
+    /**
+     * @return the data type of this value column. The value column is the query related value Set {@link
+     * ValueDataType#NOT_VALUE} if this is not the value column, read {@link ValueDataType} for more details.
+     * @since 8.0.0
+     */
+    ValueDataType dataType() default ValueDataType.NOT_VALUE;
+
+    /**
+     * ValueDataType represents the data structure of value column. The persistent way of the value column determine the
+     * available ways to query the data.
+     */
+    enum ValueDataType {
+        /**
+         * NOT_VALUE represents this value wouldn't be queried directly through metrics v2 protocol. It could be never
+         * queried, or just through hard code to do so, uch as the lines of topology and service.
+         */
+        NOT_VALUE(false),
+        /**
+         * COMMON_VALUE represents a single value, usually int or long.
+         */
+        COMMON_VALUE(true),
+        /**
+         * LABELLED_VALUE represents this metrics have multiple values with different labels.
+         */
+        LABELED_VALUE(true),
+        /**
+         * HISTOGRAM represents the values are grouped by the buckets, usually suitable for heatmap query.
+         */
+        HISTOGRAM(true),
+        /**
+         * SAMPLED_RECORD represents the values are detail data, being persistent by following some sampled rules.
+         * Usually do topn query based on value column value ASC or DESC.
+         */
+        SAMPLED_RECORD(true);
+
+        @Getter
+        private boolean isValue = false;
+
+        ValueDataType(final boolean isValue) {
+            this.isValue = isValue;
+        }
+    }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/Column.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/Column.java
@@ -66,6 +66,9 @@ public @interface Column {
     int length() default 200;
 
     /**
+     * Column with data type != {@link ValueDataType#NOT_VALUE} represents this is a value column. Indicate it would be
+     * queried by UI/CLI.
+     *
      * @return the data type of this value column. The value column is the query related value Set {@link
      * ValueDataType#NOT_VALUE} if this is not the value column, read {@link ValueDataType} for more details.
      * @since 8.0.0

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/ValueColumnMetadata.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/ValueColumnMetadata.java
@@ -20,6 +20,8 @@ package org.apache.skywalking.oap.server.core.storage.annotation;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.skywalking.oap.server.core.query.sql.Function;
 
@@ -35,8 +37,12 @@ public enum ValueColumnMetadata {
     /**
      * Register the new metadata for the given model name.
      */
-    public void putIfAbsent(String modelName, String valueCName, Function function, int defaultValue) {
-        mapping.putIfAbsent(modelName, new ValueColumn(valueCName, function, defaultValue));
+    public void putIfAbsent(String modelName,
+                            String valueCName,
+                            Column.ValueDataType dataType,
+                            Function function,
+                            int defaultValue) {
+        mapping.putIfAbsent(modelName, new ValueColumn(valueCName, dataType, function, defaultValue));
     }
 
     /**
@@ -57,6 +63,10 @@ public enum ValueColumnMetadata {
         return findColumn(metricsName).defaultValue;
     }
 
+    public Optional<ValueColumn> readValueColumnDefinition(String metricsName) {
+        return Optional.ofNullable(mapping.get(metricsName));
+    }
+
     private ValueColumn findColumn(String metricsName) {
         ValueColumn column = mapping.get(metricsName);
         if (column == null) {
@@ -65,9 +75,11 @@ public enum ValueColumnMetadata {
         return column;
     }
 
+    @Getter
     @RequiredArgsConstructor
-    class ValueColumn {
+    public class ValueColumn {
         private final String valueCName;
+        private final Column.ValueDataType dataType;
         private final Function function;
         private final int defaultValue;
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
@@ -76,13 +76,13 @@ public class StorageModels implements IModelManager, INewModel, IModelOverride {
                 modelColumns.add(
                     new ModelColumn(
                         new ColumnName(modelName, column.columnName()), field.getType(), column.matchQuery(), column
-                        .storageOnly(), column.isValue(), column.length()));
+                        .storageOnly(), column.dataType().isValue(), column.length()));
                 if (log.isDebugEnabled()) {
                     log.debug("The field named {} with the {} type", column.columnName(), field.getType());
                 }
-                if (column.isValue()) {
+                if (column.dataType().isValue()) {
                     ValueColumnMetadata.INSTANCE.putIfAbsent(
-                        modelName, column.columnName(), column.function(), column.defaultValue());
+                        modelName, column.columnName(), column.dataType(), column.function(), column.defaultValue());
                 }
 
                 List<QueryUnifiedIndex> indexDefinitions = new ArrayList<>();

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/ITopNRecordsQueryDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/ITopNRecordsQueryDAO.java
@@ -33,5 +33,7 @@ import org.apache.skywalking.oap.server.library.module.Service;
  * @since 8.0.0
  */
 public interface ITopNRecordsQueryDAO extends Service {
-    List<SelectedRecord> readSampledRecords(TopNCondition condition, Duration duration) throws IOException;
+    List<SelectedRecord> readSampledRecords(TopNCondition condition,
+                                            final String valueColumnName,
+                                            Duration duration) throws IOException;
 }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/CoreModuleTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/CoreModuleTest.java
@@ -26,6 +26,6 @@ public class CoreModuleTest {
     public void testOpenServiceList() {
         CoreModule coreModule = new CoreModule();
 
-        Assert.assertEquals(27, coreModule.services().length);
+        Assert.assertEquals(28, coreModule.services().length);
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TopNRecordsQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TopNRecordsQueryEsDAO.java
@@ -45,6 +45,7 @@ public class TopNRecordsQueryEsDAO extends EsDAO implements ITopNRecordsQueryDAO
 
     @Override
     public List<SelectedRecord> readSampledRecords(final TopNCondition condition,
+                                                   final String valueColumnName,
                                                    final Duration duration) throws IOException {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
@@ -59,7 +60,7 @@ public class TopNRecordsQueryEsDAO extends EsDAO implements ITopNRecordsQueryDAO
 
         sourceBuilder.query(boolQueryBuilder);
         sourceBuilder.size(condition.getTopN())
-                     .sort(TopN.LATENCY, condition.getOrder().equals(Order.DES) ? SortOrder.DESC : SortOrder.ASC);
+                     .sort(valueColumnName, condition.getOrder().equals(Order.DES) ? SortOrder.DESC : SortOrder.ASC);
         SearchResponse response = getClient().search(condition.getName(), sourceBuilder);
 
         List<SelectedRecord> results = new ArrayList<>(condition.getTopN());
@@ -68,7 +69,7 @@ public class TopNRecordsQueryEsDAO extends EsDAO implements ITopNRecordsQueryDAO
             SelectedRecord record = new SelectedRecord();
             record.setName((String) searchHit.getSourceAsMap().get(TopN.STATEMENT));
             record.setRefId((String) searchHit.getSourceAsMap().get(TopN.TRACE_ID));
-            record.setValue(((Number) searchHit.getSourceAsMap().get(TopN.LATENCY)).toString());
+            record.setValue(((Number) searchHit.getSourceAsMap().get(valueColumnName)).toString());
             results.add(record);
         }
 

--- a/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/TopNRecordsQuery.java
+++ b/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/TopNRecordsQuery.java
@@ -52,6 +52,7 @@ public class TopNRecordsQuery implements ITopNRecordsQueryDAO {
 
     @Override
     public List<SelectedRecord> readSampledRecords(final TopNCondition condition,
+                                                   final String valueColumnName,
                                                    final Duration duration) throws IOException {
         String function = InfluxConstants.SORT_ASC;
         // Have to re-sort here. Because the function, top()/bottom(), get the result ordered by the `time`.
@@ -62,7 +63,7 @@ public class TopNRecordsQuery implements ITopNRecordsQueryDAO {
         }
 
         WhereQueryImpl query = select()
-            .function(function, TopN.LATENCY, condition.getTopN())
+            .function(function, valueColumnName, condition.getTopN())
             .column(TopN.STATEMENT)
             .column(TopN.TRACE_ID)
             .from(client.getDatabase(), condition.getName())

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TopNRecordsQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TopNRecordsQueryDAO.java
@@ -43,6 +43,7 @@ public class H2TopNRecordsQueryDAO implements ITopNRecordsQueryDAO {
 
     @Override
     public List<SelectedRecord> readSampledRecords(final TopNCondition condition,
+                                                   final String valueColumnName,
                                                    final Duration duration) throws IOException {
         StringBuilder sql = new StringBuilder("select * from " + condition.getName() + " where ");
         List<Object> parameters = new ArrayList<>(10);
@@ -58,7 +59,7 @@ public class H2TopNRecordsQueryDAO implements ITopNRecordsQueryDAO {
         sql.append(" and ").append(TopN.TIME_BUCKET).append(" <= ?");
         parameters.add(duration.getEndTimeBucket());
 
-        sql.append(" order by ").append(TopN.LATENCY);
+        sql.append(" order by ").append(valueColumnName);
         if (condition.getOrder().equals(Order.DES)) {
             sql.append(" desc ");
         } else {
@@ -74,7 +75,7 @@ public class H2TopNRecordsQueryDAO implements ITopNRecordsQueryDAO {
                     SelectedRecord record = new SelectedRecord();
                     record.setName(resultSet.getString(TopN.STATEMENT));
                     record.setRefId(resultSet.getString(TopN.TRACE_ID));
-                    record.setValue(resultSet.getString(TopN.LATENCY));
+                    record.setValue(resultSet.getString(valueColumnName));
                     results.add(record);
                 }
             }

--- a/oap-server/server-tools/profile-exporter/tool-profile-snapshot-server-mock/src/main/java/org/apache/skywalking/oap/server/tool/profile/core/MockCoreModuleProvider.java
+++ b/oap-server/server-tools/profile-exporter/tool-profile-snapshot-server-mock/src/main/java/org/apache/skywalking/oap/server/tool/profile/core/MockCoreModuleProvider.java
@@ -36,6 +36,7 @@ import org.apache.skywalking.oap.server.core.query.AggregationQueryService;
 import org.apache.skywalking.oap.server.core.query.AlarmQueryService;
 import org.apache.skywalking.oap.server.core.query.LogQueryService;
 import org.apache.skywalking.oap.server.core.query.MetadataQueryService;
+import org.apache.skywalking.oap.server.core.query.MetricsMetadataQueryService;
 import org.apache.skywalking.oap.server.core.query.MetricsQueryService;
 import org.apache.skywalking.oap.server.core.query.ProfileTaskQueryService;
 import org.apache.skywalking.oap.server.core.query.TopNRecordsQueryService;
@@ -132,6 +133,7 @@ public class MockCoreModuleProvider extends CoreModuleProvider {
             NetworkAddressAliasCache.class, new NetworkAddressAliasCache(moduleConfig));
 
         this.registerServiceImplementation(TopologyQueryService.class, new TopologyQueryService(getManager()));
+        this.registerServiceImplementation(MetricsMetadataQueryService.class, new MetricsMetadataQueryService());
         this.registerServiceImplementation(MetricsQueryService.class, new MetricsQueryService(getManager()));
         this.registerServiceImplementation(TraceQueryService.class, new TraceQueryService(getManager()));
         this.registerServiceImplementation(LogQueryService.class, new LogQueryService(getManager()));


### PR DESCRIPTION
In the SkyWalking 8 and metrics v2 query protocol, we provide a way in GraphQL level to fetch the metrics type for the UI and CLI tool, it could know which are available ways to do metrics query.

```graphql
extend type Query {
    # Metrics definition metadata query. Response the metrics type which determines the suitable query methods.
    typeOfMetrics(name: String!): MetricsType!
}

# Metrics type is a new concept since v8.
enum MetricsType {
    # Can't find the metrics type definition.
    UNKNOWN
    # Regular value type is suitable for readMetricsValue, readMetricsValues and sortMetrics
    REGULAR_VALUE
    # Metrics value includes multiple labels, is suitable for readLabeledMetricsValues
    # Label should be assigned before the query happens, such as at the setting stage
    LABELED_VALUE
    # Heatmap value suitable for readHeatMap
    HEATMAP
    # Top metrics is for readSampledRecords only.
    SAMPLED_RECORD
}
```

## Query Examples
```graphql
# request
{
  typeOfMetrics(name: "service_percentile")
}

# response
{
  "data": {
    "typeOfMetrics": "LABELED_VALUE"
  }
}
```

```graphql
# request
{
  typeOfMetrics(name: "service_apdex")
}
# response
{
  "data": {
    "typeOfMetrics": "REGULAR_VALUE"
  }
}
```

```graphql
# request
{
  typeOfMetrics(name: "all_heatmap")
}

# response
{
  "data": {
    "typeOfMetrics": "HEATMAP"
  }
}
```

```graphql
# request
{
  typeOfMetrics(name: "segment")
}

# response
{
  "data": {
    "typeOfMetrics": "UNKNOWN"
  }
}
```