### PR TITLE
fix to get 'peer' in SingleServerConfig

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/ConnectionManagerInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/ConnectionManagerInterceptor.java
@@ -58,8 +58,8 @@ public class ConnectionManagerInterceptor implements InstanceMethodsAroundInterc
             EnhancedInstance retInst = (EnhancedInstance) ret;
 
             if (singleServerConfig != null) {
-                Object SingleAddress = ClassUtil.getObjectField(singleServerConfig, "address");
-                peer.append(getPeer(SingleAddress));
+                Object singleAddress = ClassUtil.getObjectField(singleServerConfig, "address");
+                peer.append(getPeer(singleAddress));
                 retInst.setSkyWalkingDynamicField(PeerFormat.shorten(peer.toString()));
                 return ret;
             }

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/ConnectionManagerInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/ConnectionManagerInterceptor.java
@@ -18,9 +18,6 @@
 
 package org.apache.skywalking.apm.plugin.redisson.v3;
 
-import java.lang.reflect.Method;
-import java.net.URI;
-import java.util.Collection;
 import org.apache.skywalking.apm.agent.core.context.util.PeerFormat;
 import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
@@ -31,22 +28,27 @@ import org.apache.skywalking.apm.plugin.redisson.v3.util.ClassUtil;
 import org.redisson.config.Config;
 import org.redisson.connection.ConnectionManager;
 
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Collection;
+
 public class ConnectionManagerInterceptor implements InstanceMethodsAroundInterceptor {
 
     private static final ILog logger = LogManager.getLogger(ConnectionManagerInterceptor.class);
 
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
-        MethodInterceptResult result) throws Throwable {
+                             MethodInterceptResult result) throws Throwable {
     }
 
     @Override
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
-        Object ret) throws Throwable {
+                              Object ret) throws Throwable {
         try {
             ConnectionManager connectionManager = (ConnectionManager) objInst;
             Config config = connectionManager.getCfg();
 
+            Object singleServerConfig = ClassUtil.getObjectField(config, "singleServerConfig");
             Object sentinelServersConfig = ClassUtil.getObjectField(config, "sentinelServersConfig");
             Object masterSlaveServersConfig = ClassUtil.getObjectField(config, "masterSlaveServersConfig");
             Object clusterServersConfig = ClassUtil.getObjectField(config, "clusterServersConfig");
@@ -55,6 +57,12 @@ public class ConnectionManagerInterceptor implements InstanceMethodsAroundInterc
             StringBuilder peer = new StringBuilder();
             EnhancedInstance retInst = (EnhancedInstance) ret;
 
+            if (singleServerConfig != null) {
+                Object SingleAddress = ClassUtil.getObjectField(singleServerConfig, "address");
+                peer.append(getPeer(SingleAddress));
+                retInst.setSkyWalkingDynamicField(PeerFormat.shorten(peer.toString()));
+                return ret;
+            }
             if (sentinelServersConfig != null) {
                 appendAddresses(peer, (Collection) ClassUtil.getObjectField(sentinelServersConfig, "sentinelAddresses"));
                 retInst.setSkyWalkingDynamicField(PeerFormat.shorten(peer.toString()));
@@ -98,7 +106,7 @@ public class ConnectionManagerInterceptor implements InstanceMethodsAroundInterc
      * @param obj Address object
      * @return the sw peer
      */
-    private String getPeer(Object obj) {
+    static String getPeer(Object obj) {
         if (obj instanceof String) {
             return ((String) obj).replace("redis://", "");
         } else if (obj instanceof URI) {
@@ -112,6 +120,6 @@ public class ConnectionManagerInterceptor implements InstanceMethodsAroundInterc
 
     @Override
     public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
-        Class<?>[] argumentsTypes, Throwable t) {
+                                      Class<?>[] argumentsTypes, Throwable t) {
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptorTest.java
@@ -23,6 +23,7 @@ import org.apache.skywalking.apm.agent.test.tools.AgentServiceRule;
 import org.apache.skywalking.apm.agent.test.tools.SegmentStorage;
 import org.apache.skywalking.apm.agent.test.tools.SegmentStoragePoint;
 import org.apache.skywalking.apm.agent.test.tools.TracingSegmentRunner;
+import org.apache.skywalking.apm.plugin.redisson.v3.util.ClassUtil;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
 import org.junit.Before;
@@ -32,6 +33,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+import org.redisson.config.Config;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(TracingSegmentRunner.class)
@@ -65,8 +67,8 @@ public class RedisConnectionMethodInterceptorTest {
     }
 
     @SuppressWarnings({
-        "rawtypes",
-        "unchecked"
+            "rawtypes",
+            "unchecked"
     })
     @Before
     public void setUp() throws Exception {
@@ -78,7 +80,18 @@ public class RedisConnectionMethodInterceptorTest {
 
     @Test
     public void testIntercept() throws Throwable {
-        interceptor.onConstruct(mockRedisConnectionInstance, new Object[] {mockRedisClientInstance});
+        interceptor.onConstruct(mockRedisConnectionInstance, new Object[]{mockRedisClientInstance});
         MatcherAssert.assertThat((String) mockRedisConnectionInstance.getSkyWalkingDynamicField(), Is.is("127.0.0.1:6379;127.0.0.1:6378;"));
+    }
+
+
+    @Test
+    public void testSingleServerMode() throws Throwable {
+        String redisAddress = "redis://127.0.0.1:6379";
+        Config config = new Config();
+        config.useSingleServer().setAddress(redisAddress);
+        Object singleServerConfig = ClassUtil.getObjectField(config, "singleServerConfig");
+        Object address = ClassUtil.getObjectField(singleServerConfig, "address");
+        MatcherAssert.assertThat("127.0.0.1:6379", Is.is(ConnectionManagerInterceptor.getPeer(address)));
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptorTest.java
@@ -84,7 +84,6 @@ public class RedisConnectionMethodInterceptorTest {
         MatcherAssert.assertThat((String) mockRedisConnectionInstance.getSkyWalkingDynamicField(), Is.is("127.0.0.1:6379;127.0.0.1:6378;"));
     }
 
-
     @Test
     public void testSingleServerMode() throws Throwable {
         String redisAddress = "redis://127.0.0.1:6379";


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
fix to get 'peer' in SingleServerConfig, this method to throw exception in 'org.apache.skywalking.apm.agent.core.context.TracingContext#createExitSpan' because 'peer' is null. in sw 6 version, this also one of  problem to throw  'NoSuchElementException'  in 'org.apache.skywalking.apm.agent.core.context.ContextManager#capture'

- How to fix?
use singleServerConfig to get peer.
___
### New feature or improvement
- Describe the details and related test reports.
