### PR TITLE
Fix endpoint dependency bug in MQ and uninstrumented proxy cases, and support endpoint dependency(v2 of endpoint topology case).

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/type/EndpointNode.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/type/EndpointNode.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.query.type;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class EndpointNode {
+    private String id;
+    private String name;
+    private String serviceId;
+    private String serviceName;
+    /**
+     * Not type for endpoint for now.
+     */
+    private String type = "";
+    private boolean isReal;
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/type/EndpointTopology.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/type/EndpointTopology.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.query.type;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class EndpointTopology {
+    private final List<EndpointNode> nodes;
+    private final List<Call> calls;
+
+    public EndpointTopology() {
+        this.nodes = new ArrayList<>();
+        this.calls = new ArrayList<>();
+    }
+}

--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/TopologyQuery.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/TopologyQuery.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.query.TopologyQueryService;
 import org.apache.skywalking.oap.server.core.query.input.Duration;
+import org.apache.skywalking.oap.server.core.query.type.EndpointTopology;
 import org.apache.skywalking.oap.server.core.query.type.ServiceInstanceTopology;
 import org.apache.skywalking.oap.server.core.query.type.Topology;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
@@ -69,8 +70,18 @@ public class TopologyQuery implements GraphQLQueryResolver {
         );
     }
 
