### PR TITLE
Revert "add php component"

### DIFF
--- a/oap-server/server-bootstrap/src/main/resources/component-libraries.yml
+++ b/oap-server/server-bootstrap/src/main/resources/component-libraries.yml
@@ -52,7 +52,7 @@ ORACLE:
   languages: Java
 Redis:
   id: 7
-  languages: Java,C#,Node.js,PHP
+  languages: Java,C#,Node.js
 Motan:
   id: 8
   languages: Java
@@ -91,7 +91,7 @@ JettyServer:
   languages: Java
 Memcached:
   id: 20
-  languages: Java,PHP
+  languages: Java
 ShardingJDBC:
   id: 21
   languages: Java
@@ -100,7 +100,7 @@ PostgreSQL:
   languages: Java,C#,Node.js
 GRPC:
   id: 23
-  languages: Java,PHP
+  languages: Java
 ElasticJob:
   id: 24
   languages: Java
@@ -378,29 +378,6 @@ Nginx:
   id: 6000
   languages: Lua
 
-
-# PHP components
-# [6000, 7000) for PHP agent
-PHP:
-  id: 6000
-  languages: PHP
-cURL:
-  id: 6001
-  languages: PHP
-PDO:
-  id: 6002
-  languages: PHP
-Mysqli:
-  id: 6003
-  languages: PHP
-Yar:
-  id: 6004
-  languages: PHP
-Predis:
-  id: 6005
-  languages: PHP
-
-
 # [7000, 8000) are reserved for Python components
 Python:
   id: 7000
@@ -444,5 +421,3 @@ Component-Server-Mappings:
   pulsar-consumer: Pulsar
   rest-high-level-client: Elasticsearch
   mariadb-jdbc: Mariadb
-  Mysqli: Mysql
-  Predis: Redis


### PR DESCRIPTION
Reverts apache/skywalking#4871 @heyanlong You did a wrong change. Your PR provides the duplicate component id with Nginx LUA, which breaks the e2e and should not happen.