### PR TITLE
In no-init mode, should only check the index existence for the no-time-series index(ES only)

### DIFF
--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
@@ -53,11 +53,12 @@ public class StorageEsInstaller extends ModelInstaller {
     protected boolean isExists(Model model) throws StorageException {
         ElasticSearchClient esClient = (ElasticSearchClient) client;
         try {
-            String timeSeriesIndexName =
-                model.isTimeSeries() ?
-                    TimeSeriesUtils.latestWriteIndexName(model) :
-                    model.getName();
-            return esClient.isExistsTemplate(model.getName()) && esClient.isExistsIndex(timeSeriesIndexName);
+            if (model.isTimeSeries()) {
+                return esClient.isExistsTemplate(model.getName()) && esClient.isExistsIndex(
+                    TimeSeriesUtils.latestWriteIndexName(model));
+            } else {
+                return esClient.isExistsIndex(model.getName());
+            }
         } catch (IOException e) {
             throw new StorageException(e.getMessage());
         }


### PR DESCRIPTION
The 8.0.0 can't bootstrap in the `no-init` mode, as it checked the template even there is no template for the no-time-series index.

FYI all @apache/skywalking-committers 