### PR TITLE
Make OAL controlled by the receivers.

### DIFF
--- a/apm-dist-es7/src/main/assembly/binary-es7.xml
+++ b/apm-dist-es7/src/main/assembly/binary-es7.xml
@@ -48,21 +48,14 @@
             <includes>
                 <include>application.yml</include>
                 <include>component-libraries.yml</include>
-                <include>official_analysis.oal</include>
                 <include>gateways.yml</include>
                 <include>service-apdex-threshold.yml</include>
+                <include>oal/core.oal</include>
+                <include>oal/java-agent.oal</include>
+                <include>oal/dotnet-agent.oal</include>
+                <include>oal/envoy.oal</include>
             </includes>
             <outputDirectory>/config</outputDirectory>
-        </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/../oap-server/server-starter-es7/target/skywalking-oap-assembly/skywalking-oap/config</directory>
-            <outputDirectory>/config</outputDirectory>
-            <includes>
-                <include>*.yml</include>
-                <include>*.xml</include>
-                <include>*.properties</include>
-                <include>*.oal</include>
-            </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../oap-server/server-starter-es7/target/skywalking-oap-assembly/skywalking-oap/libs</directory>

--- a/apm-dist/src/main/assembly/binary.xml
+++ b/apm-dist/src/main/assembly/binary.xml
@@ -48,21 +48,14 @@
             <includes>
                 <include>application.yml</include>
                 <include>component-libraries.yml</include>
-                <include>official_analysis.oal</include>
                 <include>gateways.yml</include>
                 <include>service-apdex-threshold.yml</include>
+                <include>oal/core.oal</include>
+                <include>oal/java-agent.oal</include>
+                <include>oal/dotnet-agent.oal</include>
+                <include>oal/envoy.oal</include>
             </includes>
             <outputDirectory>/config</outputDirectory>
-        </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/../oap-server/server-starter/target/skywalking-oap-assembly/skywalking-oap/config</directory>
-            <outputDirectory>/config</outputDirectory>
-            <includes>
-                <include>*.yml</include>
-                <include>*.xml</include>
-                <include>*.properties</include>
-                <include>*.oal</include>
-            </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../oap-server/server-starter/target/skywalking-oap-assembly/skywalking-oap/libs</directory>

--- a/docs/en/guides/README.md
+++ b/docs/en/guides/README.md
@@ -107,7 +107,7 @@ and private plugin developer should read this.
 - If you want to build a new probe or plugin in any language, please read [Component library definition and extension](Component-library-settings.md) document.
 - [Storage extension development guide](storage-extention.md). Help potential contributors to build a new 
 storage implementor besides the official.
-- Customize analysis by oal script. OAL scripts locate in `config/official_analysis.oal`. You could change it and reboot the OAP server. Read 
+- Customize analysis by oal script. OAL scripts locate in `config/oal/*.oal`. You could change it and reboot the OAP server. Read 
 [Observability Analysis Language Introduction](../concepts-and-designs/oal.md) if you need to learn about OAL script.
 - [Source and scope extension for new metrics](source-extension.md). If you want to analysis a new metrics, which SkyWalking
 haven't provide. You need to 

--- a/docs/en/guides/backend-oal-scripts.md
+++ b/docs/en/guides/backend-oal-scripts.md
@@ -1,7 +1,7 @@
 # Official OAL script
 First, read [OAL introduction](../concepts-and-designs/oal.md).
 
-Find OAL script at the `/config/official_analysis.oal` of SkyWalking dist, since 6.3.
+Find OAL script at the `/config/oal/*.oal` of SkyWalking dist, since 8.0.0.
 You could change it(such as adding filter condition, or add new metrics) and reboot the OAP server, then it will affect.
 
 All metrics named in this script could be used in alarm and UI query. 

