### PR TITLE
fix NPE when fetch empty readHeatMap metrics.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/type/HeatMap.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/type/HeatMap.java
@@ -34,7 +34,7 @@ import org.apache.skywalking.oap.server.core.analysis.metrics.DataTable;
 @Getter
 public class HeatMap {
     private List<HeatMapColumn> values = new ArrayList<>(10);
-    private List<Bucket> buckets = null;
+    private List<Bucket> buckets = new ArrayList<>();
 
     public void addBucket(Bucket bucket) {
         this.buckets.add(bucket);
@@ -50,8 +50,7 @@ public class HeatMap {
         DataTable dataset = new DataTable(rawdata);
 
         final List<String> sortedKeys = dataset.sortedKeys(new KeyComparator(true));
-        if (buckets == null) {
-            buckets = new ArrayList<>(dataset.size());
+        if (buckets.isEmpty()) {
             for (int i = 0; i < sortedKeys.size(); i++) {
                 final Bucket bucket = new Bucket();
                 final String minValue = sortedKeys.get(i);


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
cause NPE when fetch read heat map metrics. In https://github.com/apache/skywalking/blob/master/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/type/HeatMap.java#L114 method.
- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
