### PR TITLE
The NoneStreamEsDAO implementation doesn't use real index name to insert

### DIFF
--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/NoneStreamEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/NoneStreamEsDAO.java
@@ -41,7 +41,7 @@ public class NoneStreamEsDAO extends EsDAO implements INoneStreamDAO {
     @Override
     public void insert(Model model, NoneStream noneStream) throws IOException {
         XContentBuilder builder = map2builder(storageBuilder.data2Map(noneStream));
-        String modelName = model.getName();
+        String modelName = TimeSeriesUtils.writeIndexName(model, noneStream.getTimeBucket());
         getClient().forceInsert(modelName, noneStream.id(), builder);
     }
 }


### PR DESCRIPTION
@sunrongxin7666 I have found out the reason of your reported issue. The existing codes are using the template name rather than the index name(with time bucket suffix) to insert data, which is not supported by the ElasticSearch. We haven't a chance to test this case before, thanks for your detailed report, which makes me easier to catch the reason.

All existing metrics and traces insert/update are doing in the right now, but due to profile is new in the 7.0, it seems @mrproliu missed this, and this can't be caught by the current TTL e2e.

Resolves #4794. 