### PR TITLE
Make the default application.yml more friendly in the configuration s…

### DIFF
--- a/docs/en/setup/backend/dynamic-config.md
+++ b/docs/en/setup/backend/dynamic-config.md
@@ -18,11 +18,11 @@ This feature depends on upstream service, so it is **DISABLED** by default.
 configuration:
   selector: ${SW_CONFIGURATION:none}
   none:
-  apollo:
-    apolloMeta: http://106.12.25.204:8080
-    apolloCluster: default
-    appId: skywalking
-    period: 5
+  grpc:
+    host: ${SW_DCS_SERVER_HOST:""}
+    port: ${SW_DCS_SERVER_PORT:80}
+    clusterName: ${SW_DCS_CLUSTER_NAME:SkyWalking}
+    period: ${SW_DCS_PERIOD:20}
   # ... other implementations
 ```
 
@@ -35,41 +35,11 @@ The SkyWalking OAP fetches the configuration from the implementation(any system)
 configuration:
   selector: ${SW_CONFIGURATION:grpc}
   grpc:
-    host: 127.0.0.1
-    port: 9555
+    host: ${SW_DCS_SERVER_HOST:""}
+    port: ${SW_DCS_SERVER_PORT:80}
+    clusterName: ${SW_DCS_CLUSTER_NAME:SkyWalking}
+    period: ${SW_DCS_PERIOD:20}
 ```
