### PR TITLE
Polish metrics logic, fix service traffic bug

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceTraffic.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceTraffic.java
@@ -72,6 +72,8 @@ public class ServiceTraffic extends Metrics {
     public void deserialize(final RemoteData remoteData) {
         setName(remoteData.getDataStrings(0));
         setNodeType(NodeType.valueOf(remoteData.getDataIntegers(0)));
+        // Time bucket is not a part of persistent, but still is required in the first time insert.
+        setTimeBucket(remoteData.getDataLongs(0));
     }
 
     @Override
@@ -79,6 +81,8 @@ public class ServiceTraffic extends Metrics {
         final RemoteData.Builder builder = RemoteData.newBuilder();
         builder.addDataStrings(name);
         builder.addDataIntegers(nodeType.value());
+        // Time bucket is not a part of persistent, but still is required in the first time insert.
+        builder.addDataLongs(getTimeBucket());
         return builder;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceTraffic.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceTraffic.java
@@ -38,7 +38,10 @@ import org.apache.skywalking.oap.server.core.storage.annotation.Column;
 @Stream(name = ServiceTraffic.INDEX_NAME, scopeId = DefaultScopeDefine.SERVICE,
     builder = ServiceTraffic.Builder.class, processor = MetricsStreamProcessor.class)
 @MetricsExtension(supportDownSampling = false, supportUpdate = false)
-@EqualsAndHashCode
+@EqualsAndHashCode(of = {
+    "name",
+    "nodeType"
+})
 public class ServiceTraffic extends Metrics {
     public static final String INDEX_NAME = "service_traffic";
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/AggregationQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/AggregationQueryService.java
@@ -70,17 +70,31 @@ public class AggregationQueryService implements Service {
                 case ServiceInstance:
                     final IDManager.ServiceInstanceID.InstanceIDDefinition instanceIDDefinition
                         = IDManager.ServiceInstanceID.analysisId(selectedRecord.getId());
-                    IDManager.ServiceID.ServiceIDDefinition serviceIDDefinition =
-                        IDManager.ServiceID.analysisId(instanceIDDefinition.getServiceId());
-                    selectedRecord.setName(serviceIDDefinition.getName() + " - " + instanceIDDefinition.getName());
+                    /**
+                     * Add the service name into the name if this is global top N.
+                     */
+                    if (StringUtil.isEmpty(condition.getParentService())) {
+                        IDManager.ServiceID.ServiceIDDefinition serviceIDDefinition =
+                            IDManager.ServiceID.analysisId(instanceIDDefinition.getServiceId());
+                        selectedRecord.setName(serviceIDDefinition.getName() + " - " + instanceIDDefinition.getName());
+                    } else {
+                        selectedRecord.setName(instanceIDDefinition.getName());
+                    }
                     break;
                 case Endpoint:
                     final IDManager.EndpointID.EndpointIDDefinition endpointIDDefinition
                         = IDManager.EndpointID.analysisId(selectedRecord.getId());
-                    serviceIDDefinition =
-                        IDManager.ServiceID.analysisId(endpointIDDefinition.getServiceId());
-                    selectedRecord.setName(serviceIDDefinition.getName()
-                                               + " - " + endpointIDDefinition.getEndpointName());
+                    /**
+                     * Add the service name into the name if this is global top N.
+                     */
+                    if (StringUtil.isEmpty(condition.getParentService())) {
+                        IDManager.ServiceID.ServiceIDDefinition serviceIDDefinition =
+                            IDManager.ServiceID.analysisId(endpointIDDefinition.getServiceId());
+                        selectedRecord.setName(serviceIDDefinition.getName()
+                                                   + " - " + endpointIDDefinition.getEndpointName());
+                    } else {
+                        selectedRecord.setName(endpointIDDefinition.getEndpointName());
+                    }
                     break;
                 default:
                     selectedRecord.setName(Const.UNKNOWN);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/AggregationQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/AggregationQueryService.java
@@ -68,10 +68,19 @@ public class AggregationQueryService implements Service {
                     selectedRecord.setName(IDManager.ServiceID.analysisId(selectedRecord.getId()).getName());
                     break;
                 case ServiceInstance:
-                    selectedRecord.setName(IDManager.ServiceInstanceID.analysisId(selectedRecord.getId()).getName());
+                    final IDManager.ServiceInstanceID.InstanceIDDefinition instanceIDDefinition
+                        = IDManager.ServiceInstanceID.analysisId(selectedRecord.getId());
+                    IDManager.ServiceID.ServiceIDDefinition serviceIDDefinition =
+                        IDManager.ServiceID.analysisId(instanceIDDefinition.getServiceId());
+                    selectedRecord.setName(serviceIDDefinition.getName() + " - " + instanceIDDefinition.getName());
                     break;
                 case Endpoint:
-                    selectedRecord.setName(IDManager.EndpointID.analysisId(selectedRecord.getId()).getEndpointName());
+                    final IDManager.EndpointID.EndpointIDDefinition endpointIDDefinition
+                        = IDManager.EndpointID.analysisId(selectedRecord.getId());
+                    serviceIDDefinition =
+                        IDManager.ServiceID.analysisId(endpointIDDefinition.getServiceId());
+                    selectedRecord.setName(serviceIDDefinition.getName()
+                                               + " - " + endpointIDDefinition.getEndpointName());
                     break;
                 default:
                     selectedRecord.setName(Const.UNKNOWN);

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
@@ -276,7 +276,7 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
         });
 
         exitSourceBuilders.forEach(exitSourceBuilder -> {
-            sourceReceiver.receive(exitSourceBuilder.toService());		
+            sourceReceiver.receive(exitSourceBuilder.toService());	
             sourceReceiver.receive(exitSourceBuilder.toServiceRelation());
 
             /*

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
@@ -276,7 +276,6 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
         });
 
         exitSourceBuilders.forEach(exitSourceBuilder -> {
-            sourceReceiver.receive(exitSourceBuilder.toService());
             sourceReceiver.receive(exitSourceBuilder.toServiceRelation());
 
             /*

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
@@ -276,7 +276,7 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
         });
 
         exitSourceBuilders.forEach(exitSourceBuilder -> {
-            sourceReceiver.receive(exitSourceBuilder.toService());	
+            sourceReceiver.receive(exitSourceBuilder.toService());
             sourceReceiver.receive(exitSourceBuilder.toServiceRelation());
 
             /*

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
@@ -276,6 +276,9 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
         });
 
         exitSourceBuilders.forEach(exitSourceBuilder -> {
+            sourceReceiver.receive(exitSourceBuilder.toService());		
+            sourceReceiver.receive(exitSourceBuilder.toServiceRelation());
+
             /*
              * Some of the agent can not have the upstream real network address, such as https://github.com/apache/skywalking-nginx-lua.
              */

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
@@ -276,9 +276,6 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
         });
 
         exitSourceBuilders.forEach(exitSourceBuilder -> {
-            sourceReceiver.receive(exitSourceBuilder.toService());
-            sourceReceiver.receive(exitSourceBuilder.toServiceRelation());
-
             /*
              * Some of the agent can not have the upstream real network address, such as https://github.com/apache/skywalking-nginx-lua.
              */


### PR DESCRIPTION
I am reviewing our demo env carefully, fixed the following.
1. Service Traffic should serialize and deserialize the time bucket, otherwise, there is a chance `service_traffic-0` generated.
1. Service Traffic should serialize and deserialize the time bucket, otherwise, there is a chance `service_traffic-0` generated.
1. Make top N results more clear about the owner. Previously, the same endpoint names of different services look the same.
1. Sync UI.
1. Fix service traffic equal and hashcode method. The time bucket is not a part of the entity attribute.