### PR TITLE
Fix too many mang ipv4 records reported by the agent when deployed in container.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
@@ -116,7 +116,7 @@ public class Config {
         /**
          * Limit the length of the ipv4 list size.
          */
-        public static int IPV4_LIST_SIZE = 5;
+        public static int IPV4_LIST_SIZE = 10;
     }
 
     public static class Collector {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
@@ -109,6 +109,14 @@ public class Config {
          * Keep tracing even the backend is not available.
          */
         public static boolean KEEP_TRACING = false;
+
+    }
+
+    public static class OsInfo {
+        /**
+         * Limit the length of the ipv4 list size.
+         */
+        public static int IPV4_LIST_SIZE = 5;
     }
 
     public static class Collector {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/os/OSUtil.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/os/OSUtil.java
@@ -57,7 +57,7 @@ public class OSUtil {
 
     public static List<String> getAllIPV4() {
         if (IPV4_LIST == null) {
-            IPV4_LIST = new LinkedList<String>();
+            IPV4_LIST = new LinkedList<>();
             try {
                 Enumeration<NetworkInterface> interfs = NetworkInterface.getNetworkInterfaces();
                 while (interfs.hasMoreElements()) {
@@ -103,8 +103,8 @@ public class OSUtil {
         return PROCESS_NO;
     }
 
-    public static List<KeyStringValuePair> buildOSInfo() {
-        List<KeyStringValuePair> osInfo = new ArrayList<KeyStringValuePair>();
+    public static List<KeyStringValuePair> buildOSInfo(int ipv4Size) {
+        List<KeyStringValuePair> osInfo = new ArrayList<>();
 
         String osName = getOsName();
         if (osName != null) {
@@ -116,6 +116,9 @@ public class OSUtil {
         }
         List<String> allIPV4 = getAllIPV4();
         if (allIPV4.size() > 0) {
+            if (allIPV4.size() >= ipv4Size) {
+                allIPV4.subList(0, ipv4Size);
+            }
             for (String ipv4 : allIPV4) {
                 osInfo.add(KeyStringValuePair.newBuilder().setKey("ipv4").setValue(ipv4).build());
             }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/os/OSUtil.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/os/OSUtil.java
@@ -116,8 +116,8 @@ public class OSUtil {
         }
         List<String> allIPV4 = getAllIPV4();
         if (allIPV4.size() > 0) {
-            if (allIPV4.size() >= ipv4Size) {
-                allIPV4.subList(0, ipv4Size);
+            if (allIPV4.size() > ipv4Size) {
+                allIPV4 = allIPV4.subList(0, ipv4Size);
             }
             for (String ipv4 : allIPV4) {
                 osInfo.add(KeyStringValuePair.newBuilder().setKey("ipv4").setValue(ipv4).build());

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/ServiceManagementClient.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/ServiceManagementClient.java
@@ -119,7 +119,8 @@ public class ServiceManagementClient implements BootService, Runnable, GRPCChann
                             .reportInstanceProperties(InstanceProperties.newBuilder()
                                                                         .setService(Config.Agent.SERVICE_NAME)
                                                                         .setServiceInstance(Config.Agent.INSTANCE_NAME)
-                                                                        .addAllProperties(OSUtil.buildOSInfo())
+                                                                        .addAllProperties(OSUtil.buildOSInfo(
+                                                                            Config.OsInfo.IPV4_LIST_SIZE))
                                                                         .addAllProperties(SERVICE_INSTANCE_PROPERTIES)
                                                                         .build());
                         instancePropertiesSubmitted = true;

--- a/docs/en/setup/service-agent/java-agent/README.md
+++ b/docs/en/setup/service-agent/java-agent/README.md
@@ -84,6 +84,7 @@ property key | Description | Default |
 `agent.force_reconnection_period `|Force reconnection period of grpc, based on grpc_channel_check_interval.|`1`|
 `agent.operation_name_threshold `|The operationName max length, setting this value > 190 is not recommended.|`150`|
 `agent.keep_tracing`|Keep tracing even the backend is not available if this value is `true`.|`false`|
+`osinfo.ipv4_list_size`| Limit the length of the ipv4 list size. |`5`|
 `collector.grpc_channel_check_interval`|grpc channel status check interval.|`30`|
 `collector.heartbeat_period`|agent heartbeat report period. Unit, second.|`30`|
 `collector.backend_service`|Collector SkyWalking trace receiver service addresses.|`127.0.0.1:11800`|

--- a/docs/en/setup/service-agent/java-agent/README.md
+++ b/docs/en/setup/service-agent/java-agent/README.md
@@ -84,7 +84,7 @@ property key | Description | Default |
 `agent.force_reconnection_period `|Force reconnection period of grpc, based on grpc_channel_check_interval.|`1`|
 `agent.operation_name_threshold `|The operationName max length, setting this value > 190 is not recommended.|`150`|
 `agent.keep_tracing`|Keep tracing even the backend is not available if this value is `true`.|`false`|
-`osinfo.ipv4_list_size`| Limit the length of the ipv4 list size. |`5`|
+`osinfo.ipv4_list_size`| Limit the length of the ipv4 list size. |`10`|
 `collector.grpc_channel_check_interval`|grpc channel status check interval.|`30`|
 `collector.heartbeat_period`|agent heartbeat report period. Unit, second.|`30`|
 `collector.backend_service`|Collector SkyWalking trace receiver service addresses.|`127.0.0.1:11800`|


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
https://github.com/apache/skywalking/issues/4707
___
### Bug fix
- Bug description.
too much ipv4 record causes too long when inserting into DB.
- How to fix?
add a limitation of the ipv4 list size.
___
### New feature or improvement
- Describe the details and related test reports.
