### PR TITLE
Fix the cache unclear bug.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedData.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedData.java
@@ -74,8 +74,12 @@ public class LimitedSizeBufferedData<STORAGE_DATA extends ComparableStorageData 
 
     @Override
     public List<STORAGE_DATA> read() {
-        List<STORAGE_DATA> collection = new ArrayList<>();
-        data.values().forEach(e -> e.forEach(collection::add));
-        return collection;
+        try {
+            List<STORAGE_DATA> collection = new ArrayList<>();
+            data.values().forEach(e -> e.forEach(collection::add));
+            return collection;
+        } finally {
+            data.clear();
+        }
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedData.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedData.java
@@ -76,7 +76,7 @@ public class LimitedSizeBufferedData<STORAGE_DATA extends ComparableStorageData 
     public List<STORAGE_DATA> read() {
         try {
             List<STORAGE_DATA> collection = new ArrayList<>();
-            data.values().forEach(e -> e.forEach(collection::add));
+            data.values().forEach(collection::addAll);
             return collection;
         } finally {
             data.clear();

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/MergableBufferedData.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/MergableBufferedData.java
@@ -57,6 +57,10 @@ public class MergableBufferedData<METRICS extends Metrics> implements BufferedDa
 
     @Override
     public List<METRICS> read() {
-        return buffer.values().stream().collect(Collectors.toList());
+        try {
+            return buffer.values().stream().collect(Collectors.toList());
+        } finally {
+            buffer.clear();
+        }
     }
 }


### PR DESCRIPTION
The cache should be read-once. I forgot to support this in the new implementation, the aggregation will be inaccurate and keep growing. This would burn the CPU and storage.

This is a very serious bug.