### PR TITLE
Fix docker-entrypoint.sh error

### DIFF
--- a/docker/oap/docker-entrypoint.sh
+++ b/docker/oap/docker-entrypoint.sh
@@ -28,7 +28,9 @@ EXT_LIB_DIR=/skywalking/ext-libs
 EXT_CONFIG_DIR=/skywalking/ext-config
 
 # Override configuration files
-cp -vfR ${EXT_CONFIG_DIR}/ config/
+if [ "$(ls -A $EXT_CONFIG_DIR)" ]; then
+  cp -vfR ${EXT_CONFIG_DIR}/* config/
+fi
 
 CLASSPATH="config:$CLASSPATH"
 for i in oap-libs/*.jar


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
`cp -vfR ${EXT_CONFIG_DIR}/ config/ ` 
1. empty ext dir will cause cp error
2. will copy the ext dir to config dir. 
- How to fix?
1. check dir is not empty
2. cp ext_dir/* 
___
### New feature or improvement
- Describe the details and related test reports.
