### PR TITLE
Add two metrics for endpoint relationship.

### DIFF
--- a/oap-server/server-bootstrap/src/main/resources/oal/core.oal
+++ b/oap-server/server-bootstrap/src/main/resources/oal/core.oal
@@ -61,6 +61,8 @@ endpoint_percentile = from(Endpoint.latency).percentile(10); // Multiple values 
 // Endpoint relation scope metrics
 endpoint_relation_cpm = from(EndpointRelation.*).filter(detectPoint == DetectPoint.SERVER).cpm();
 endpoint_relation_resp_time = from(EndpointRelation.rpcLatency).filter(detectPoint == DetectPoint.SERVER).longAvg();
+endpoint_relation_sla = from(EndpointRelation.*).filter(detectPoint == DetectPoint.SERVER).percent(status == true);
+endpoint_relation_percentile = from(EndpointRelation.rpcLatency).filter(detectPoint == DetectPoint.SERVER).percentile(10); // Multiple values including p50, p75, p90, p95, p99
 
 database_access_resp_time = from(DatabaseAccess.latency).longAvg();
 database_access_sla = from(DatabaseAccess.*).percent(status == true);


### PR DESCRIPTION
Adding two metrics
1. `endpoint_relation_sla` representing the successful rate of endpoint relationship
1. `endpoint_relation_percentile` representing the percentile of the RPC latency between the endpoints.