### PR TITLE
Fix ApdexMetrics bug when the number of requests for a service per day is more than 2147483647/10000

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetrics.java
@@ -49,15 +49,15 @@ public abstract class ApdexMetrics extends Metrics implements IntValueHolder {
     @Getter
     @Setter
     @Column(columnName = TOTAL_NUM, storageOnly = true)
-    private int totalNum;
+    private long totalNum;
     @Getter
     @Setter
     @Column(columnName = S_NUM, storageOnly = true)
-    private int sNum;
+    private long sNum;
     @Getter
     @Setter
     @Column(columnName = T_NUM, storageOnly = true)
-    private int tNum;
+    private long tNum;
     @Getter
     @Setter
     @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Avg)
@@ -87,7 +87,7 @@ public abstract class ApdexMetrics extends Metrics implements IntValueHolder {
 
     @Override
     public void calculate() {
-        value = (sNum * 10000 + tNum * 10000 / 2) / totalNum;
+        value = (int) ((sNum * 10000 + tNum * 10000 / 2) / totalNum);
     }
 
     @Override


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
ApdexMetrics calculation method (sNum * 10000 + tNum * 10000 / 2) / totalNum
when sNum more then 214749，sNum * 10000 will exceed the maximum value of int。
- How to fix?
Change type of `sNum`,`tNum`,`totalNum`   form int to long。
___
### New feature or improvement
- Describe the details and related test reports.
