### PR TITLE
Make sure the DB service could be generated.

### DIFF
--- a/docs/en/concepts-and-designs/oal.md
+++ b/docs/en/concepts-and-designs/oal.md
@@ -58,8 +58,8 @@ In this case, all input are requests of each endpoint, condition is `endpoint.st
 
 In this case, calls of each service. 
 
-- `thermodynamic`. Read [Heatmap in WIKI](https://en.wikipedia.org/wiki/Heat_map)
-> All_heatmap = from(All.latency).thermodynamic(100, 20);
+- `histogram`. Read [Heatmap in WIKI](https://en.wikipedia.org/wiki/Heat_map)
+> All_heatmap = from(All.latency).histogram(100, 20);
 
 In this case, thermodynamic heatmap of all incoming requests. 
 The parameter (1) is the precision of latency calculation, such as in above case, 113ms and 193ms are considered same in the 101-200ms group.

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceMetaDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceMetaDispatcher.java
@@ -16,30 +16,19 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.source;
+package org.apache.skywalking.oap.server.core.analysis.manual.service;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.skywalking.oap.server.core.analysis.IDManager;
-import org.apache.skywalking.oap.server.core.analysis.NodeType;
+import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
+import org.apache.skywalking.oap.server.core.analysis.worker.MetricsStreamProcessor;
+import org.apache.skywalking.oap.server.core.source.ServiceMeta;
 
-import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_UPDATE;
-
-@Getter
-@Setter
-@ScopeDeclaration(id = SERVICE_UPDATE, name = "ServiceUpdate")
-@ScopeDefaultColumn.VirtualColumnDefinition(fieldName = "entityId", columnName = "entity_id", isID = true, type = String.class)
-public class ServiceUpdate extends Source {
+public class ServiceMetaDispatcher implements SourceDispatcher<ServiceMeta> {
     @Override
-    public int scope() {
-        return DefaultScopeDefine.SERVICE_UPDATE;
+    public void dispatch(final ServiceMeta source) {
+        ServiceTraffic traffic = new ServiceTraffic();
+        traffic.setTimeBucket(source.getTimeBucket());
+        traffic.setName(source.getName());
+        traffic.setNodeType(source.getNodeType());
+        MetricsStreamProcessor.getInstance().in(traffic);
     }
-
-    @Override
-    public String getEntityId() {
-        return IDManager.ServiceID.buildId(name, NodeType.Normal);
-    }
-
-    private String name;
-    private NodeType nodeType;
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DefaultScopeDefine.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DefaultScopeDefine.java
@@ -63,7 +63,7 @@ public class DefaultScopeDefine {
     public static final int PROFILE_TASK = 26;
     public static final int PROFILE_TASK_LOG = 27;
     public static final int PROFILE_TASK_SEGMENT_SNAPSHOT = 28;
-    public static final int SERVICE_UPDATE = 29;
+    public static final int SERVICE_META = 29;
     public static final int SERVICE_INSTANCE_UPDATE = 30;
     public static final int NETWORK_ADDRESS_ALIAS = 31;
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceMeta.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceMeta.java
@@ -16,19 +16,30 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.manual.service;
+package org.apache.skywalking.oap.server.core.source;
 
-import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
-import org.apache.skywalking.oap.server.core.analysis.worker.MetricsStreamProcessor;
-import org.apache.skywalking.oap.server.core.source.ServiceUpdate;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.skywalking.oap.server.core.analysis.IDManager;
+import org.apache.skywalking.oap.server.core.analysis.NodeType;
 
-public class ServiceUpdateDispatcher implements SourceDispatcher<ServiceUpdate> {
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_META;
+
+@Getter
+@Setter
+@ScopeDeclaration(id = SERVICE_META, name = "ServiceMeta")
+@ScopeDefaultColumn.VirtualColumnDefinition(fieldName = "entityId", columnName = "entity_id", isID = true, type = String.class)
+public class ServiceMeta extends Source {
     @Override
-    public void dispatch(final ServiceUpdate source) {
-        ServiceTraffic traffic = new ServiceTraffic();
-        traffic.setTimeBucket(source.getTimeBucket());
-        traffic.setName(source.getName());
-        traffic.setNodeType(source.getNodeType());
-        MetricsStreamProcessor.getInstance().in(traffic);
+    public int scope() {
+        return DefaultScopeDefine.SERVICE_META;
     }
+
+    @Override
+    public String getEntityId() {
+        return IDManager.ServiceID.buildId(name, NodeType.Normal);
+    }
+
+    private String name;
+    private NodeType nodeType;
 }

--- a/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/grpc/ManagementServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/grpc/ManagementServiceHandler.java
@@ -35,7 +35,7 @@ import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.analysis.manual.instance.InstanceTraffic;
 import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
 import org.apache.skywalking.oap.server.core.source.ServiceInstanceUpdate;
-import org.apache.skywalking.oap.server.core.source.ServiceUpdate;
+import org.apache.skywalking.oap.server.core.source.ServiceMeta;
 import org.apache.skywalking.oap.server.core.source.SourceReceiver;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.server.grpc.GRPCHandler;
@@ -91,11 +91,11 @@ public class ManagementServiceHandler extends ManagementServiceGrpc.ManagementSe
         serviceInstanceUpdate.setTimeBucket(timeBucket);
         sourceReceiver.receive(serviceInstanceUpdate);
 
-        ServiceUpdate serviceUpdate = new ServiceUpdate();
-        serviceUpdate.setName(serviceName);
-        serviceUpdate.setNodeType(NodeType.Normal);
-        serviceUpdate.setTimeBucket(timeBucket);
-        sourceReceiver.receive(serviceUpdate);
+        ServiceMeta serviceMeta = new ServiceMeta();
+        serviceMeta.setName(serviceName);
+        serviceMeta.setNodeType(NodeType.Normal);
+        serviceMeta.setTimeBucket(timeBucket);
+        sourceReceiver.receive(serviceMeta);
 
         responseObserver.onNext(Commands.newBuilder().build());
         responseObserver.onCompleted();

--- a/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/rest/ManagementServiceKeepAliveHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/rest/ManagementServiceKeepAliveHandler.java
@@ -31,7 +31,7 @@ import org.apache.skywalking.oap.server.core.analysis.NodeType;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
 import org.apache.skywalking.oap.server.core.source.ServiceInstanceUpdate;
-import org.apache.skywalking.oap.server.core.source.ServiceUpdate;
+import org.apache.skywalking.oap.server.core.source.ServiceMeta;
 import org.apache.skywalking.oap.server.core.source.SourceReceiver;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.server.jetty.ArgumentsParseException;
@@ -70,11 +70,11 @@ public class ManagementServiceKeepAliveHandler extends JettyJsonHandler {
         serviceInstanceUpdate.setTimeBucket(timeBucket);
         sourceReceiver.receive(serviceInstanceUpdate);
 
-        ServiceUpdate serviceUpdate = new ServiceUpdate();
-        serviceUpdate.setName(serviceName);
-        serviceUpdate.setNodeType(NodeType.Normal);
-        serviceUpdate.setTimeBucket(timeBucket);
-        sourceReceiver.receive(serviceUpdate);
+        ServiceMeta serviceMeta = new ServiceMeta();
+        serviceMeta.setName(serviceName);
+        serviceMeta.setNodeType(NodeType.Normal);
+        serviceMeta.setTimeBucket(timeBucket);
+        sourceReceiver.receive(serviceMeta);
 
         return gson.fromJson(ProtoBufJsonUtils.toJSON(Commands.newBuilder().build()), JsonElement.class);
     }

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
@@ -286,6 +286,7 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
                 sourceReceiver.receive(serviceInstanceRelation);
             }
             if (RequestType.DATABASE.equals(exitSourceBuilder.getType())) {
+                sourceReceiver.receive(exitSourceBuilder.toServiceMeta());
                 sourceReceiver.receive(exitSourceBuilder.toDatabaseAccess());
             }
         });

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/SourceBuilder.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/SourceBuilder.java
@@ -33,6 +33,7 @@ import org.apache.skywalking.oap.server.core.source.RequestType;
 import org.apache.skywalking.oap.server.core.source.Service;
 import org.apache.skywalking.oap.server.core.source.ServiceInstance;
 import org.apache.skywalking.oap.server.core.source.ServiceInstanceRelation;
+import org.apache.skywalking.oap.server.core.source.ServiceMeta;
 import org.apache.skywalking.oap.server.core.source.ServiceRelation;
 
 @RequiredArgsConstructor
@@ -109,6 +110,9 @@ class SourceBuilder {
     @Setter
     private long timeBucket;
 
+    /**
+     * The global level metrics source
+     */
     All toAll() {
         All all = new All();
         all.setName(destServiceName);
@@ -122,6 +126,9 @@ class SourceBuilder {
         return all;
     }
 
+    /**
+     * Service meta and metrics related source of {@link #destServiceName}. The metrics base on the OAL scripts.
+     */
     Service toService() {
         Service service = new Service();
         service.setName(destServiceName);
@@ -136,6 +143,9 @@ class SourceBuilder {
         return service;
     }
 
+    /**
+     * Service topology meta and metrics related source. The metrics base on the OAL scripts.
+     */
     ServiceRelation toServiceRelation() {
         ServiceRelation serviceRelation = new ServiceRelation();
         serviceRelation.setSourceServiceName(sourceServiceName);
@@ -155,6 +165,10 @@ class SourceBuilder {
         return serviceRelation;
     }
 
+    /**
+     * Service instance meta and metrics of {@link #destServiceInstanceName} related source. The metrics base on the OAL
+     * scripts.
+     */
     ServiceInstance toServiceInstance() {
         ServiceInstance serviceInstance = new ServiceInstance();
         serviceInstance.setName(destServiceInstanceName);
@@ -169,6 +183,9 @@ class SourceBuilder {
         return serviceInstance;
     }
 
+    /**
+     * Service instance topology/dependency meta and metrics related source. The metrics base on the OAL scripts.
+     */
     ServiceInstanceRelation toServiceInstanceRelation() {
         if (StringUtil.isEmpty(sourceServiceInstanceName) || StringUtil.isEmpty(destServiceInstanceName)) {
             return null;
@@ -191,6 +208,9 @@ class SourceBuilder {
         return serviceInstanceRelation;
     }
 
+    /**
+     * Endpoint meta and metrics of {@link #destEndpointName} related source. The metrics base on the OAL scripts.
+     */
     Endpoint toEndpoint() {
         Endpoint endpoint = new Endpoint();
         endpoint.setName(destEndpointName);
@@ -205,6 +225,9 @@ class SourceBuilder {
         return endpoint;
     }
 
+    /**
+     * Endpoint depedency meta and metrics related source. The metrics base on the OAL scripts.
+     */
     EndpointRelation toEndpointRelation() {
         if (StringUtil.isEmpty(sourceEndpointName) || StringUtil.isEmpty(destEndpointName)) {
             return null;
@@ -228,6 +251,21 @@ class SourceBuilder {
         return endpointRelation;
     }
 
+    /**
+     * Service meta is only for building the service list, but wouldn't be same as {@link #toService()}, which could
+     * generate traffic and metrics both.
+     */
+    ServiceMeta toServiceMeta() {
+        ServiceMeta service = new ServiceMeta();
+        service.setName(destServiceName);
+        service.setNodeType(destNodeType);
+        service.setTimeBucket(timeBucket);
+        return service;
+    }
+
+    /**
+     * Database traffic metrics source. The metrics base on the OAL scripts.
+     */
     DatabaseAccess toDatabaseAccess() {
         if (!RequestType.DATABASE.equals(type)) {
             return null;


### PR DESCRIPTION
In my previous fix #4754, I removed many unnecessary generated metrics and meta, but also remove the metadata of DB conjecture service, which make the DB doesn't show up in the DB dashboard selector.

This PR is bringing that back. Also, this include a small fix about OAL function change, `thermodynamic` renamed to `histogram`.