### PR TITLE
make Ignored trace more easy to use.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/IgnoredTracerContext.java
@@ -65,7 +65,7 @@ public class IgnoredTracerContext implements AbstractTracerContext {
 
     @Override
     public String getReadablePrimaryTraceId() {
-        return "[Ignored Trace]";
+        return "Ignored_Trace";
     }
 
     @Override


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance
___
### New feature or improvement
- Describe the details and related test reports.

According to the scenario we use. we use `apm-toolkit-trace` plugin to integrate `TID` into log system. 
And we used `filebeat` to collect our app's log from log file.

```bash
2020-04-22 16:01:54.749 [TID:218.72.15875425146380005] [http-nio-18081-exec-3] DEBUG o.s.web.servlet.DispatcherServlet -Completed 200 OK
2020-04-22 16:01:55.353 [TID:N/A] [pool-6-thread-1] INFO  i.d.discovery.DaocloudAgentClient -start to fetch instance list
2020-04-22 16:01:55.353 [TID:[Ignored Trace]] [pool-6-thread-1] DEBUG o.s.web.client.RestTemplate -HTTP POST http://10.15.200.17:***
2020-04-22 16:01:55.353 [TID:[Ignored Trace]] [pool-6-thread-1] DEBUG o.s.web.client.RestTemplate -Accept=[application/json, application/*+json]
2020-04-22 16:01:55.353 [TID:[Ignored Trace]] [pool-6-thread-1] DEBUG o.s.web.client.RestTemplate -Writing [{env_id=e79490e0-ce4b-49a6-809a-822d10536689}] with org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
```

But when we use regular expression to match `TID` value, it looks as follow:
![image](https://user-images.githubusercontent.com/12468337/79956981-7ed32280-84b3-11ea-9c4a-995cd3ea1042.png)

So, remove `[]` warp would be more friendly to users.
