### PR TITLE
Group Parameterized Endpoints

### DIFF
--- a/apm-dist-es7/src/main/assembly/binary-es7.xml
+++ b/apm-dist-es7/src/main/assembly/binary-es7.xml
@@ -50,6 +50,7 @@
                 <include>component-libraries.yml</include>
                 <include>gateways.yml</include>
                 <include>service-apdex-threshold.yml</include>
+                <include>endpoint_name_grouping.yml</include>
                 <include>oal/core.oal</include>
                 <include>oal/java-agent.oal</include>
                 <include>oal/dotnet-agent.oal</include>

--- a/apm-dist/src/main/assembly/binary.xml
+++ b/apm-dist/src/main/assembly/binary.xml
@@ -50,6 +50,7 @@
                 <include>component-libraries.yml</include>
                 <include>gateways.yml</include>
                 <include>service-apdex-threshold.yml</include>
+                <include>endpoint_name_grouping.yml</include>
                 <include>oal/core.oal</include>
                 <include>oal/java-agent.oal</include>
                 <include>oal/dotnet-agent.oal</include>

--- a/docs/en/setup/backend/backend-setup.md
+++ b/docs/en/setup/backend/backend-setup.md
@@ -105,6 +105,8 @@ or 3rd party configuration management system.
 1. [Uninstrumented Gateways](uninstrumented-gateways.md). Configure gateways/proxies that are not supported by SkyWalking agent plugins,
 to reflect the delegation in topology graph.
 1. [Apdex threshold](apdex-threshold.md). Configure the thresholds for different services if Apdex calculation is activated in the OAL.
+1. [Group Parameterized Endpoints](endpoint-grouping-rules.md). Configure the grouping rules for parameterized endpoints,
+to improve the meaning of the metrics.
 
 ## Telemetry for backend
 OAP backend cluster itself underlying is a distributed streaming process system. For helping the Ops team,

--- a/docs/en/setup/backend/dynamic-config.md
+++ b/docs/en/setup/backend/dynamic-config.md
@@ -1,6 +1,6 @@
 # Dynamic Configuration
 SkyWalking Configurations mostly are set through `application.yml` and OS system environment variables.
-But some of them are supporting dynamic settings from upstream management system.
+At the same time, some of them are supporting dynamic settings from upstream management system.
 
 Right now, SkyWalking supports following dynamic configurations.
 

