### PR TITLE
8.0.0 release notice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,72 +2,66 @@ Changes by Version
 ==================
 Release Notes.
 
-7.0.0
+8.0.0
 ------------------
 
 #### Project
-* SkyWalking discards the supports of JDK 1.6 and 1.7 on the java agent side. The minimal requirement of JDK is JDK8.
-* Support method performance profile.
-* Provide new E2E test framework.
-* Remove AppVeyor from the CI, use GitHub action only.
-* Provide new plugin test tool.
-* Don't support SkyWalking v5 agent in-wire and out-wire protocol. v6 is required.
+* v3 protocol is added and implemented. All previous releases are incompatible with 8.x releases.
+* Service, Instance, Endpoint register mechanism and inventory storage entities are removed.
+* New GraphQL query protocol is provided, the legacy procotol is still supported(plan to remove at the end of this year).
+* Support Prometheus network protocol. Metrics in Prometheus format could be transferred into SkyWalking.
+* Python agent provided.
+* All inventory caches have been removed.
 
 #### Java Agent
-* Add lazy injection API in the agent core.
-* Support Servlet 2.5 in the Struts plugin.
-* Fix RestTemplate plugin ClassCastException in the Async call.
-* Add Finagle plugin.
-* Add test cases of H2 and struts.
-* Add Armeria 0.98 plugin.
-* Fix ElasticSearch plugin bug.
-* Fix EHCache plugin bug.
-* Fix a potential I/O leak.
-* Support Oracle SID mode.
-* Update Byte-buddy core.
-* Performance tuning: replace AtomicInteger with AtomicIntegerFieldUpdater.
-* Add AVRO plugin.
-* Update to JDK 1.8
-* Optimize the ignore plugin.
-* Enhance the gRPC plugin.
-* Add Kotlin Coroutine plugin.
-* Support HTTP parameter collection in Tomcat and SpringMVC plugin.
-* Add @Tag annotation in the application toolkit.
-* Move Lettuce into the default plugin list.
-* Move Webflux into the default plugin list.
-* Add HttpClient 3.x plugin.
+* Add MariaDB plugin.
+* Vert.x plugin enhancement. More cases are covered.
+* Support v3 extension header.
+* Fix ElasticSearch 5.x plugin TransportClient error.
+* Support Correlation protocol v1.
+* Fix Finagle plugin bug, in processing Noop Span.
+* Make `CommandService` daemon to avoid blocking target application shutting down gracefully
 
 #### OAP-Backend
-* Support InfluxDB as a new storage option.
-* Add `selector` in the `application.yml`. Make the provider activation more flexible through System ENV.
-* Support sub-topology map query.
-* Support gRPC SSL.
-* Support HTTP protocol for agent.
-* Support Nginx LUA agent.
-* Support skip the instance relationship analysis if some agents doesn't have upstream address, currently for LUA agent.
-* Support metrics entity name in the storage. Optional, default OFF.
-* Merge the HOUR and DAY metrics into MINUTE in the ElasticSearch storage implementation. Reduce the payload for ElasticSearch server.
-* Support change detection mechanism in DCS.
-* Support Daily step in the ElasticSearch storage implementation for low traffic system.
-* Provide profile export tool.
-* Support alarm gRPC hook.
-* Fix PHP language doesn't show up on the instance page.
-* Add more comments in the source codes.
-* Add a new metrics type, multiple linears.
-* Fix thread concurrency issue in the alarm core.
+* Support meter system for Prometheus adoption. In future releases, we will add native meter APIs and MicroMeter(Sleuth) system.
+* Support endpoint grouping.
+* Add **SuperDataSet** annotation for storage entity. 
+* Add **superDatasetIndexShardsFactor** in the ElasticSearch storage, to provide more shards for @SuperDataSet annotated entites. Typically TraceSegment.
+* Support alarm settings for relationship of service, instance, and endpoint level metrics.
+* Support alarm settings for database(conjecture node in tracing scenario).
+* Data Model could be added in the runtime, don't depend on the bootstrap sequence anymore.
+* Reduce the memory cost, due to no inventory caches.
+* No buffer files in tracing and service mesh cases.
+* New ReadWriteSafe cache implementation. Simplify codes.
+* Provide default way for metrics query, even the metrics doesn't exist.
+* New GraphQL query protocol is provided. Support the metrics type query.
+* Set up length rule of service, instance, and endpoint.
+* Adjust the default jks for ElasticSearch to empty.
+* Fix Apdex function integer overflow issue. 
+* Fix profile storage issue.
+* Fix TTL issue.
+* Fix H2 column type bug.
+* Add JRE 8-14 test for the backend. 
 
 #### UI
-* Support custom topology definition.
-
+* UI dashboard is 100% configurable to adopt new metrics definited in the backend.
 
 #### Document
-* Add FAQ about `python2` command required in the compiling.
-* Add doc about new e2e framework.
-* Add doc about the new profile feature.
-* Powered-by page updated.
+* Add v8 upgrade document.
+* Make the coverage accurate including UT and e2e tests.
+* Add miss doc about collecting parameters in the profiled traces.
 
-All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/37?closed=1)
+#### CVE
+* Fix SQL Injection vulnerability in H2/MySQL implementation.
+* Upgrade Nacos to avoid the FastJson CVE in high frequency.
+* Upgrade jasckson-databind to 2.9.10. 
 
+
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/45?closed=1)
+
+7.0.0 release
+------------------
+You could find all CHANGES of 7.0.0 at [here](https://github.com/apache/skywalking/blob/v7.0.0/CHANGES.md)
 
 6.x releases
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ Release Notes.
 * Fix ElasticSearch 5.x plugin TransportClient error.
 * Support Correlation protocol v1.
 * Fix Finagle plugin bug, in processing Noop Span.
-* Make `CommandService` daemon to avoid blocking target application shutting down gracefully
+* Make `CommandService` daemon to avoid blocking target application shutting down gracefully.
 
 #### OAP-Backend
 * Support meter system for Prometheus adoption. In future releases, we will add native meter APIs and MicroMeter(Sleuth) system.


### PR DESCRIPTION
Set up the changes for 8.0.0 release.

FYI @ascrutae, I am still expecting your new GateWay plugin, but since you haven't submitted, I just exclude it out of release notice for now.