### PR TITLE
Fix the wrong sortN condition

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/input/TopNCondition.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/input/TopNCondition.java
@@ -43,7 +43,7 @@ public class TopNCondition {
      * Normal service is the service having installed agent or metrics reported directly. Unnormal service is
      * conjectural service, usually detected by the agent.
      */
-    private boolean isNormal;
+    private boolean normal;
     /**
      * Indicate the metrics entity scope. Because this is a top list, don't need to set the Entity like the
      * MetricsCondition. Only accept scope = {@link Scope#Service} {@link Scope#ServiceInstance} and {@link


### PR DESCRIPTION
The `isNormal` is not supported in GraphQL-java, I changed `MetricsCondition` before, but forgot this one.

Now, it is working,
```graphql
{
  sortMetrics(condition : {
    name: "test_long_metrics",
    topN: 10,
    scope: Service,
    order: DES
  }, 
  duration: {step:MINUTE, start: "2020-05-14 1030", end: "2020-05-14 1040"}
  ) {
    name,
    id,
    value,
    refId
  }
}
```