--- a/docs/en/setup/backend/dynamic-config.md
+++ b/docs/en/setup/backend/dynamic-config.md
@@ -10,6 +10,7 @@ Right now, SkyWalking supports following dynamic configurations.
 |receiver-trace.default.uninstrumentedGateways| The uninstrumented gateways, override `gateways.yml`. | same as [`gateways.yml`](uninstrumented-gateways.md#configuration-format) |
 |alarm.default.alarm-settings| The alarm settings, will override `alarm-settings.yml`. | same as [`alarm-settings.yml`](backend-alarm.md) |
 |core.default.apdexThreshold| The apdex threshold settings, will override `service-apdex-threshold.yml`. | same as [`service-apdex-threshold.yml`](apdex-threshold.md) |
+|core.default.endpoint-name-grouping| The endpoint name grouping setting, will override `endpoint_name_grouping.yml`. | same as [`endpoint_name_grouping.yml`](endpoint-grouping-rules.md) |
 
 
 This feature depends on upstream service, so it is **DISABLED** by default.

--- a/docs/en/setup/backend/endpoint-grouping-rules.md
+++ b/docs/en/setup/backend/endpoint-grouping-rules.md
@@ -1,0 +1,23 @@
+# Group Parameterized Endpoints
+In most cases, the endpoint should be detected automatically through the language agents, service mesh observability solution, 
+or configuration of meter system.
+
+There are some special cases, especially when people use REST style URI, the application codes put the parameter in the endpoint name, 
+such as putting order id in the URI, like `/prod/ORDER123` and `/prod/ORDER123`. But logically, people expect they could
+have an endpoint name like `prod/{order-id}`. This is the feature of parameterized endpoint grouping designed for.
+
+Current, user could set up grouping rules through the static YAML file, named `endpoint_name_grouping.yml`,
+or use [Dynamic Configuration](dynamic-config.md) to initial and update the endpoint grouping rule.
+
+## Configuration Format
+No matter in static local file or dynamic configuration value, they are sharing the same YAML format.
+
+```yaml
+grouping:
+  # Endpoint of the service would follow the following rules
+  - service-name: serviceA
+    rules:
+      # Logic name when the regex expression matched.
+      - endpoint-name: /prod/{id}
+        regex: \/prod\/.+
+```

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmRulesWatcher.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmRulesWatcher.java
@@ -56,7 +56,7 @@ public class AlarmRulesWatcher extends ConfigChangeWatcher {
 
     @Override
     public void notify(ConfigChangeEvent value) {
-        if (value.getEventType() == EventType.DELETE) {
+        if (value.getEventType().equals(EventType.DELETE)) {
             settingsString = Const.EMPTY_STRING;
             notify(new Rules());
         } else {

--- a/oap-server/server-bootstrap/pom.xml
+++ b/oap-server/server-bootstrap/pom.xml
@@ -242,6 +242,7 @@
                         <exclude>component-libraries.yml</exclude>
                         <exclude>gateways.yml</exclude>
                         <exclude>service-apdex-threshold.yml</exclude>
+                        <exclude>endpoint_name_grouping.yml</exclude>
                         <exclude>oal/core.oal</exclude>
                         <exclude>oal/java-agent.oal</exclude>
                         <exclude>oal/dotnet-agent.oal</exclude>

--- a/oap-server/server-bootstrap/src/main/resources/endpoint_name_grouping.yml
+++ b/oap-server/server-bootstrap/src/main/resources/endpoint_name_grouping.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Endpoint name grouping rules.
+# In most cased, endpoint name should be detected by agents or service mesh automatically, and aggregate the metrics based
+# on the name.
+# But, in some cases, application puts the parameter in the endpoint name, such as putting order id in the URI, like
+# /prod/ORDER123, /prod/ORDER456.
+# This grouping file provides the regex based definition capability to merge those endpoints into a group by better and
+# more meaningful aggregation metrics.
+
+#grouping:
+#  # Endpoint of the service would follow the following rules
+#  - service-name: serviceA
+#    rules:
+#      - endpoint-name: /prod/{id}
+#        regex: \/prod\/.+

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModule.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModule.java
@@ -27,7 +27,7 @@ import org.apache.skywalking.oap.server.core.command.CommandService;
 import org.apache.skywalking.oap.server.core.config.ConfigService;
 import org.apache.skywalking.oap.server.core.config.DownSamplingConfigService;
 import org.apache.skywalking.oap.server.core.config.IComponentLibraryCatalogService;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
 import org.apache.skywalking.oap.server.core.profile.ProfileTaskMutationService;
 import org.apache.skywalking.oap.server.core.query.AggregationQueryService;
@@ -67,7 +67,7 @@ public class CoreModule extends ModuleDefine {
         List<Class> classes = new ArrayList<>();
         classes.add(ConfigService.class);
         classes.add(DownSamplingConfigService.class);
-        classes.add(NamingLengthControl.class);
+        classes.add(NamingControl.class);
         classes.add(IComponentLibraryCatalogService.class);
 
         classes.add(IWorkerInstanceGetter.class);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/NamingControl.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/NamingControl.java
@@ -20,18 +20,20 @@ package org.apache.skywalking.oap.server.core.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.skywalking.oap.server.core.config.group.EndpointNameGrouping;
 import org.apache.skywalking.oap.server.library.module.Service;
 
 /**
- * NamingLengthControl provides the service to make the names of service, instance and endpoint following the length
- * rules.
+ * NamingControl provides the service to make the names of service, instance and endpoint following the rules or
+ * patterns, including length control, grouping, etc.
  */
 @RequiredArgsConstructor
 @Slf4j
-public class NamingLengthControl implements Service {
+public class NamingControl implements Service {
     private final int serviceNameMaxLength;
     private final int instanceNameMaxLength;
     private final int endpointNameMaxLength;
+    private final EndpointNameGrouping endpointNameGrouping;
 
     /**
      * Format endpoint name by using the length config in the core module. This is a global rule, every place including
@@ -88,10 +90,11 @@ public class NamingLengthControl implements Service {
      * endpoint as the {@link org.apache.skywalking.oap.server.core.source.Source} should follow this for any core
      * module implementation.
      *
+     * @param serviceName  the service of the given endpoint.
      * @param endpointName raw data, literal string.
      * @return the string, which length less than or equals {@link #endpointNameMaxLength};
      */
-    public String formatEndpointName(String endpointName) {
+    public String formatEndpointName(String serviceName, String endpointName) {
         if (endpointName.length() > endpointNameMaxLength) {
             final String rename = endpointName.substring(0, endpointNameMaxLength);
             if (log.isDebugEnabled()) {
@@ -102,7 +105,7 @@ public class NamingLengthControl implements Service {
                     serviceNameMaxLength
                 );
             }
-            return rename;
+            return endpointNameGrouping.format(serviceName, rename);
         } else {
             return endpointName;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRule.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRule.java
@@ -36,13 +36,8 @@ public class EndpointGroupingRule {
      * @param ruleRegex         match the endpoints which should be in the group name.
      */
     void addRule(String serviceName, String endpointGroupName, String ruleRegex) {
-        if (rules.containsKey(serviceName)) {
-            rules.get(serviceName).addRule(endpointGroupName, ruleRegex);
-        } else {
-            StringFormatGroup newGroup = new StringFormatGroup();
-            newGroup.addRule(endpointGroupName, ruleRegex);
-            rules.put(serviceName, newGroup);
-        }
+        final StringFormatGroup formatGroup = rules.computeIfAbsent(serviceName, name -> new StringFormatGroup());
+        formatGroup.addRule(endpointGroupName, ruleRegex);
     }
 
     /**

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRule.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRule.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.config.group;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.skywalking.apm.util.StringFormatGroup;
+
+/**
+ * Endpoint group rule hosts all group rules of all services.
+ */
+public class EndpointGroupingRule {
+    private Map<String, StringFormatGroup> rules = new HashMap<>();
+
+    /**
+     * Add a new rule to the context.
+     *
+     * @param serviceName       of the new rule
+     * @param endpointGroupName represents the logic endpoint name.
+     * @param ruleRegex         match the endpoints which should be in the group name.
+     */
+    void addRule(String serviceName, String endpointGroupName, String ruleRegex) {
+        if (rules.containsKey(serviceName)) {
+            rules.get(serviceName).addRule(endpointGroupName, ruleRegex);
+        } else {
+            StringFormatGroup newGroup = new StringFormatGroup();
+            newGroup.addRule(endpointGroupName, ruleRegex);
+            rules.put(serviceName, newGroup);
+        }
+    }
+
+    /**
+     * @param service      of the given endpoint belonged.
+     * @param endpointName to do group checking.
+     * @return group result and new endpoint name if rule matched.
+     */
+    public StringFormatGroup.FormatResult format(String service, String endpointName) {
+        final StringFormatGroup stringFormatGroup = rules.get(service);
+        if (stringFormatGroup != null) {
+            return stringFormatGroup.format(endpointName);
+        } else {
+            return new StringFormatGroup.FormatResult(false, endpointName, endpointName);
+        }
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRuleReader.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRuleReader.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.config.group;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.skywalking.apm.util.StringUtil;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Read the input stream including the default endpoint grouping rules. And trans
+ */
+public class EndpointGroupingRuleReader {
+    private Map yamlData;
+
+    public EndpointGroupingRuleReader(InputStream inputStream) {
+        Yaml yaml = new Yaml();
+        yamlData = yaml.loadAs(inputStream, Map.class);
+    }
+
+    public EndpointGroupingRuleReader(Reader io) {
+        Yaml yaml = new Yaml();
+        yamlData = yaml.loadAs(io, Map.class);
+    }
+
+    /**
+     * @return the loaded rules.
+     */
+    EndpointGroupingRule read() {
+        EndpointGroupingRule endpointGroupingRule = new EndpointGroupingRule();
+
+        if (Objects.nonNull(yamlData)) {
+            List rulesData = (List) yamlData.get("grouping");
+            if (rulesData != null) {
+                rulesData.forEach(ruleObj -> {
+                    final Map rule = (Map) ruleObj;
+                    final String serviceName = (String) rule.get("service-name");
+                    if (StringUtil.isEmpty(serviceName)) {
+                        throw new IllegalArgumentException("service-name can't be empty");
+                    }
+                    final List endpointRules = (List) rule.get("rules");
+                    if (endpointRules != null) {
+                        endpointRules.forEach(endpointRuleObj -> {
+                            final Map endpointRule = (Map) endpointRuleObj;
+                            final String endpointLogicGroupName = (String) endpointRule.get("endpoint-name");
+                            final String groupRegex = (String) endpointRule.get("regex");
+                            if (StringUtil.isEmpty(endpointLogicGroupName) || StringUtil.isEmpty(groupRegex)) {
+                                return;
+                            }
+                            endpointGroupingRule.addRule(serviceName, endpointLogicGroupName, groupRegex);
+                        });
+                    }
+                });
+            }
+        }
+
+        return endpointGroupingRule;
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGrouping.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGrouping.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.config.group;
+
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.skywalking.apm.util.StringFormatGroup;
+
+@Slf4j
+public class EndpointNameGrouping {
+    @Setter
+    private volatile EndpointGroupingRule endpointGroupingRule;
+
+    public String format(String serviceName, String endpointName) {
+        if (endpointGroupingRule == null) {
+            return endpointName;
+        }
+        final StringFormatGroup.FormatResult formatResult = endpointGroupingRule.format(serviceName, endpointName);
+        if (log.isDebugEnabled() || log.isTraceEnabled()) {
+            if (formatResult.isMatch()) {
+                log.debug("Endpoint {} of Service {} has been renamed in group {}",
+                          endpointName, serviceName, formatResult.getName()
+                );
+            } else {
+                log.trace("Endpoint {} of Service {} keeps unchanged.", endpointName, serviceName);
+            }
+        }
+        return formatResult.getName();
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGroupingRuleWatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGroupingRuleWatcher.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.config.group;
+
+import java.io.FileNotFoundException;
+import java.io.StringReader;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.skywalking.oap.server.configuration.api.ConfigChangeWatcher;
+import org.apache.skywalking.oap.server.library.module.ModuleProvider;
+import org.apache.skywalking.oap.server.library.util.ResourceUtils;
+
+/**
+ * The config change watcher for endpoint name grouping rule.
+ */
+@Slf4j
+public class EndpointNameGroupingRuleWatcher extends ConfigChangeWatcher {
+    private final EndpointNameGrouping grouping;
+    private volatile String ruleSetting;
+
+    public EndpointNameGroupingRuleWatcher(ModuleProvider provider,
+                                           EndpointNameGrouping grouping) throws FileNotFoundException {
+        super(provider.module().getName(), provider, "endpoint-name-grouping");
+        this.grouping = grouping;
+        // This is just a place holder text representing the original text.
+        ruleSetting = "SkyWalking endpoint rule";
+        grouping.setEndpointGroupingRule(new EndpointGroupingRuleReader(
+            ResourceUtils.read("endpoint_name_grouping.yml")).read());
+    }
+
+    @Override
+    public void notify(final ConfigChangeEvent value) {
+        if (value.getEventType().equals(EventType.DELETE)) {
+            ruleSetting = "";
+            grouping.setEndpointGroupingRule(new EndpointGroupingRule());
+        } else {
+            ruleSetting = value.getNewValue();
+            grouping.setEndpointGroupingRule(new EndpointGroupingRuleReader(new StringReader(ruleSetting)).read());
+        }
+    }
+
+    @Override
+    public String value() {
+        return ruleSetting;
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/StringFormatGroup.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/StringFormatGroup.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.config.group;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/**
+ * Group patterns use {@link java.util.regex.Pattern} as core, could group the input strings to matched group or return
+ * original string.
+ */
+@ToString
+public class StringFormatGroup {
+    private final List<PatternRule> rules;
+
+    public StringFormatGroup() {
+        rules = new ArrayList<>();
+    }
+
+    /**
+     * Add a new match rule. The rule will follow the order of being added.
+     *
+     * @param name      will be used when ruleRegex matched.
+     * @param ruleRegex to match target string.
+     */
+    public void addRule(String name, String ruleRegex) {
+        for (PatternRule rule : rules) {
+            if (rule.name.equals(name)) {
+                return;
+            }
+        }
+        PatternRule rule = new PatternRule(name, ruleRegex);
+        rules.add(rule);
+    }
+
+    /**
+     * Format the string based on rules.
+     *
+     * @param string to be formatted
+     * @return matched rule name, or original string.
+     */
+    public StringFormatGroup.FormatResult format(String string) {
+        for (PatternRule rule : rules) {
+            if (rule.getPattern().matcher(string).matches()) {
+                return new FormatResult(true, rule.getName());
+            }
+        }
+        return new FormatResult(false, string);
+    }
+
+    @Override
+    public String toString() {
+        return "StringFormatGroup{" +
+            "rules=" + rules +
+            '}';
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    public static class FormatResult {
+        private final boolean match;
+        private final String name;
+    }
+
+    @Getter
+    @ToString
+    private static class PatternRule {
+        private String name;
+        private Pattern pattern;
+
+        private PatternRule(String name, String ruleRegex) {
+            this.name = name;
+            pattern = Pattern.compile(ruleRegex);
+        }
+    }
+}

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRuleReaderTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRuleReaderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.config.group;
+
+import org.apache.skywalking.apm.util.StringFormatGroup;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EndpointGroupingRuleReaderTest {
+    @Test
+    public void testReadingRule() {
+        EndpointGroupingRuleReader reader = new EndpointGroupingRuleReader(this.getClass()
+                                                                               .getClassLoader()
+                                                                               .getResourceAsStream(
+                                                                                   "endpoint_name_grouping.yml"));
+        final EndpointGroupingRule rule = reader.read();
+
+        StringFormatGroup.FormatResult formatResult = rule.format("serviceA", "/prod/123");
+        Assert.assertTrue(formatResult.isMatch());
+        Assert.assertEquals("/prod/{id}", formatResult.getName());
+
+        formatResult = rule.format("serviceA", "/prod/");
+        Assert.assertFalse(formatResult.isMatch());
+
+        formatResult = rule.format("serviceB", "/prod/123");
+        Assert.assertFalse(formatResult.isMatch());
+    }
+}

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGroupingRuleWatcherTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGroupingRuleWatcherTest.java
@@ -107,5 +107,8 @@ public class EndpointNameGroupingRuleWatcherTest {
         ));
 
         Assert.assertEquals("/prod/order-id", endpointNameGrouping.format("serviceA", "/prod/123"));
+
+        watcher.notify(new ConfigChangeWatcher.ConfigChangeEvent("", ConfigChangeWatcher.EventType.DELETE));
+        Assert.assertEquals("/prod/123", endpointNameGrouping.format("serviceA", "/prod/123"));
     }
 }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGroupingRuleWatcherTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGroupingRuleWatcherTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.config.group;
+
+import java.io.FileNotFoundException;
+import org.apache.skywalking.oap.server.configuration.api.ConfigChangeWatcher;
+import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.library.module.ModuleConfig;
+import org.apache.skywalking.oap.server.library.module.ModuleDefine;
+import org.apache.skywalking.oap.server.library.module.ModuleProvider;
+import org.apache.skywalking.oap.server.library.module.ModuleStartException;
+import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EndpointNameGroupingRuleWatcherTest {
+    @Test
+    public void testWatcher() throws FileNotFoundException {
+        EndpointNameGrouping endpointNameGrouping = new EndpointNameGrouping();
+
+        EndpointNameGroupingRuleWatcher watcher = new EndpointNameGroupingRuleWatcher(
+            new ModuleProvider() {
+                @Override
+                public String name() {
+                    return "test";
+                }
+
+                @Override
+                public Class<? extends ModuleDefine> module() {
+                    return CoreModule.class;
+                }
+
+                @Override
+                public ModuleConfig createConfigBeanIfAbsent() {
+                    return null;
+                }
+
+                @Override
+                public void prepare() throws ServiceNotProvidedException, ModuleStartException {
+
+                }
+
+                @Override
+                public void start() throws ServiceNotProvidedException, ModuleStartException {
+
+                }
+
+                @Override
+                public void notifyAfterCompleted() throws ServiceNotProvidedException, ModuleStartException {
+
+                }
+
+                @Override
+                public String[] requiredModules() {
+                    return new String[0];
+                }
+            }, endpointNameGrouping);
+        Assert.assertEquals("/prod/{id}", endpointNameGrouping.format("serviceA", "/prod/123"));
+
+        watcher.notify(new ConfigChangeWatcher.ConfigChangeEvent(
+            "# Licensed to the Apache Software Foundation (ASF) under one or more\n" +
+                "# contributor license agreements.  See the NOTICE file distributed with\n" +
+                "# this work for additional information regarding copyright ownership.\n" +
+                "# The ASF licenses this file to You under the Apache License, Version 2.0\n" +
+                "# (the \"License\"); you may not use this file except in compliance with\n" +
+                "# the License.  You may obtain a copy of the License at\n" +
+                "#\n" +
+                "#     http://www.apache.org/licenses/LICENSE-2.0\n" +
+                "#\n" +
+                "# Unless required by applicable law or agreed to in writing, software\n" +
+                "# distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                "# See the License for the specific language governing permissions and\n" +
+                "# limitations under the License.\n" +
+                "\n" +
+                "# Endpoint name grouping rules.\n" +
+                "# In most cased, endpoint name should be detected by agents or service mesh automatically, and aggregate the metrics based\n" +
+                "# on the name.\n" +
+                "# But, in some cases, application put the parameter in the endpoint name, such as putting order id in the URI, like\n" +
+                "# /prod/ORDER123, /prod/ORDER123.\n" +
+                "# This grouping file provides the regex based definition capability to merge those endpoints into a group by better and\n" +
+                "# more meaningful aggregation metrics.\n" +
+                "\n" +
+                "grouping:\n" +
+                "  # Endpoint of the service would follow the following rules\n" +
+                "  - service-name: serviceA\n" +
+                "    rules:\n" +
+                "      - endpoint-name: /prod/order-id\n" +
+                "        regex: \\/prod\\/.+"
+            , ConfigChangeWatcher.EventType.MODIFY
+        ));
+
+        Assert.assertEquals("/prod/order-id", endpointNameGrouping.format("serviceA", "/prod/123"));
+    }
+}

--- a/oap-server/server-core/src/test/resources/endpoint_name_grouping.yml
+++ b/oap-server/server-core/src/test/resources/endpoint_name_grouping.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Endpoint name grouping rules.
+# In most cased, endpoint name should be detected by agents or service mesh automatically, and aggregate the metrics based
+# on the name.
+# But, in some cases, application puts the parameter in the endpoint name, such as putting order id in the URI, like
+# /prod/ORDER123, /prod/ORDER456.
+# This grouping file provides the regex based definition capability to merge those endpoints into a group by better and
+# more meaningful aggregation metrics.
+
+grouping:
+  # Endpoint of the service would follow the following rules
+  - service-name: serviceA
+    rules:
+      - endpoint-name: /prod/{id}
+        regex: \/prod\/.+

--- a/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/clr/provider/handler/CLRMetricReportServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-clr-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/clr/provider/handler/CLRMetricReportServiceHandler.java
@@ -25,20 +25,20 @@ import org.apache.skywalking.apm.network.language.agent.v3.CLRMetricCollection;
 import org.apache.skywalking.apm.network.language.agent.v3.CLRMetricReportServiceGrpc;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.server.grpc.GRPCHandler;
 
 @Slf4j
 public class CLRMetricReportServiceHandler extends CLRMetricReportServiceGrpc.CLRMetricReportServiceImplBase implements GRPCHandler {
     private final CLRSourceDispatcher clrSourceDispatcher;
-    private final NamingLengthControl namingLengthControl;
+    private final NamingControl namingControl;
 
     public CLRMetricReportServiceHandler(ModuleManager moduleManager) {
         clrSourceDispatcher = new CLRSourceDispatcher(moduleManager);
-        this.namingLengthControl = moduleManager.find(CoreModule.NAME)
-                                                .provider()
-                                                .getService(NamingLengthControl.class);
+        this.namingControl = moduleManager.find(CoreModule.NAME)
+                                          .provider()
+                                          .getService(NamingControl.class);
     }
 
     @Override
@@ -48,8 +48,8 @@ public class CLRMetricReportServiceHandler extends CLRMetricReportServiceGrpc.CL
         }
 
         final CLRMetricCollection.Builder builder = request.toBuilder();
-        builder.setService(namingLengthControl.formatServiceName(builder.getService()));
-        builder.setServiceInstance(namingLengthControl.formatInstanceName(builder.getServiceInstance()));
+        builder.setService(namingControl.formatServiceName(builder.getService()));
+        builder.setServiceInstance(namingControl.formatInstanceName(builder.getServiceInstance()));
 
         request.getMetricsList().forEach(metrics -> {
             long minuteTimeBucket = TimeBucket.getMinuteTimeBucket(metrics.getTime());

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMMetricReportServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMMetricReportServiceHandler.java
@@ -24,20 +24,20 @@ import org.apache.skywalking.apm.network.common.v3.Commands;
 import org.apache.skywalking.apm.network.language.agent.v3.JVMMetricCollection;
 import org.apache.skywalking.apm.network.language.agent.v3.JVMMetricReportServiceGrpc;
 import org.apache.skywalking.oap.server.core.CoreModule;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.server.grpc.GRPCHandler;
 
 @Slf4j
 public class JVMMetricReportServiceHandler extends JVMMetricReportServiceGrpc.JVMMetricReportServiceImplBase implements GRPCHandler {
     private final JVMSourceDispatcher jvmSourceDispatcher;
-    private final NamingLengthControl namingLengthControl;
+    private final NamingControl namingControl;
 
     public JVMMetricReportServiceHandler(ModuleManager moduleManager) {
         this.jvmSourceDispatcher = new JVMSourceDispatcher(moduleManager);
-        this.namingLengthControl = moduleManager.find(CoreModule.NAME)
-                                                .provider()
-                                                .getService(NamingLengthControl.class);
+        this.namingControl = moduleManager.find(CoreModule.NAME)
+                                          .provider()
+                                          .getService(NamingControl.class);
     }
 
     @Override
@@ -50,8 +50,8 @@ public class JVMMetricReportServiceHandler extends JVMMetricReportServiceGrpc.JV
             );
         }
         final JVMMetricCollection.Builder builder = request.toBuilder();
-        builder.setService(namingLengthControl.formatServiceName(builder.getService()));
-        builder.setServiceInstance(namingLengthControl.formatInstanceName(builder.getServiceInstance()));
+        builder.setService(namingControl.formatServiceName(builder.getService()));
+        builder.setServiceInstance(namingControl.formatInstanceName(builder.getServiceInstance()));
 
         builder.getMetricsList().forEach(jvmMetric -> {
             jvmSourceDispatcher.sendMetric(builder.getService(), builder.getServiceInstance(), jvmMetric);

--- a/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/grpc/ManagementServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/grpc/ManagementServiceHandler.java
@@ -33,7 +33,7 @@ import org.apache.skywalking.oap.server.core.analysis.IDManager;
 import org.apache.skywalking.oap.server.core.analysis.NodeType;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.analysis.manual.instance.InstanceTraffic;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.core.source.ServiceInstanceUpdate;
 import org.apache.skywalking.oap.server.core.source.ServiceMeta;
 import org.apache.skywalking.oap.server.core.source.SourceReceiver;
@@ -42,21 +42,21 @@ import org.apache.skywalking.oap.server.library.server.grpc.GRPCHandler;
 
 public class ManagementServiceHandler extends ManagementServiceGrpc.ManagementServiceImplBase implements GRPCHandler {
     private final SourceReceiver sourceReceiver;
-    private final NamingLengthControl namingLengthControl;
+    private final NamingControl namingControl;
 
     public ManagementServiceHandler(ModuleManager moduleManager) {
         this.sourceReceiver = moduleManager.find(CoreModule.NAME).provider().getService(SourceReceiver.class);
-        this.namingLengthControl = moduleManager.find(CoreModule.NAME)
-                                                .provider()
-                                                .getService(NamingLengthControl.class);
+        this.namingControl = moduleManager.find(CoreModule.NAME)
+                                          .provider()
+                                          .getService(NamingControl.class);
     }
 
     @Override
     public void reportInstanceProperties(final InstanceProperties request,
                                          final StreamObserver<Commands> responseObserver) {
         ServiceInstanceUpdate serviceInstanceUpdate = new ServiceInstanceUpdate();
-        final String serviceName = namingLengthControl.formatServiceName(request.getService());
-        final String instanceName = namingLengthControl.formatInstanceName(request.getServiceInstance());
+        final String serviceName = namingControl.formatServiceName(request.getService());
+        final String instanceName = namingControl.formatInstanceName(request.getServiceInstance());
         serviceInstanceUpdate.setServiceId(IDManager.ServiceID.buildId(serviceName, NodeType.Normal));
         serviceInstanceUpdate.setName(instanceName);
 
@@ -82,8 +82,8 @@ public class ManagementServiceHandler extends ManagementServiceGrpc.ManagementSe
     @Override
     public void keepAlive(final InstancePingPkg request, final StreamObserver<Commands> responseObserver) {
         final long timeBucket = TimeBucket.getTimeBucket(System.currentTimeMillis(), DownSampling.Minute);
-        final String serviceName = namingLengthControl.formatServiceName(request.getService());
-        final String instanceName = namingLengthControl.formatInstanceName(request.getServiceInstance());
+        final String serviceName = namingControl.formatServiceName(request.getService());
+        final String instanceName = namingControl.formatInstanceName(request.getServiceInstance());
 
         ServiceInstanceUpdate serviceInstanceUpdate = new ServiceInstanceUpdate();
         serviceInstanceUpdate.setServiceId(IDManager.ServiceID.buildId(serviceName, NodeType.Normal));

--- a/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/rest/ManagementServiceKeepAliveHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/rest/ManagementServiceKeepAliveHandler.java
@@ -29,7 +29,7 @@ import org.apache.skywalking.oap.server.core.analysis.DownSampling;
 import org.apache.skywalking.oap.server.core.analysis.IDManager;
 import org.apache.skywalking.oap.server.core.analysis.NodeType;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.core.source.ServiceInstanceUpdate;
 import org.apache.skywalking.oap.server.core.source.ServiceMeta;
 import org.apache.skywalking.oap.server.core.source.SourceReceiver;
@@ -40,14 +40,14 @@ import org.apache.skywalking.oap.server.library.util.ProtoBufJsonUtils;
 
 public class ManagementServiceKeepAliveHandler extends JettyJsonHandler {
     private final SourceReceiver sourceReceiver;
-    private final NamingLengthControl namingLengthControl;
+    private final NamingControl namingControl;
     private final Gson gson = new Gson();
 
     public ManagementServiceKeepAliveHandler(ModuleManager moduleManager) {
         this.sourceReceiver = moduleManager.find(CoreModule.NAME).provider().getService(SourceReceiver.class);
-        this.namingLengthControl = moduleManager.find(CoreModule.NAME)
-                                                .provider()
-                                                .getService(NamingLengthControl.class);
+        this.namingControl = moduleManager.find(CoreModule.NAME)
+                                          .provider()
+                                          .getService(NamingControl.class);
     }
 
     @Override
@@ -60,8 +60,8 @@ public class ManagementServiceKeepAliveHandler extends JettyJsonHandler {
         final InstanceProperties.Builder request = InstanceProperties.newBuilder();
         ProtoBufJsonUtils.fromJSON(getJsonBody(req), request);
 
-        final String serviceName = namingLengthControl.formatServiceName(request.getService());
-        final String instanceName = namingLengthControl.formatInstanceName(request.getServiceInstance());
+        final String serviceName = namingControl.formatServiceName(request.getService());
+        final String instanceName = namingControl.formatInstanceName(request.getServiceInstance());
 
         final long timeBucket = TimeBucket.getTimeBucket(System.currentTimeMillis(), DownSampling.Minute);
         ServiceInstanceUpdate serviceInstanceUpdate = new ServiceInstanceUpdate();

--- a/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/rest/ManagementServiceReportPropertiesHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/rest/ManagementServiceReportPropertiesHandler.java
@@ -34,7 +34,7 @@ import org.apache.skywalking.oap.server.core.analysis.IDManager;
 import org.apache.skywalking.oap.server.core.analysis.NodeType;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.analysis.manual.instance.InstanceTraffic;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.core.source.ServiceInstanceUpdate;
 import org.apache.skywalking.oap.server.core.source.SourceReceiver;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
@@ -44,14 +44,14 @@ import org.apache.skywalking.oap.server.library.util.ProtoBufJsonUtils;
 
 public class ManagementServiceReportPropertiesHandler extends JettyJsonHandler {
     private final SourceReceiver sourceReceiver;
-    private final NamingLengthControl namingLengthControl;
+    private final NamingControl namingControl;
     private final Gson gson = new Gson();
 
     public ManagementServiceReportPropertiesHandler(ModuleManager moduleManager) {
         this.sourceReceiver = moduleManager.find(CoreModule.NAME).provider().getService(SourceReceiver.class);
-        this.namingLengthControl = moduleManager.find(CoreModule.NAME)
-                                                .provider()
-                                                .getService(NamingLengthControl.class);
+        this.namingControl = moduleManager.find(CoreModule.NAME)
+                                          .provider()
+                                          .getService(NamingControl.class);
     }
 
     @Override
@@ -64,8 +64,8 @@ public class ManagementServiceReportPropertiesHandler extends JettyJsonHandler {
         final InstanceProperties.Builder request = InstanceProperties.newBuilder();
         ProtoBufJsonUtils.fromJSON(getJsonBody(req), request);
 
-        final String serviceName = namingLengthControl.formatServiceName(request.getService());
-        final String instanceName = namingLengthControl.formatInstanceName(request.getServiceInstance());
+        final String serviceName = namingControl.formatServiceName(request.getService());
+        final String instanceName = namingControl.formatInstanceName(request.getServiceInstance());
 
         ServiceInstanceUpdate serviceInstanceUpdate = new ServiceInstanceUpdate();
         serviceInstanceUpdate.setServiceId(IDManager.ServiceID.buildId(serviceName, NodeType.Normal));

--- a/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/TelemetryDataDispatcher.java
+++ b/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/TelemetryDataDispatcher.java
@@ -26,7 +26,7 @@ import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.IDManager;
 import org.apache.skywalking.oap.server.core.analysis.NodeType;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.core.source.All;
 import org.apache.skywalking.oap.server.core.source.DetectPoint;
 import org.apache.skywalking.oap.server.core.source.Endpoint;
@@ -50,7 +50,7 @@ import org.apache.skywalking.oap.server.telemetry.api.MetricsTag;
 @Slf4j
 public class TelemetryDataDispatcher {
     private static SourceReceiver SOURCE_RECEIVER;
-    private static NamingLengthControl NAME_LENGTH_CONTROL;
+    private static NamingControl NAME_LENGTH_CONTROL;
     private static HistogramMetrics MESH_ANALYSIS_METRICS;
 
     private TelemetryDataDispatcher() {
@@ -63,7 +63,7 @@ public class TelemetryDataDispatcher {
                                                      .getService(MetricsCreator.class);
         NAME_LENGTH_CONTROL = moduleManager.find(CoreModule.NAME)
                                            .provider()
-                                           .getService(NamingLengthControl.class);
+                                           .getService(NamingControl.class);
         MESH_ANALYSIS_METRICS = metricsCreator.createHistogramMetric(
             "mesh_analysis_latency", "The process latency of service mesh telemetry", MetricsTag.EMPTY_KEY,
             MetricsTag.EMPTY_VALUE
@@ -86,7 +86,7 @@ public class TelemetryDataDispatcher {
                 data.setDestServiceInstance(NAME_LENGTH_CONTROL.formatInstanceName(data.getDestServiceInstance()));
             }
             if (data.getEndpoint() != null) {
-                data.setEndpoint(NAME_LENGTH_CONTROL.formatEndpointName(data.getEndpoint()));
+                data.setEndpoint(NAME_LENGTH_CONTROL.formatEndpointName(data.getDestServiceName(), data.getEndpoint()));
             }
 
             doDispatch(data);

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
@@ -35,7 +35,7 @@ import org.apache.skywalking.oap.server.core.analysis.NodeType;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.analysis.manual.networkalias.NetworkAddressAlias;
 import org.apache.skywalking.oap.server.core.cache.NetworkAddressAliasCache;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.core.source.DatabaseSlowStatement;
 import org.apache.skywalking.oap.server.core.source.DetectPoint;
 import org.apache.skywalking.oap.server.core.source.EndpointRelation;
@@ -61,7 +61,7 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
     private final SourceReceiver sourceReceiver;
     private final TraceServiceModuleConfig config;
     private final NetworkAddressAliasCache networkAddressAliasCache;
-    private final NamingLengthControl namingLengthControl;
+    private final NamingControl namingControl;
 
     @Override
     public boolean containsPoint(Point point) {
@@ -87,7 +87,7 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
         if (span.getRefsCount() > 0) {
             for (int i = 0; i < span.getRefsCount(); i++) {
                 SegmentReference reference = span.getRefs(i);
-                SourceBuilder sourceBuilder = new SourceBuilder(namingLengthControl);
+                SourceBuilder sourceBuilder = new SourceBuilder(namingControl);
 
                 if (StringUtil.isEmpty(reference.getParentEndpoint())) {
                     sourceBuilder.setSourceEndpointName(Const.USER_ENDPOINT_NAME);
@@ -117,7 +117,7 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
                 entrySourceBuilders.add(sourceBuilder);
             }
         } else {
-            SourceBuilder sourceBuilder = new SourceBuilder(namingLengthControl);
+            SourceBuilder sourceBuilder = new SourceBuilder(namingControl);
             sourceBuilder.setSourceServiceName(Const.USER_SERVICE_NAME);
             sourceBuilder.setSourceServiceInstanceName(Const.USER_INSTANCE_NAME);
             sourceBuilder.setSourceEndpointName(Const.USER_ENDPOINT_NAME);
@@ -144,7 +144,7 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
             return;
         }
 
-        SourceBuilder sourceBuilder = new SourceBuilder(namingLengthControl);
+        SourceBuilder sourceBuilder = new SourceBuilder(namingControl);
 
         final String networkAddress = span.getPeer();
         if (StringUtil.isEmpty(networkAddress)) {
@@ -297,22 +297,22 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
     public static class Factory implements AnalysisListenerFactory {
         private final SourceReceiver sourceReceiver;
         private final NetworkAddressAliasCache networkAddressAliasCache;
-        private final NamingLengthControl namingLengthControl;
+        private final NamingControl namingControl;
 
         public Factory(ModuleManager moduleManager) {
             this.sourceReceiver = moduleManager.find(CoreModule.NAME).provider().getService(SourceReceiver.class);
             this.networkAddressAliasCache = moduleManager.find(CoreModule.NAME)
                                                          .provider()
                                                          .getService(NetworkAddressAliasCache.class);
-            this.namingLengthControl = moduleManager.find(CoreModule.NAME)
-                                                    .provider()
-                                                    .getService(NamingLengthControl.class);
+            this.namingControl = moduleManager.find(CoreModule.NAME)
+                                              .provider()
+                                              .getService(NamingControl.class);
         }
 
         @Override
         public AnalysisListener create(ModuleManager moduleManager, TraceServiceModuleConfig config) {
             return new MultiScopesAnalysisListener(
-                sourceReceiver, config, networkAddressAliasCache, namingLengthControl);
+                sourceReceiver, config, networkAddressAliasCache, namingControl);
         }
     }
 }

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/NetworkAddressAliasMappingListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/NetworkAddressAliasMappingListener.java
@@ -27,7 +27,7 @@ import org.apache.skywalking.apm.network.language.agent.v3.SpanObject;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.NodeType;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.core.source.NetworkAddressAliasSetup;
 import org.apache.skywalking.oap.server.core.source.SourceReceiver;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
@@ -46,7 +46,7 @@ import org.apache.skywalking.oap.server.receiver.trace.provider.TraceServiceModu
 public class NetworkAddressAliasMappingListener implements EntryAnalysisListener {
     private final SourceReceiver sourceReceiver;
     private final TraceServiceModuleConfig config;
-    private final NamingLengthControl namingLengthControl;
+    private final NamingControl namingControl;
 
     @Override
     public void parseEntry(SpanObject span, SegmentObject segmentObject) {
@@ -59,7 +59,7 @@ public class NetworkAddressAliasMappingListener implements EntryAnalysisListener
         if (!span.getSpanLayer().equals(SpanLayer.MQ)) {
             span.getRefsList().forEach(segmentReference -> {
                 if (RefType.CrossProcess.equals(segmentReference.getRefType())) {
-                    final String networkAddressUsedAtPeer = namingLengthControl.formatServiceName(
+                    final String networkAddressUsedAtPeer = namingControl.formatServiceName(
                         segmentReference.getNetworkAddressUsedAtPeer());
                     if (config.getUninstrumentedGatewaysConfig().isAddressConfiguredAsGateway(
                         networkAddressUsedAtPeer)) {
@@ -68,8 +68,8 @@ public class NetworkAddressAliasMappingListener implements EntryAnalysisListener
                          */
                         return;
                     }
-                    final String serviceName = namingLengthControl.formatServiceName(segmentObject.getService());
-                    final String instanceName = namingLengthControl.formatInstanceName(
+                    final String serviceName = namingControl.formatServiceName(segmentObject.getService());
+                    final String instanceName = namingControl.formatInstanceName(
                         segmentObject.getServiceInstance());
 
                     final NetworkAddressAliasSetup networkAddressAliasSetup = new NetworkAddressAliasSetup();
@@ -97,18 +97,18 @@ public class NetworkAddressAliasMappingListener implements EntryAnalysisListener
 
     public static class Factory implements AnalysisListenerFactory {
         private final SourceReceiver sourceReceiver;
-        private final NamingLengthControl namingLengthControl;
+        private final NamingControl namingControl;
 
         public Factory(ModuleManager moduleManager) {
             this.sourceReceiver = moduleManager.find(CoreModule.NAME).provider().getService(SourceReceiver.class);
-            this.namingLengthControl = moduleManager.find(CoreModule.NAME)
-                                                    .provider()
-                                                    .getService(NamingLengthControl.class);
+            this.namingControl = moduleManager.find(CoreModule.NAME)
+                                              .provider()
+                                              .getService(NamingControl.class);
         }
 
         @Override
         public AnalysisListener create(ModuleManager moduleManager, TraceServiceModuleConfig config) {
-            return new NetworkAddressAliasMappingListener(sourceReceiver, config, namingLengthControl);
+            return new NetworkAddressAliasMappingListener(sourceReceiver, config, namingControl);
         }
     }
 }

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/SegmentAnalysisListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/SegmentAnalysisListener.java
@@ -28,7 +28,7 @@ import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.IDManager;
 import org.apache.skywalking.oap.server.core.analysis.NodeType;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.core.source.Segment;
 import org.apache.skywalking.oap.server.core.source.SourceReceiver;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
@@ -43,10 +43,11 @@ import org.apache.skywalking.oap.server.receiver.trace.provider.TraceServiceModu
 public class SegmentAnalysisListener implements FirstAnalysisListener, EntryAnalysisListener, SegmentListener {
     private final SourceReceiver sourceReceiver;
     private final TraceSegmentSampler sampler;
-    private final NamingLengthControl namingLengthControl;
+    private final NamingControl namingControl;
 
     private final Segment segment = new Segment();
     private SAMPLE_STATUS sampleStatus = SAMPLE_STATUS.UNKNOWN;
+    private String serviceName = Const.EMPTY_STRING;
     private String serviceId = Const.EMPTY_STRING;
     private String endpointId = Const.EMPTY_STRING;
     private String endpointName = Const.EMPTY_STRING;
@@ -67,8 +68,9 @@ public class SegmentAnalysisListener implements FirstAnalysisListener, EntryAnal
         }
 
         if (StringUtil.isEmpty(serviceId)) {
+            serviceName = namingControl.formatServiceName(segmentObject.getService());
             serviceId = IDManager.ServiceID.buildId(
-                namingLengthControl.formatServiceName(segmentObject.getService()),
+                serviceName,
                 NodeType.Normal
             );
         }
@@ -79,7 +81,7 @@ public class SegmentAnalysisListener implements FirstAnalysisListener, EntryAnal
         segment.setServiceId(serviceId);
         segment.setServiceInstanceId(IDManager.ServiceInstanceID.buildId(
             serviceId,
-            namingLengthControl.formatInstanceName(segmentObject.getServiceInstance())
+            namingControl.formatInstanceName(segmentObject.getServiceInstance())
         ));
         segment.setLatency(duration);
         segment.setStartTime(startTimestamp);
@@ -89,7 +91,7 @@ public class SegmentAnalysisListener implements FirstAnalysisListener, EntryAnal
         segment.setDataBinary(segmentObject.toByteArray());
         segment.setVersion(3);
 
-        endpointName = namingLengthControl.formatEndpointName(span.getOperationName());
+        endpointName = namingControl.formatEndpointName(serviceName, span.getOperationName());
         endpointId = IDManager.EndpointID.buildId(
             serviceId,
             endpointName
@@ -100,8 +102,9 @@ public class SegmentAnalysisListener implements FirstAnalysisListener, EntryAnal
     @Override
     public void parseEntry(SpanObject span, SegmentObject segmentObject) {
         if (StringUtil.isEmpty(serviceId)) {
+            serviceName = namingControl.formatServiceName(segmentObject.getService());
             serviceId = IDManager.ServiceID.buildId(
-                segmentObject.getService(), NodeType.fromSpanLayerValue(span.getSpanLayer()));
+                serviceName, NodeType.fromSpanLayerValue(span.getSpanLayer()));
         }
 
         endpointId = IDManager.EndpointID.buildId(
@@ -109,7 +112,7 @@ public class SegmentAnalysisListener implements FirstAnalysisListener, EntryAnal
             span.getOperationName()
         );
 
-        endpointName = namingLengthControl.formatEndpointName(span.getOperationName());
+        endpointName = namingControl.formatEndpointName(serviceName, span.getOperationName());
         endpointId = IDManager.EndpointID.buildId(
             serviceId,
             endpointName
@@ -169,19 +172,19 @@ public class SegmentAnalysisListener implements FirstAnalysisListener, EntryAnal
     public static class Factory implements AnalysisListenerFactory {
         private final SourceReceiver sourceReceiver;
         private final TraceSegmentSampler sampler;
-        private final NamingLengthControl namingLengthControl;
+        private final NamingControl namingControl;
 
         public Factory(ModuleManager moduleManager, TraceServiceModuleConfig config) {
             this.sourceReceiver = moduleManager.find(CoreModule.NAME).provider().getService(SourceReceiver.class);
             this.sampler = new TraceSegmentSampler(config.getSampleRate());
-            this.namingLengthControl = moduleManager.find(CoreModule.NAME)
-                                                    .provider()
-                                                    .getService(NamingLengthControl.class);
+            this.namingControl = moduleManager.find(CoreModule.NAME)
+                                              .provider()
+                                              .getService(NamingControl.class);
         }
 
         @Override
         public AnalysisListener create(ModuleManager moduleManager, TraceServiceModuleConfig config) {
-            return new SegmentAnalysisListener(sourceReceiver, sampler, namingLengthControl);
+            return new SegmentAnalysisListener(sourceReceiver, sampler, namingControl);
         }
     }
 }

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/SourceBuilder.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/SourceBuilder.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.apache.skywalking.apm.util.StringUtil;
 import org.apache.skywalking.oap.server.core.analysis.NodeType;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
 import org.apache.skywalking.oap.server.core.source.All;
 import org.apache.skywalking.oap.server.core.source.DatabaseAccess;
 import org.apache.skywalking.oap.server.core.source.DetectPoint;
@@ -38,13 +38,13 @@ import org.apache.skywalking.oap.server.core.source.ServiceRelation;
 
 @RequiredArgsConstructor
 class SourceBuilder {
-    private final NamingLengthControl namingLengthControl;
+    private final NamingControl namingControl;
 
     @Getter
     private String sourceServiceName;
 
     public void setSourceServiceName(final String sourceServiceName) {
-        this.sourceServiceName = namingLengthControl.formatServiceName(sourceServiceName);
+        this.sourceServiceName = namingControl.formatServiceName(sourceServiceName);
     }
 
     @Getter
@@ -54,21 +54,21 @@ class SourceBuilder {
     private String sourceServiceInstanceName;
 
     public void setSourceServiceInstanceName(final String sourceServiceInstanceName) {
-        this.sourceServiceInstanceName = namingLengthControl.formatInstanceName(sourceServiceInstanceName);
+        this.sourceServiceInstanceName = namingControl.formatInstanceName(sourceServiceInstanceName);
     }
 
     @Getter
     private String sourceEndpointName;
 
     public void setSourceEndpointName(final String sourceEndpointName) {
-        this.sourceEndpointName = namingLengthControl.formatEndpointName(sourceEndpointName);
+        this.sourceEndpointName = namingControl.formatEndpointName(sourceServiceName, sourceEndpointName);
     }
 
     @Getter
     private String destServiceName;
 
     public void setDestServiceName(final String destServiceName) {
-        this.destServiceName = namingLengthControl.formatServiceName(destServiceName);
+        this.destServiceName = namingControl.formatServiceName(destServiceName);
     }
 
     @Getter
@@ -78,14 +78,14 @@ class SourceBuilder {
     private String destServiceInstanceName;
 
     public void setDestServiceInstanceName(final String destServiceInstanceName) {
-        this.destServiceInstanceName = namingLengthControl.formatServiceName(destServiceInstanceName);
+        this.destServiceInstanceName = namingControl.formatServiceName(destServiceInstanceName);
     }
 
     @Getter
     private String destEndpointName;
 
     public void setDestEndpointName(final String destEndpointName) {
-        this.destEndpointName = namingLengthControl.formatEndpointName(destEndpointName);
+        this.destEndpointName = namingControl.formatEndpointName(destServiceName, destEndpointName);
     }
 
     @Getter

--- a/oap-server/server-tools/profile-exporter/tool-profile-snapshot-server-mock/src/main/java/org/apache/skywalking/oap/server/tool/profile/core/MockCoreModuleProvider.java
+++ b/oap-server/server-tools/profile-exporter/tool-profile-snapshot-server-mock/src/main/java/org/apache/skywalking/oap/server/tool/profile/core/MockCoreModuleProvider.java
@@ -31,7 +31,8 @@ import org.apache.skywalking.oap.server.core.command.CommandService;
 import org.apache.skywalking.oap.server.core.config.ConfigService;
 import org.apache.skywalking.oap.server.core.config.DownSamplingConfigService;
 import org.apache.skywalking.oap.server.core.config.IComponentLibraryCatalogService;
-import org.apache.skywalking.oap.server.core.config.NamingLengthControl;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
+import org.apache.skywalking.oap.server.core.config.group.EndpointNameGrouping;
 import org.apache.skywalking.oap.server.core.oal.rt.OALEngineLoaderService;
 import org.apache.skywalking.oap.server.core.profile.ProfileTaskMutationService;
 import org.apache.skywalking.oap.server.core.query.AggregationQueryService;
@@ -97,7 +98,10 @@ public class MockCoreModuleProvider extends CoreModuleProvider {
 
     @Override
     public void prepare() throws ServiceNotProvidedException, ModuleStartException {
-        this.registerServiceImplementation(NamingLengthControl.class, new NamingLengthControl(50, 50, 150));
+        this.registerServiceImplementation(
+            NamingControl.class,
+            new NamingControl(50, 50, 150, new EndpointNameGrouping())
+        );
 
         MockStreamAnnotationListener streamAnnotationListener = new MockStreamAnnotationListener(getManager());
         annotationScan.registerListener(streamAnnotationListener);


### PR DESCRIPTION
# Group Parameterized Endpoints
In most cases, the endpoint should be detected automatically through the language agents, service mesh observability solution, or configuration of the meter system.

There are some special cases, especially when people use REST style URI, the application codes put the parameter in the endpoint name, such as putting order id in the URI, like `/prod/ORDER123` and `/prod/ORDER123`. But logically, people expect they could have an endpoint name like `prod/{order-id}`. This is the feature of parameterized endpoint grouping designed for.

Current, user could set up grouping rules through the static YAML file, named `endpoint_name_grouping.yml`, or use Dynamic Configuration to initial and update the endpoint grouping rule.

## Configuration Format
No matter in static local file or dynamic configuration value, they are sharing the same YAML format.

```yaml
grouping:
  # Endpoint of the service would follow the following rules
  - service-name: serviceA
    rules:
      # Logic name when the regex expression matched.
      - endpoint-name: /prod/{id}
        regex: \/prod\/.+
```