-
-## Dynamic Configuration Apollo Implementation
-
-[Apollo](https://github.com/ctripcorp/apollo/) is also supported as DCC(Dynamic Configuration Center), to use it, just configured as follows:
-
-```yaml
-configuration:
-  selector: ${SW_CONFIGURATION:apollo}
-  apollo:
-    apolloMeta: <your apollo meta address>
-    apolloCluster: default
-    appId: skywalking
-    period: 5
-```
-
-## Dynamic Configuration Nacos Implementation
-
-[Nacos](https://github.com/alibaba/nacos) is also supported as DCC(Dynamic Configuration Center), to use it, please configure as follows:
-
-```yaml
-configuration:
-  selector: ${SW_CONFIGURATION:nacos}
-  nacos:
-    serverAddr: 127.0.0.1
-    port: 8848
-    group: 'skywalking'
-    namespace: ''
-    period : 60
-    clusterName: "default"
-  # ... other configurations
-```
-
 
 ## Dynamic Configuration Zookeeper Implementation
 
@@ -79,12 +49,12 @@ configuration:
 configuration:
   selector: ${SW_CONFIGURATION:zookeeper}
   zookeeper:
-    period : 60 # Unit seconds, sync period. Default fetch every 60 seconds.
-    nameSpace: /default
-    hostPort: localhost:2181
-    baseSleepTimeMs: 1000 # initial amount of time to wait between retries
-    maxRetries: 3 # max number of times to retry
-  # ... other configurations
+    period: ${SW_CONFIG_ZK_PERIOD:60} # Unit seconds, sync period. Default fetch every 60 seconds.
+    nameSpace: ${SW_CONFIG_ZK_NAMESPACE:/default}
+    hostPort: ${SW_CONFIG_ZK_HOST_PORT:localhost:2181}
+    # Retry Policy
+    baseSleepTimeMs: ${SW_CONFIG_ZK_BASE_SLEEP_TIME_MS:1000} # initial amount of time to wait between retries
+    maxRetries: ${SW_CONFIG_ZK_MAX_RETRIES:3} # max number of times to retry
 ```
 
 ## Dynamic Configuration Etcd Implementation
@@ -95,11 +65,10 @@ configuration:
 configuration:
   selector: ${SW_CONFIGURATION:etcd}
   etcd:
-    period : 60 # Unit seconds, sync period. Default fetch every 60 seconds.
-    group :  'skywalking'
-    serverAddr: localhost:2379
-    clusterName: "default"
-  # ... other configurations
+    period: ${SW_CONFIG_ETCD_PERIOD:60} # Unit seconds, sync period. Default fetch every 60 seconds.
+    group: ${SW_CONFIG_ETCD_GROUP:skywalking}
+    serverAddr: ${SW_CONFIG_ETCD_SERVER_ADDR:localhost:2379}
+    clusterName: ${SW_CONFIG_ETCD_CLUSTER_NAME:default}
 ```
 
 ## Dynamic Configuration Consul Implementation
@@ -111,12 +80,48 @@ configuration:
   selector: ${SW_CONFIGURATION:consul}
   consul:
     # Consul host and ports, separated by comma, e.g. 1.2.3.4:8500,2.3.4.5:8500
-    hostAndPorts: 127.0.0.1:8500
+    hostAndPorts: ${SW_CONFIG_CONSUL_HOST_AND_PORTS:1.2.3.4:8500}
     # Sync period in seconds. Defaults to 60 seconds.
-    period: 60
-    # aclToken of connection consul (optional)
-    aclToken: ${consul.aclToken}
-  # ... other configurations
+    period: ${SW_CONFIG_CONSUL_PERIOD:1}
+    # Consul aclToken
+    aclToken: ${SW_CONFIG_CONSUL_ACL_TOKEN:""}
+```
+
+## Dynamic Configuration Apollo Implementation
+
+[Apollo](https://github.com/ctripcorp/apollo/) is also supported as DCC(Dynamic Configuration Center), to use it, just configured as follows:
+
+```yaml
+configuration:
+  selector: ${SW_CONFIGURATION:apollo}
+  apollo:
+    apolloMeta: ${SW_CONFIG_APOLLO:http://106.12.25.204:8080}
+    apolloCluster: ${SW_CONFIG_APOLLO_CLUSTER:default}
+    apolloEnv: ${SW_CONFIG_APOLLO_ENV:""}
+    appId: ${SW_CONFIG_APOLLO_APP_ID:skywalking}
+    period: ${SW_CONFIG_APOLLO_PERIOD:5}
+```
+
+## Dynamic Configuration Nacos Implementation
+
+[Nacos](https://github.com/alibaba/nacos) is also supported as DCC(Dynamic Configuration Center), to use it, please configure as follows:
+
+```yaml
+configuration:
+  selector: ${SW_CONFIGURATION:nacos}
+  nacos:
+    # Nacos Server Host
+    serverAddr: ${SW_CONFIG_NACOS_SERVER_ADDR:127.0.0.1}
+    # Nacos Server Port
+    port: ${SW_CONFIG_NACOS_SERVER_PORT:8848}
+    # Nacos Configuration Group
+    group: ${SW_CONFIG_NACOS_SERVER_GROUP:skywalking}
+    # Nacos Configuration namespace
+    namespace: ${SW_CONFIG_NACOS_SERVER_NAMESPACE:}
+    # Unit seconds, sync period. Default fetch every 60 seconds.
+    period: ${SW_CONFIG_NACOS_PERIOD:60}
+    # the name of current cluster, set the name if you want to upstream system known.
+    clusterName: ${SW_CONFIG_NACOS_CLUSTER_NAME:default}
 ```
 
 

--- a/oap-server/server-bootstrap/src/main/resources/application.yml
+++ b/oap-server/server-bootstrap/src/main/resources/application.yml
@@ -240,44 +240,49 @@ receiver-so11y:
 configuration:
   selector: ${SW_CONFIGURATION:none}
   none:
+  grpc:
+    host: ${SW_DCS_SERVER_HOST:""}
+    port: ${SW_DCS_SERVER_PORT:80}
+    clusterName: ${SW_DCS_CLUSTER_NAME:SkyWalking}
+    period: ${SW_DCS_PERIOD:20}
   apollo:
-    apolloMeta: http://106.12.25.204:8080
-    apolloCluster: default
-    apolloEnv: ""
-    appId: skywalking
-    period: 5
+    apolloMeta: ${SW_CONFIG_APOLLO:http://106.12.25.204:8080}
+    apolloCluster: ${SW_CONFIG_APOLLO_CLUSTER:default}
+    apolloEnv: ${SW_CONFIG_APOLLO_ENV:""}
+    appId: ${SW_CONFIG_APOLLO_APP_ID:skywalking}
+    period: ${SW_CONFIG_APOLLO_PERIOD:5}
   nacos:
     # Nacos Server Host
-    serverAddr: 127.0.0.1
+    serverAddr: ${SW_CONFIG_NACOS_SERVER_ADDR:127.0.0.1}
     # Nacos Server Port
-    port: 8848
+    port: ${SW_CONFIG_NACOS_SERVER_PORT:8848}
     # Nacos Configuration Group
-    group: 'skywalking'
+    group: ${SW_CONFIG_NACOS_SERVER_GROUP:skywalking}
     # Nacos Configuration namespace
-    namespace: ''
+    namespace: ${SW_CONFIG_NACOS_SERVER_NAMESPACE:}
     # Unit seconds, sync period. Default fetch every 60 seconds.
-    period: 60
+    period: ${SW_CONFIG_NACOS_PERIOD:60}
     # the name of current cluster, set the name if you want to upstream system known.
-    clusterName: "default"
+    clusterName: ${SW_CONFIG_NACOS_CLUSTER_NAME:default}
   zookeeper:
-    period: 60 # Unit seconds, sync period. Default fetch every 60 seconds.
-    nameSpace: /default
-    hostPort: localhost:2181
+    period: ${SW_CONFIG_ZK_PERIOD:60} # Unit seconds, sync period. Default fetch every 60 seconds.
+    nameSpace: ${SW_CONFIG_ZK_NAMESPACE:/default}
+    hostPort: ${SW_CONFIG_ZK_HOST_PORT:localhost:2181}
     # Retry Policy
-    baseSleepTimeMs: 1000 # initial amount of time to wait between retries
-    maxRetries: 3 # max number of times to retry
+    baseSleepTimeMs: ${SW_CONFIG_ZK_BASE_SLEEP_TIME_MS:1000} # initial amount of time to wait between retries
+    maxRetries: ${SW_CONFIG_ZK_MAX_RETRIES:3} # max number of times to retry
   etcd:
-    period: 60 # Unit seconds, sync period. Default fetch every 60 seconds.
-    group:  'skywalking'
-    serverAddr: localhost:2379
-    clusterName: "default"
+    period: ${SW_CONFIG_ETCD_PERIOD:60} # Unit seconds, sync period. Default fetch every 60 seconds.
+    group: ${SW_CONFIG_ETCD_GROUP:skywalking}
+    serverAddr: ${SW_CONFIG_ETCD_SERVER_ADDR:localhost:2379}
+    clusterName: ${SW_CONFIG_ETCD_CLUSTER_NAME:default}
   consul:
     # Consul host and ports, separated by comma, e.g. 1.2.3.4:8500,2.3.4.5:8500
-    hostAndPorts: ${consul.address}
+    hostAndPorts: ${SW_CONFIG_CONSUL_HOST_AND_PORTS:1.2.3.4:8500}
     # Sync period in seconds. Defaults to 60 seconds.
-    period: 1
+    period: ${SW_CONFIG_CONSUL_PERIOD:1}
     # Consul aclToken
-    #aclToken: ${consul.aclToken}
+    aclToken: ${SW_CONFIG_CONSUL_ACL_TOKEN:""}
 
 exporter:
   selector: ${SW_EXPORTER:-}

--- a/test/e2e/e2e-test/docker/python/Dockerfile.python
+++ b/test/e2e/e2e-test/docker/python/Dockerfile.python
@@ -19,7 +19,7 @@ ENV COMMIT_HASH=445d64c162555a3ff92b98e8ccec3cdc1a66876d
 
 WORKDIR /app
 
-RUN git clone https://github.com/apache/skywalking-python.git --depth=1 $(pwd)
+RUN git clone https://github.com/apache/skywalking-python.git $(pwd)
 
 RUN git reset --hard ${COMMIT_HASH} && git submodule update --init
 


### PR DESCRIPTION
When I was reading the dynamic configuration document, I noticed the document and default `application.yml` don't follow the recommended format, which should provide the system env names. So I added them.