### PR TITLE
Fix npe in afterMethod/handleMethodException of kafka/finagle plugins

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstanceMethodsAroundInterceptor.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstanceMethodsAroundInterceptor.java
@@ -36,7 +36,7 @@ public interface InstanceMethodsAroundInterceptor {
     /**
      * called after target method invocation. Even method's invocation triggers an exception.
      *
-     * @param ret the method's original return value.
+     * @param ret the method's original return value. May be null if the method triggers an exception.
      * @return the method's actual return value.
      */
     Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientDestTracingFilterInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientDestTracingFilterInterceptor.java
@@ -58,7 +58,9 @@ public class ClientDestTracingFilterInterceptor extends AbstractInterceptor {
     @Override
     public void handleMethodExceptionImpl(EnhancedInstance enhancedInstance, Method method, Object[] objects,
                                           Class<?>[] classes, Throwable t) {
-        ContextManager.activeSpan().errorOccurred().log(t);
+        if (ContextManager.isActive()) {
+            ContextManager.activeSpan().errorOccurred().log(t);
+        }
     }
 
     private String getRemote(Object[] objects) {

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientDestTracingFilterInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientDestTracingFilterInterceptor.java
@@ -58,6 +58,10 @@ public class ClientDestTracingFilterInterceptor extends AbstractInterceptor {
     @Override
     public void handleMethodExceptionImpl(EnhancedInstance enhancedInstance, Method method, Object[] objects,
                                           Class<?>[] classes, Throwable t) {
+        /*
+         * Current thread may not be the same thread that execute ClientTracingFilterInterceptor, we can not ensure
+         * there is an active span
+         */
         if (ContextManager.isActive()) {
             ContextManager.activeSpan().errorOccurred().log(t);
         }

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientTracingFilterInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientTracingFilterInterceptor.java
@@ -91,8 +91,6 @@ public class ClientTracingFilterInterceptor extends AbstractInterceptor {
 
     @Override
     public void handleMethodExceptionImpl(EnhancedInstance enhancedInstance, Method method, Object[] objects, Class<?>[] classes, Throwable throwable) {
-        if (ContextManager.isActive()) {
-            ContextManager.activeSpan().errorOccurred().log(throwable);
-        }
+        ContextManager.activeSpan().errorOccurred().log(throwable);
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientTracingFilterInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientTracingFilterInterceptor.java
@@ -66,6 +66,9 @@ public class ClientTracingFilterInterceptor extends AbstractInterceptor {
         getLocalContextHolder().remove(SW_SPAN);
         getMarshalledContextHolder().remove(SWContextCarrier$.MODULE$);
 
+        /*
+         * If the intercepted method throws exception, the ret will be null
+         */
         if (ret == null) {
             ContextManager.stopSpan(finagleSpan);
         } else {

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientTracingFilterInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ClientTracingFilterInterceptor.java
@@ -66,27 +66,33 @@ public class ClientTracingFilterInterceptor extends AbstractInterceptor {
         getLocalContextHolder().remove(SW_SPAN);
         getMarshalledContextHolder().remove(SWContextCarrier$.MODULE$);
 
-        finagleSpan.prepareForAsync();
-        ContextManager.stopSpan(finagleSpan);
+        if (ret == null) {
+            ContextManager.stopSpan(finagleSpan);
+        } else {
+            finagleSpan.prepareForAsync();
+            ContextManager.stopSpan(finagleSpan);
 
-        ((Future<?>) ret).addEventListener(new FutureEventListener<Object>() {
-            @Override
-            public void onSuccess(Object value) {
-                finagleSpan.asyncFinish();
-            }
+            ((Future<?>) ret).addEventListener(new FutureEventListener<Object>() {
+                @Override
+                public void onSuccess(Object value) {
+                    finagleSpan.asyncFinish();
+                }
 
-            @Override
-            public void onFailure(Throwable cause) {
-                finagleSpan.errorOccurred();
-                finagleSpan.log(cause);
-                finagleSpan.asyncFinish();
-            }
-        });
+                @Override
+                public void onFailure(Throwable cause) {
+                    finagleSpan.errorOccurred();
+                    finagleSpan.log(cause);
+                    finagleSpan.asyncFinish();
+                }
+            });
+        }
         return ret;
     }
 
     @Override
     public void handleMethodExceptionImpl(EnhancedInstance enhancedInstance, Method method, Object[] objects, Class<?>[] classes, Throwable throwable) {
-        ContextManager.activeSpan().errorOccurred().log(throwable);
+        if (ContextManager.isActive()) {
+            ContextManager.activeSpan().errorOccurred().log(throwable);
+        }
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ServerTracingFilterInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ServerTracingFilterInterceptor.java
@@ -61,6 +61,10 @@ public class ServerTracingFilterInterceptor extends AbstractInterceptor {
     public Object afterMethodImpl(EnhancedInstance enhancedInstance, Method method, Object[] objects, Class<?>[] classes, Object ret) throws Throwable {
         final AbstractSpan finagleSpan = getSpan();
         getLocalContextHolder().remove(FinagleCtxs.SW_SPAN);
+
+        /*
+         * If the intercepted method throws exception, the ret will be null
+         */
         if (ret == null) {
             ContextManager.stopSpan(finagleSpan);
         } else {

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ServerTracingFilterInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/finagle/ServerTracingFilterInterceptor.java
@@ -86,8 +86,6 @@ public class ServerTracingFilterInterceptor extends AbstractInterceptor {
     @Override
     public void handleMethodExceptionImpl(EnhancedInstance enhancedInstance, Method method, Object[] objects,
                                           Class<?>[] classes, Throwable t) {
-        if (ContextManager.isActive()) {
-            ContextManager.activeSpan().errorOccurred().log(t);
-        }
+        ContextManager.activeSpan().errorOccurred().log(t);
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/KafkaConsumerInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/KafkaConsumerInterceptor.java
@@ -51,6 +51,9 @@ public class KafkaConsumerInterceptor implements InstanceMethodsAroundIntercepto
     @Override
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         Object ret) throws Throwable {
+        /*
+         * If the intercepted method throws exception, the ret will be null
+         */
         if (ret == null) {
             return ret;
         }
@@ -91,6 +94,10 @@ public class KafkaConsumerInterceptor implements InstanceMethodsAroundIntercepto
     @Override
     public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
         Class<?>[] argumentsTypes, Throwable t) {
+        /*
+         * The entry span is created in {@link #afterMethod}, but {@link #handleMethodException} is called before
+         * {@link #afterMethod}, before the creation of entry span, we can not ensure there is an active span
+         */
         if (ContextManager.isActive()) {
             ContextManager.activeSpan().errorOccurred().log(t);
         }

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/KafkaConsumerInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/KafkaConsumerInterceptor.java
@@ -51,6 +51,9 @@ public class KafkaConsumerInterceptor implements InstanceMethodsAroundIntercepto
     @Override
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         Object ret) throws Throwable {
+        if (ret == null) {
+            return ret;
+        }
         Map<TopicPartition, List<ConsumerRecord<?, ?>>> records = (Map<TopicPartition, List<ConsumerRecord<?, ?>>>) ret;
         //
         // The entry span will only be created when the consumer received at least one message.
@@ -88,6 +91,8 @@ public class KafkaConsumerInterceptor implements InstanceMethodsAroundIntercepto
     @Override
     public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
         Class<?>[] argumentsTypes, Throwable t) {
-        ContextManager.activeSpan().errorOccurred().log(t);
+        if (ContextManager.isActive()) {
+            ContextManager.activeSpan().errorOccurred().log(t);
+        }
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
```text
ERROR 2020-04-24 15:35:36:776 canalMessageListenerContainer-C-1 InstMethodsInter : class[class org.apache.kafka.clients.consumer.KafkaConsumer] handle method[pollOnce] exception failure
java.lang.NullPointerException
        at org.apache.skywalking.apm.agent.core.context.ContextManager.activeSpan(ContextManager.java:171)
        at org.apache.skywalking.apm.plugin.kafka.KafkaConsumerInterceptor.handleMethodException(KafkaConsumerInterceptor.java:91)
        at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:90)
        at org.apache.kafka.clients.consumer.KafkaConsumer.pollOnce(KafkaConsumer.java)
        at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1043)
        at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.run(KafkaMessageListenerContainer.java:568)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.lang.Thread.run(Thread.java:748)

ERROR 2020-04-24 15:35:36:778 canalMessageListenerContainer-C-1 InstMethodsInter : class[class org.apache.kafka.clients.consumer.KafkaConsumer] after method[pollOnce] intercept failure
java.lang.NullPointerException
        at org.apache.skywalking.apm.plugin.kafka.KafkaConsumerInterceptor.afterMethod(KafkaConsumerInterceptor.java:58)
        at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:97)
        at org.apache.kafka.clients.consumer.KafkaConsumer.pollOnce(KafkaConsumer.java)
        at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1043)
        at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.run(KafkaMessageListenerContainer.java:568)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.lang.Thread.run(Thread.java:748)
```
- How to fix?
1. invoke `ContextManager.isActive()` before  `ContextManager.activeSpan()`
2. test if ret is null in afterMethod implementation
___
### New feature or improvement
- Describe the details and related test reports.
