### PR TITLE
Update LUA e2e commit id for Nginx LUA agent release.

### DIFF
--- a/test/e2e/e2e-test/docker/lua/Dockerfile.nginx
+++ b/test/e2e/e2e-test/docker/lua/Dockerfile.nginx
@@ -15,7 +15,7 @@
 
 FROM openresty/openresty
 
-ENV COMMIT_HASH=4c0eee3991e022f93703569c8e7bf114de7bb310
+ENV COMMIT_HASH=b4700215abf5797279e7613ab96d8141a89d0b48
 
 WORKDIR /usr/share/skywalking-nginx-lua
 


### PR DESCRIPTION
According to release vote mail, https://lists.apache.org/thread.html/r7f2967762c1a0fa82f82f82c94203f08b897bafd9c276a91ab577d78%40%3Cdev.skywalking.apache.org%3E, this is the commit id.

Run the test in the e2e env with the main repo.