+    /**
+     * Replaced by {@link #getEndpointDependencies(String, Duration)}
+     */
+    @Deprecated
     public Topology getEndpointTopology(final String endpointId, final Duration duration) throws IOException {
         return getQueryService().getEndpointTopology(
+            duration.getStartTimeBucket(), duration.getEndTimeBucket(), endpointId);
+    }
+
+    public EndpointTopology getEndpointDependencies(final String endpointId,
+                                                    final Duration duration) throws IOException {
+        return getQueryService().getEndpointDependencies(
             duration.getStartTimeBucket(), duration.getEndTimeBucket(), endpointId);
     }
 }

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListener.java
@@ -107,6 +107,7 @@ public class MultiScopesAnalysisListener implements EntryAnalysisListener, ExitA
                 if (span.getSpanLayer().equals(SpanLayer.MQ) ||
                     config.getUninstrumentedGatewaysConfig().isAddressConfiguredAsGateway(networkAddressUsedAtPeer)) {
                     sourceBuilder.setSourceServiceName(networkAddressUsedAtPeer);
+                    sourceBuilder.setSourceEndpointOwnerServiceName(reference.getParentService());
                     sourceBuilder.setSourceServiceInstanceName(networkAddressUsedAtPeer);
                     sourceBuilder.setSourceNodeType(NodeType.fromSpanLayerValue(span.getSpanLayer()));
                 } else {

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/SourceBuilder.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/SourceBuilder.java
@@ -57,6 +57,17 @@ class SourceBuilder {
         this.sourceServiceInstanceName = namingControl.formatInstanceName(sourceServiceInstanceName);
     }
 
+    /**
+     * Source endpoint could be not owned by {@link #sourceServiceName}, such as in the MQ or un-instrumented proxy
+     * cases. This service always comes from the span.ref, so it is always a normal service.
+     */
+    @Getter
+    private String sourceEndpointOwnerServiceName;
+
+    public void setSourceEndpointOwnerServiceName(final String sourceServiceName) {
+        this.sourceEndpointOwnerServiceName = namingControl.formatServiceName(sourceServiceName);
+    }
+
     @Getter
     private String sourceEndpointName;
 
@@ -234,8 +245,13 @@ class SourceBuilder {
         }
         EndpointRelation endpointRelation = new EndpointRelation();
         endpointRelation.setEndpoint(sourceEndpointName);
-        endpointRelation.setServiceName(sourceServiceName);
-        endpointRelation.setServiceNodeType(sourceNodeType);
+        if (sourceEndpointOwnerServiceName == null) {
+            endpointRelation.setServiceName(sourceServiceName);
+            endpointRelation.setServiceNodeType(sourceNodeType);
+        } else {
+            endpointRelation.setServiceName(sourceEndpointOwnerServiceName);
+            endpointRelation.setServiceNodeType(NodeType.Normal);
+        }
         endpointRelation.setServiceInstanceName(sourceServiceInstanceName);
         endpointRelation.setChildEndpoint(destEndpointName);
         endpointRelation.setChildServiceName(destServiceName);

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListenerTest.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/MultiScopesAnalysisListenerTest.java
@@ -282,6 +282,7 @@ public class MultiScopesAnalysisListenerTest {
         Assert.assertEquals("127.0.0.1", serviceInstanceRelation.getSourceServiceInstanceName());
         Assert.assertEquals(serviceInstance.getName(), serviceInstanceRelation.getDestServiceInstanceName());
         Assert.assertEquals("downstream-endpoint", endpointRelation.getEndpoint());
+        Assert.assertEquals("downstream-service", endpointRelation.getServiceName());
         Assert.assertEquals(endpoint.getName(), endpointRelation.getChildEndpoint());
     }
 


### PR DESCRIPTION
1. Fix endpoint dependency bug in MQ and uninstrumented proxy cases. The new `MultiScopesAnalysisListenerTest` is really helpful on locating this complex analysis issue.
1. Support endpoint dependency(v2 of endpoint topology case).

New graphql query
```graphql
{
  getEndpointDependencies(
    endpointId: "bW9ja19iX3NlcnZpY2U=.1_b3JnLnNreXdha2luZy5hcG0udGVzdGNhc2UuZHViYm8uc2VydmljZXMuR3JlZXRTZXJ2aWNlSW1wbC5kb0J1c2luZXNzKCk=",
  duration: {step:MINUTE, start: "2020-06-30 1750", end: "2020-06-30 1850"}
  ) {
    nodes {
      id,
      name,
      serviceId,
      serviceName,
      type,
      isReal
    },
    calls{
      id,
      source,
      target,
      detectPoints
    }
  }
}
```

```graphql
{
  "data": {
    "getEndpointDependencies": {
      "nodes": [
        {
          "id": "bW9ja19hX3NlcnZpY2U=.1_L2R1YmJveC1jYXNlL2Nhc2UvZHViYm94LXJlc3Q=",
          "name": "/dubbox-case/case/dubbox-rest",
          "serviceId": "bW9ja19hX3NlcnZpY2U=.1",
          "serviceName": "mock_a_service",
          "type": "",
          "isReal": true
        },
        {
          "id": "bW9ja19iX3NlcnZpY2U=.1_b3JnLnNreXdha2luZy5hcG0udGVzdGNhc2UuZHViYm8uc2VydmljZXMuR3JlZXRTZXJ2aWNlSW1wbC5kb0J1c2luZXNzKCk=",
          "name": "org.skywaking.apm.testcase.dubbo.services.GreetServiceImpl.doBusiness()",
          "serviceId": "bW9ja19iX3NlcnZpY2U=.1",
          "serviceName": "mock_b_service",
          "type": "",
          "isReal": true
        },
        {
          "id": "bW9ja19jX3NlcnZpY2U=.1_b3JnLmFwYWNoZS5za3l3YWxraW5nLlJvY2tldE1R",
          "name": "org.apache.skywalking.RocketMQ",
          "serviceId": "bW9ja19jX3NlcnZpY2U=.1",
          "serviceName": "mock_c_service",
          "type": "",
          "isReal": true
        }
      ],
      "calls": [
        {
          "id": "bW9ja19hX3NlcnZpY2U=.1-L2R1YmJveC1jYXNlL2Nhc2UvZHViYm94LXJlc3Q=-bW9ja19iX3NlcnZpY2U=.1-b3JnLnNreXdha2luZy5hcG0udGVzdGNhc2UuZHViYm8uc2VydmljZXMuR3JlZXRTZXJ2aWNlSW1wbC5kb0J1c2luZXNzKCk=",
          "source": "bW9ja19hX3NlcnZpY2U=.1_L2R1YmJveC1jYXNlL2Nhc2UvZHViYm94LXJlc3Q=",
          "target": "bW9ja19iX3NlcnZpY2U=.1_b3JnLnNreXdha2luZy5hcG0udGVzdGNhc2UuZHViYm8uc2VydmljZXMuR3JlZXRTZXJ2aWNlSW1wbC5kb0J1c2luZXNzKCk=",
          "detectPoints": [
            "SERVER"
          ]
        },
        {
          "id": "bW9ja19iX3NlcnZpY2U=.1-b3JnLnNreXdha2luZy5hcG0udGVzdGNhc2UuZHViYm8uc2VydmljZXMuR3JlZXRTZXJ2aWNlSW1wbC5kb0J1c2luZXNzKCk=-bW9ja19jX3NlcnZpY2U=.1-b3JnLmFwYWNoZS5za3l3YWxraW5nLlJvY2tldE1R",
          "source": "bW9ja19iX3NlcnZpY2U=.1_b3JnLnNreXdha2luZy5hcG0udGVzdGNhc2UuZHViYm8uc2VydmljZXMuR3JlZXRTZXJ2aWNlSW1wbC5kb0J1c2luZXNzKCk=",
          "target": "bW9ja19jX3NlcnZpY2U=.1_b3JnLmFwYWNoZS5za3l3YWxraW5nLlJvY2tldE1R",
          "detectPoints": [
            "SERVER"
          ]
        }
      ]
    }
  }
}
```