--- a/docs/en/protocols/query-protocol.md
+++ b/docs/en/protocols/query-protocol.md
@@ -71,7 +71,7 @@ extend type Query {
 }
 ```
 
-Metrics are defined in the [official_analysis.oal](../../../oap-server/server-bootstrap/src/main/resources/official_analysis.oal).
+Metrics are defined in the `config/oal/*.oal` files.
 
 ### Aggregation
 Aggregation query means the metrics data need a secondary aggregation in query stage, which makes the query 

--- a/oap-server/server-bootstrap/pom.xml
+++ b/oap-server/server-bootstrap/pom.xml
@@ -240,9 +240,12 @@
                         <exclude>log4j2.xml</exclude>
                         <exclude>alarm-settings.yml</exclude>
                         <exclude>component-libraries.yml</exclude>
-                        <exclude>official_analysis.oal</exclude>
                         <exclude>gateways.yml</exclude>
                         <exclude>service-apdex-threshold.yml</exclude>
+                        <exclude>oal/core.oal</exclude>
+                        <exclude>oal/java-agent.oal</exclude>
+                        <exclude>oal/dotnet-agent.oal</exclude>
+                        <exclude>oal/envoy.oal</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/oap-server/server-bootstrap/src/main/resources/application.yml
+++ b/oap-server/server-bootstrap/src/main/resources/application.yml
@@ -192,6 +192,7 @@ istio-telemetry:
 envoy-metric:
   selector: ${SW_ENVOY_METRIC:default}
   default:
+    acceptMetricsService: ${SW_ENVOY_METRIC_SERVICE:true}
     alsHTTPAnalysis: ${SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS:""}
 
 prometheus-fetcher:

--- a/oap-server/server-bootstrap/src/main/resources/oal/core.oal
+++ b/oap-server/server-bootstrap/src/main/resources/oal/core.oal
@@ -37,7 +37,6 @@ service_relation_server_resp_time = from(ServiceRelation.latency).filter(detectP
 service_relation_client_percentile = from(ServiceRelation.latency).filter(detectPoint == DetectPoint.CLIENT).percentile(10); // Multiple values including p50, p75, p90, p95, p99
 service_relation_server_percentile = from(ServiceRelation.latency).filter(detectPoint == DetectPoint.SERVER).percentile(10); // Multiple values including p50, p75, p90, p95, p99
 
-
 // Service Instance relation scope metrics for topology
 service_instance_relation_client_cpm = from(ServiceInstanceRelation.*).filter(detectPoint == DetectPoint.CLIENT).cpm();
 service_instance_relation_server_cpm = from(ServiceInstanceRelation.*).filter(detectPoint == DetectPoint.SERVER).cpm();
@@ -63,37 +62,10 @@ endpoint_percentile = from(Endpoint.latency).percentile(10); // Multiple values 
 endpoint_relation_cpm = from(EndpointRelation.*).filter(detectPoint == DetectPoint.SERVER).cpm();
 endpoint_relation_resp_time = from(EndpointRelation.rpcLatency).filter(detectPoint == DetectPoint.SERVER).longAvg();
 
-// JVM instance metrics
-instance_jvm_cpu = from(ServiceInstanceJVMCPU.usePercent).doubleAvg();
-instance_jvm_memory_heap = from(ServiceInstanceJVMMemory.used).filter(heapStatus == true).longAvg();
-instance_jvm_memory_noheap = from(ServiceInstanceJVMMemory.used).filter(heapStatus == false).longAvg();
-instance_jvm_memory_heap_max = from(ServiceInstanceJVMMemory.max).filter(heapStatus == true).longAvg();
-instance_jvm_memory_noheap_max = from(ServiceInstanceJVMMemory.max).filter(heapStatus == false).longAvg();
-instance_jvm_young_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.NEW).sum();
-instance_jvm_old_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.OLD).sum();
-instance_jvm_young_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.NEW).sum();
-instance_jvm_old_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.OLD).sum();
-
 database_access_resp_time = from(DatabaseAccess.latency).longAvg();
 database_access_sla = from(DatabaseAccess.*).percent(status == true);
 database_access_cpm = from(DatabaseAccess.*).cpm();
 database_access_percentile = from(DatabaseAccess.latency).percentile(10);
-
-// CLR instance metrics
-instance_clr_cpu = from(ServiceInstanceCLRCPU.usePercent).doubleAvg();
-instance_clr_gen0_collect_count = from(ServiceInstanceCLRGC.gen0CollectCount).sum();
-instance_clr_gen1_collect_count = from(ServiceInstanceCLRGC.gen1CollectCount).sum();
-instance_clr_gen2_collect_count = from(ServiceInstanceCLRGC.gen2CollectCount).sum();
-instance_clr_heap_memory = from(ServiceInstanceCLRGC.heapMemory).longAvg();
-instance_clr_available_completion_port_threads = from(ServiceInstanceCLRThread.availableCompletionPortThreads).max();
-instance_clr_available_worker_threads = from(ServiceInstanceCLRThread.availableWorkerThreads).max();
-instance_clr_max_completion_port_threads = from(ServiceInstanceCLRThread.maxCompletionPortThreads).max();
-instance_clr_max_worker_threads = from(ServiceInstanceCLRThread.maxWorkerThreads).max();
-
-// Envoy instance metrics
-envoy_heap_memory_max_used = from(EnvoyInstanceMetric.value).filter(metricName == "server.memory_heap_size").maxDouble();
-envoy_total_connections_used = from(EnvoyInstanceMetric.value).filter(metricName == "server.total_connections").maxDouble();
-envoy_parent_connections_used = from(EnvoyInstanceMetric.value).filter(metricName == "server.parent_connections").maxDouble();
 
 // Disable unnecessary hard core stream, targeting @Stream#name
 /////////

--- a/oap-server/server-bootstrap/src/main/resources/oal/dotnet-agent.oal
+++ b/oap-server/server-bootstrap/src/main/resources/oal/dotnet-agent.oal
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// CLR instance metrics
+instance_clr_cpu = from(ServiceInstanceCLRCPU.usePercent).doubleAvg();
+instance_clr_gen0_collect_count = from(ServiceInstanceCLRGC.gen0CollectCount).sum();
+instance_clr_gen1_collect_count = from(ServiceInstanceCLRGC.gen1CollectCount).sum();
+instance_clr_gen2_collect_count = from(ServiceInstanceCLRGC.gen2CollectCount).sum();
+instance_clr_heap_memory = from(ServiceInstanceCLRGC.heapMemory).longAvg();
+instance_clr_available_completion_port_threads = from(ServiceInstanceCLRThread.availableCompletionPortThreads).max();
+instance_clr_available_worker_threads = from(ServiceInstanceCLRThread.availableWorkerThreads).max();
+instance_clr_max_completion_port_threads = from(ServiceInstanceCLRThread.maxCompletionPortThreads).max();
+instance_clr_max_worker_threads = from(ServiceInstanceCLRThread.maxWorkerThreads).max();

--- a/oap-server/server-bootstrap/src/main/resources/oal/envoy.oal
+++ b/oap-server/server-bootstrap/src/main/resources/oal/envoy.oal
@@ -1,0 +1,4 @@
+// Envoy instance metrics
+envoy_heap_memory_max_used = from(EnvoyInstanceMetric.value).filter(metricName == "server.memory_heap_size").maxDouble();
+envoy_total_connections_used = from(EnvoyInstanceMetric.value).filter(metricName == "server.total_connections").maxDouble();
+envoy_parent_connections_used = from(EnvoyInstanceMetric.value).filter(metricName == "server.parent_connections").maxDouble();

--- a/oap-server/server-bootstrap/src/main/resources/oal/envoy.oal
+++ b/oap-server/server-bootstrap/src/main/resources/oal/envoy.oal
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 // Envoy instance metrics
 envoy_heap_memory_max_used = from(EnvoyInstanceMetric.value).filter(metricName == "server.memory_heap_size").maxDouble();
 envoy_total_connections_used = from(EnvoyInstanceMetric.value).filter(metricName == "server.total_connections").maxDouble();

--- a/oap-server/server-bootstrap/src/main/resources/oal/java-agent.oal
+++ b/oap-server/server-bootstrap/src/main/resources/oal/java-agent.oal
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// JVM instance metrics
+instance_jvm_cpu = from(ServiceInstanceJVMCPU.usePercent).doubleAvg();
+instance_jvm_memory_heap = from(ServiceInstanceJVMMemory.used).filter(heapStatus == true).longAvg();
+instance_jvm_memory_noheap = from(ServiceInstanceJVMMemory.used).filter(heapStatus == false).longAvg();
+instance_jvm_memory_heap_max = from(ServiceInstanceJVMMemory.max).filter(heapStatus == true).longAvg();
+instance_jvm_memory_noheap_max = from(ServiceInstanceJVMMemory.max).filter(heapStatus == false).longAvg();
+instance_jvm_young_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.NEW).sum();
+instance_jvm_old_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.OLD).sum();
+instance_jvm_young_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.NEW).sum();
+instance_jvm_old_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.OLD).sum();

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/oal/rt/CoreOALDefine.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/oal/rt/CoreOALDefine.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.oap.server.core.oal.rt;
+
+public class CoreOALDefine extends OALDefine {
+    public static final CoreOALDefine INSTANCE = new CoreOALDefine();
+
+    private CoreOALDefine() {
+        super(
+            "oal/core.oal",
+            "org.apache.skywalking.oap.server.core.source"
+        );
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/oal/rt/OALDefine.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/oal/rt/OALDefine.java
@@ -31,16 +31,13 @@ import static java.util.Objects.requireNonNull;
 @ToString
 @EqualsAndHashCode
 public abstract class OALDefine {
-
-    OALDefine(final String configFile,
-              final String sourcePackage,
-              final String dynamicMetricsClassPackage,
-              final String dynamicMetricsBuilderClassPackage, final String dynamicDispatcherClassPackage) {
+    protected OALDefine(final String configFile,
+              final String sourcePackage) {
         this.configFile = requireNonNull(configFile);
         this.sourcePackage = appendPoint(requireNonNull(sourcePackage));
-        this.dynamicMetricsClassPackage = appendPoint(requireNonNull(dynamicMetricsClassPackage));
-        this.dynamicMetricsBuilderClassPackage = appendPoint(requireNonNull(dynamicMetricsBuilderClassPackage));
-        this.dynamicDispatcherClassPackage = appendPoint(requireNonNull(dynamicDispatcherClassPackage));
+        this.dynamicMetricsClassPackage = appendPoint(sourcePackage + ".oal.rt.metrics");
+        this.dynamicMetricsBuilderClassPackage = appendPoint(sourcePackage + ".oal.rt.metrics.builder");
+        this.dynamicDispatcherClassPackage = appendPoint(sourcePackage + ".oal.rt.dispatcher");
     }
 
     private final String configFile;

--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/EnvoyMetricReceiverProvider.java
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/EnvoyMetricReceiverProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.receiver.envoy;
 
+import org.apache.skywalking.aop.server.receiver.mesh.MeshReceiverModule;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
@@ -82,7 +83,8 @@ public class EnvoyMetricReceiverProvider extends ModuleProvider {
         return new String[] {
             TelemetryModule.NAME,
             CoreModule.NAME,
-            SharingServerModule.NAME
+            SharingServerModule.NAME,
+            MeshReceiverModule.NAME
         };
     }
 }

--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/EnvoyMetricReceiverProvider.java
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/EnvoyMetricReceiverProvider.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.oap.server.receiver.envoy;
 
 import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
@@ -60,7 +61,14 @@ public class EnvoyMetricReceiverProvider extends ModuleProvider {
         GRPCHandlerRegister service = getManager().find(SharingServerModule.NAME)
                                                   .provider()
                                                   .getService(GRPCHandlerRegister.class);
-        service.addHandler(new MetricServiceGRPCHandler(getManager()));
+        if (config.isAcceptMetricsService()) {
+            getManager().find(CoreModule.NAME)
+                        .provider()
+                        .getService(OALEngineLoaderService.class)
+                        .load(EnvoyOALDefine.INSTANCE);
+
+            service.addHandler(new MetricServiceGRPCHandler(getManager()));
+        }
         service.addHandler(new AccessLogServiceGRPCHandler(getManager(), config));
     }
 

--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/EnvoyOALDefine.java
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/EnvoyOALDefine.java
@@ -18,23 +18,18 @@
 
 package org.apache.skywalking.oap.server.receiver.envoy;
 
-import com.google.common.base.Strings;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import lombok.Getter;
-import org.apache.skywalking.oap.server.library.module.ModuleConfig;
+import org.apache.skywalking.oap.server.core.oal.rt.OALDefine;
 
-public class EnvoyMetricReceiverConfig extends ModuleConfig {
-    @Getter
-    private boolean acceptMetricsService = false;
-    private String alsHTTPAnalysis;
+/**
+ * Envoy OAl script includes the metrics related to Envoy only.
+ */
+public class EnvoyOALDefine  extends OALDefine {
+    public static final EnvoyOALDefine INSTANCE = new EnvoyOALDefine();
 
-    public List<String> getAlsHTTPAnalysis() {
-        if (Strings.isNullOrEmpty(alsHTTPAnalysis)) {
-            return Collections.EMPTY_LIST;
-        }
-        return Arrays.stream(alsHTTPAnalysis.trim().split(",")).map(String::trim).collect(Collectors.toList());
+    private EnvoyOALDefine() {
+        super(
+            "oal/envoy.oal",
+            "org.apache.skywalking.oap.server.core.source"
+        );
     }
 }

--- a/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/clr/provider/CLRModuleProvider.java
+++ b/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/clr/provider/CLRModuleProvider.java
@@ -20,7 +20,6 @@ package org.apache.skywalking.oap.server.receiver.clr.provider;
 
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
-import org.apache.skywalking.oap.server.core.oal.rt.OfficialOALDefine;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
@@ -62,7 +61,7 @@ public class CLRModuleProvider extends ModuleProvider {
         getManager().find(CoreModule.NAME)
                     .provider()
                     .getService(OALEngineLoaderService.class)
-                    .load(OfficialOALDefine.INSTANCE);
+                    .load(CLROALDefine.INSTANCE);
 
         GRPCHandlerRegister grpcHandlerRegister = getManager().find(SharingServerModule.NAME)
                                                               .provider()

--- a/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/clr/provider/CLROALDefine.java
+++ b/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/clr/provider/CLROALDefine.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.receiver.clr.provider;
+
+import org.apache.skywalking.oap.server.core.oal.rt.OALDefine;
+
+/**
+ * CLR OAL script includes the metrics related to dot net CLR only.
+ */
+public class CLROALDefine extends OALDefine {
+    public static final CLROALDefine INSTANCE = new CLROALDefine();
+
+    private CLROALDefine() {
+        super(
+            "oal/dotnet-agent.oal",
+            "org.apache.skywalking.oap.server.core.source"
+        );
+    }
+}

--- a/oap-server/server-receiver-plugin/skywalking-istio-telemetry-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/istio/telemetry/provider/IstioTelemetryReceiverProvider.java
+++ b/oap-server/server-receiver-plugin/skywalking-istio-telemetry-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/istio/telemetry/provider/IstioTelemetryReceiverProvider.java
@@ -20,8 +20,6 @@ package org.apache.skywalking.oap.server.receiver.istio.telemetry.provider;
 
 import org.apache.skywalking.aop.server.receiver.mesh.MeshReceiverModule;
 import org.apache.skywalking.oap.server.core.CoreModule;
-import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
-import org.apache.skywalking.oap.server.core.oal.rt.OfficialOALDefine;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
@@ -54,12 +52,6 @@ public class IstioTelemetryReceiverProvider extends ModuleProvider {
 
     @Override
     public void start() throws ServiceNotProvidedException, ModuleStartException {
-        // load official analysis
-        getManager().find(CoreModule.NAME)
-                    .provider()
-                    .getService(OALEngineLoaderService.class)
-                    .load(OfficialOALDefine.INSTANCE);
-
         GRPCHandlerRegister service = getManager().find(SharingServerModule.NAME)
                                                   .provider()
                                                   .getService(GRPCHandlerRegister.class);

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/JVMModuleProvider.java
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/JVMModuleProvider.java
@@ -20,7 +20,6 @@ package org.apache.skywalking.oap.server.receiver.jvm.provider;
 
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
-import org.apache.skywalking.oap.server.core.oal.rt.OfficialOALDefine;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
@@ -57,7 +56,7 @@ public class JVMModuleProvider extends ModuleProvider {
         getManager().find(CoreModule.NAME)
                     .provider()
                     .getService(OALEngineLoaderService.class)
-                    .load(OfficialOALDefine.INSTANCE);
+                    .load(JVMOALDefine.INSTANCE);
 
         GRPCHandlerRegister grpcHandlerRegister = getManager().find(SharingServerModule.NAME)
                                                               .provider()

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/JVMOALDefine.java
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/JVMOALDefine.java
@@ -6,28 +6,30 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
-package org.apache.skywalking.oap.server.core.oal.rt;
+package org.apache.skywalking.oap.server.receiver.jvm.provider;
 
-public class OfficialOALDefine extends OALDefine {
+import org.apache.skywalking.oap.server.core.oal.rt.OALDefine;
 
-    public static final OfficialOALDefine INSTANCE = new OfficialOALDefine();
+/**
+ * JVM OAl script includes the metrics related to JVM only.
+ */
+public class JVMOALDefine extends OALDefine {
+    public static final JVMOALDefine INSTANCE = new JVMOALDefine();
 
-    private OfficialOALDefine() {
+    private JVMOALDefine() {
         super(
-            "official_analysis.oal",
-            "org.apache.skywalking.oap.server.core.source",
-            "org.apache.skywalking.oal.rt.official.metrics",
-            "org.apache.skywalking.oal.rt.official.metrics.builder",
-            "org.apache.skywalking.oal.rt.official.dispatcher"
+            "oal/java-agent.oal",
+            "org.apache.skywalking.oap.server.core.source"
         );
     }
 }

--- a/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/MeshReceiverProvider.java
+++ b/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/MeshReceiverProvider.java
@@ -20,7 +20,7 @@ package org.apache.skywalking.aop.server.receiver.mesh;
 
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
-import org.apache.skywalking.oap.server.core.oal.rt.OfficialOALDefine;
+import org.apache.skywalking.oap.server.core.oal.rt.CoreOALDefine;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
@@ -62,7 +62,7 @@ public class MeshReceiverProvider extends ModuleProvider {
         getManager().find(CoreModule.NAME)
                     .provider()
                     .getService(OALEngineLoaderService.class)
-                    .load(OfficialOALDefine.INSTANCE);
+                    .load(CoreOALDefine.INSTANCE);
 
         TelemetryDataDispatcher.init(getManager());
         GRPCHandlerRegister service = getManager().find(SharingServerModule.NAME)

--- a/oap-server/server-receiver-plugin/skywalking-so11y-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/so11y/So11yReceiverModuleProvider.java
+++ b/oap-server/server-receiver-plugin/skywalking-so11y-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/so11y/So11yReceiverModuleProvider.java
@@ -38,7 +38,7 @@ import org.apache.skywalking.oap.server.core.analysis.IDManager;
 import org.apache.skywalking.oap.server.core.analysis.NodeType;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
-import org.apache.skywalking.oap.server.core.oal.rt.OfficialOALDefine;
+import org.apache.skywalking.oap.server.core.oal.rt.CoreOALDefine;
 import org.apache.skywalking.oap.server.core.source.GCPhrase;
 import org.apache.skywalking.oap.server.core.source.MemoryPoolType;
 import org.apache.skywalking.oap.server.core.source.ServiceInstanceJVMCPU;
@@ -117,7 +117,7 @@ public class So11yReceiverModuleProvider extends ModuleProvider {
         getManager().find(CoreModule.NAME)
                     .provider()
                     .getService(OALEngineLoaderService.class)
-                    .load(OfficialOALDefine.INSTANCE);
+                    .load(CoreOALDefine.INSTANCE);
 
         sourceReceiver = getManager().find(CoreModule.NAME).provider().getService(SourceReceiver.class);
         MetricsCollector collector = getManager().find(TelemetryModule.NAME)

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/TraceModuleProvider.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/TraceModuleProvider.java
@@ -22,7 +22,7 @@ import org.apache.skywalking.oap.server.configuration.api.ConfigurationModule;
 import org.apache.skywalking.oap.server.configuration.api.DynamicConfigurationService;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
-import org.apache.skywalking.oap.server.core.oal.rt.OfficialOALDefine;
+import org.apache.skywalking.oap.server.core.oal.rt.CoreOALDefine;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
 import org.apache.skywalking.oap.server.core.server.JettyHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
@@ -88,7 +88,7 @@ public class TraceModuleProvider extends ModuleProvider {
         getManager().find(CoreModule.NAME)
                     .provider()
                     .getService(OALEngineLoaderService.class)
-                    .load(OfficialOALDefine.INSTANCE);
+                    .load(CoreOALDefine.INSTANCE);
 
         DynamicConfigurationService dynamicConfigurationService = getManager().find(ConfigurationModule.NAME)
                                                                               .provider()


### PR DESCRIPTION
Hi,

I am improving the OAL based on @arugal 's new PR, . Now, I could split the one and only `official_analysis.oal` into separated files, including
- core
- jvm
- dotnet
- envoy

`core` is also active due to trace, mesh, or so11y. Others are not activated when the receivers are open.