### PR TITLE
Fix two serious bugs in new persistent

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
@@ -169,6 +169,7 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> {
                     nextExportWorker.ifPresent(exportEvenWorker -> exportEvenWorker.in(
                         new ExportEvent(metrics, ExportEvent.EventType.INCREMENT)));
                 } else {
+                    metrics.calculate();
                     prepareRequests.add(metricsDAO.prepareBatchInsert(model, metrics));
                     nextWorker(metrics);
                 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TopNRecordsQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TopNRecordsQueryEsDAO.java
@@ -50,8 +50,8 @@ public class TopNRecordsQueryEsDAO extends EsDAO implements ITopNRecordsQueryDAO
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
         boolQueryBuilder.must().add(QueryBuilders.rangeQuery(TopN.TIME_BUCKET)
-                                                 .gte(duration.getStartTimeBucket())
-                                                 .lte(duration.getEndTimeBucket()));
+                                                 .gte(duration.getStartTimeBucketInSec())
+                                                 .lte(duration.getEndTimeBucketInSec()));
 
         if (StringUtil.isNotEmpty(condition.getParentService())) {
             final String serviceId = IDManager.ServiceID.buildId(condition.getParentService(), condition.isNormal());

--- a/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/TopNRecordsQuery.java
+++ b/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/TopNRecordsQuery.java
@@ -68,8 +68,8 @@ public class TopNRecordsQuery implements ITopNRecordsQueryDAO {
             .column(TopN.TRACE_ID)
             .from(client.getDatabase(), condition.getName())
             .where()
-            .and(gte(TopN.TIME_BUCKET, duration.getStartTimeBucket()))
-            .and(lte(TopN.TIME_BUCKET, duration.getEndTimeBucket()));
+            .and(gte(TopN.TIME_BUCKET, duration.getStartTimeBucketInSec()))
+            .and(lte(TopN.TIME_BUCKET, duration.getEndTimeBucketInSec()));
 
         if (StringUtil.isNotEmpty(condition.getParentService())) {
             final String serviceId = IDManager.ServiceID.buildId(condition.getParentService(), condition.isNormal());

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TopNRecordsQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TopNRecordsQueryDAO.java
@@ -55,9 +55,9 @@ public class H2TopNRecordsQueryDAO implements ITopNRecordsQueryDAO {
         }
 
         sql.append(" and ").append(TopN.TIME_BUCKET).append(" >= ?");
-        parameters.add(duration.getStartTimeBucket());
+        parameters.add(duration.getStartTimeBucketInSec());
         sql.append(" and ").append(TopN.TIME_BUCKET).append(" <= ?");
-        parameters.add(duration.getEndTimeBucket());
+        parameters.add(duration.getEndTimeBucketInSec());
 
         sql.append(" order by ").append(valueColumnName);
         if (condition.getOrder().equals(Order.DES)) {


### PR DESCRIPTION
I found these two issues based on @efekaptan 's https://github.com/apache/skywalking/pull/4740#issuecomment-623763022 reports.

1. TopN Query is not working since the 8.0 storage re-implementation. FYI @kezhenxu94, another thing we don't cover in the e2e.
1. Metrics are not calculated for the first time, we only can get the values in update process. Easy fix but hard to find :P