### PR TITLE
Optimize L1 and L2 aggregation.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/ReadWriteSafeCache.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/ReadWriteSafeCache.java
@@ -50,10 +50,29 @@ public class ReadWriteSafeCache<T> {
         lock = new ReentrantLock();
     }
 
+    /**
+     * Write the into the {@link #writeBufferPointer} buffer.
+     *
+     * @param data to enqueue.
+     */
     public void write(T data) {
         lock.lock();
         try {
             writeBufferPointer.accept(data);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Write the collection of data into the {@link #writeBufferPointer} buffer.
+     *
+     * @param data to enqueue.
+     */
+    public void write(List<T> data) {
+        lock.lock();
+        try {
+            data.forEach(writeBufferPointer::accept);
         } finally {
             lock.unlock();
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
@@ -83,7 +83,7 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> {
         }
 
         this.dataCarrier = new DataCarrier<>("MetricsPersistentWorker." + model.getName(), name, 1, 2000);
-        this.dataCarrier.consume(ConsumerPoolFactory.INSTANCE.get(name), new PersistentConsumer(this));
+        this.dataCarrier.consume(ConsumerPoolFactory.INSTANCE.get(name), new PersistentConsumer());
     }
 
     /**
@@ -95,11 +95,6 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> {
              null, null, null,
              enableDatabaseSession, supportUpdate
         );
-    }
-
-    @Override
-    void onWork(Metrics metrics) {
-        cacheData(metrics);
     }
 
     /**
@@ -235,13 +230,6 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> {
      * ID is declared through {@link Object#hashCode()} and {@link Object#equals(Object)} as usual.
      */
     private class PersistentConsumer implements IConsumer<Metrics> {
-
-        private final MetricsPersistentWorker persistent;
-
-        private PersistentConsumer(MetricsPersistentWorker persistent) {
-            this.persistent = persistent;
-        }
-
         @Override
         public void init() {
 
@@ -249,7 +237,7 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> {
 
         @Override
         public void consume(List<Metrics> data) {
-            data.forEach(persistent::onWork);
+            MetricsPersistentWorker.this.onWork(data);
         }
 
         @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/PersistenceWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/PersistenceWorker.java
@@ -48,14 +48,7 @@ public abstract class PersistenceWorker<INPUT extends StorageData> extends Abstr
     /**
      * Accept the input, and push the data into the cache.
      */
-    void onWork(INPUT input) {
-        cacheData(input);
-    }
-
-    /**
-     * Cache data based on different strategies. See the implementations for more details.
-     */
-    public void cacheData(INPUT input) {
+    void onWork(List<INPUT> input) {
         cache.write(input);
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/data/StreamData.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/data/StreamData.java
@@ -22,19 +22,5 @@ import org.apache.skywalking.oap.server.core.remote.Deserializable;
 import org.apache.skywalking.oap.server.core.remote.Serializable;
 
 public abstract class StreamData implements Serializable, Deserializable {
-    private boolean endOfBatch = false;
-
-    public void resetEndOfBatch() {
-        this.endOfBatch = false;
-    }
-
-    public void asEndOfBatch() {
-        this.endOfBatch = true;
-    }
-
-    public boolean isEndOfBatch() {
-        return this.endOfBatch;
-    }
-
     public abstract int remoteHashCode();
 }


### PR DESCRIPTION
- L1 Aggregation. Use **MergableBufferedData** to replace **ReadWriteSafeCache**. This could avoid the lock for every time aggregation of L1.
- L2 Aggregation. Support **batch mode** in the **MergableBufferedData**, also reduce the lock and lock race for the aggregation of L2.
- Remove the ** endOfBatch** from the ** StreamData**. With the batch mode supported in the workers, we don't need that. We take advantage of DataCarrier batch consuming feature.