### PR TITLE
Optimize the code to prevent mongo statements from being too long

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/mongodb/v3/support/MongoOperationHelper.java
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/mongodb/v3/support/MongoOperationHelper.java
@@ -128,8 +128,7 @@ public class MongoOperationHelper {
             }
             final int filterLengthLimit = Config.Plugin.MongoDB.FILTER_LENGTH_LIMIT;
             if (filterLengthLimit > 0 && params.length() > filterLengthLimit) {
-                params.append("...");
-                break;
+                return params.substring(0, filterLengthLimit) + "...";
             }
         }
         return params.toString();


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

I have a long MixedBulkWriteOperation statement in the production environment, so modify this code to avoid this problem. Please take a look if it makes sense.

The part of parameters are as follows:
`\"db.statement\":\"MixedBulkWriteOperation{\\\"d\\\": {\\\"$date\\\": 1593707332668}, \\\"b\\\": {\\\"$date\\\": 1593699028000}, \\\"c\\\": {\\\"$date\\\": 1593697348000}, \\\"tid\\\": \\\"866623046287530\\\", \\\"vid\\\": {\\\"$numberLong\\\": \\\"10317043\\\"}, \\\"a\\\": [[\\\"112.566333\\\", \\\"29.529147\\\", \\\"1593699028\\\", \\\"39.0\\\"], [\\\"112.567002\\\", \\\"29.52939\\\", \\\"1593699022\\\", \\\"43.0\\\"], [\\\"112.542396\\\", \\\"29.529999\\\", \\\"1593703612\\\", \\\"25.0\\\"], [\\\"112.532834\\\", \\\"29.534214\\\", \\\"1593704944\\\", \\\"69.0\\\"], [\\\"112.532248\\\", \\\"29.534155\\\", \\\"1593704938\\\", \\\"68.0\\\"], [\\\"112.543031\\\", \\\"29.530055\\\", \\\"1593703606\\\", \\\"44.0\\\"], [\\\"112.570258\\\", \\\"29.530724\\\", \\\"1593688378\\\", \\\"0.0\\\"], [\\\"112.569889\\\", \\\"29.530871\\\", \\\"1593700588\\\", \\\"2.0\\\"], [\\\"112.573432\\\", \\\"29.531835\\\", \\\"1593693718\\\", \\\"15.0\\\"], [\\\"112.793778\\\", \\\"29.664507\\\", \\\"1593690682\\\", \\\"77.0\\\"], [\\\"112.570258\\\", \\\"29.530726\\\", \\\"1593688372\\\", \\\"0.0\\\"], [\\\"112.569769\\\", \\\"29.531007\\\", \\\"1593700582\\\", \\\"24.0\\\"], [\\\"112.573684\\\", \\\"29.531921\\\", \\\"1593693712\\\", \\\"15.0\\\"], [\\\"112.794695\\\", \\\"29.665287\\\", \\\"1593690688\\\", \\\"74.0\\\"], [\\\"112.565679\\\", \\\"29.528897\\\", \\\"1593699034\\\", \\\"43.0\\\"], [\\\"112.534283\\\", \\\"29.534365\\\", \\\"1593704950\\\", \\\"46.0\\\"], [\\\"112.535122\\\", \\\"29.534448\\\", \\\"1593704956\\\", \\\"48.0\\\"], [\\\"112.541453\\\", \\\"29.529875\\\", \\\"1593703624\\\", \\\"43.0\\\"], [\\\"112.542053\\\", \\\"29.529955\\\", \\\"1593703618\\\", \\\"14.0\\\"], [\\\"112.570258\\\", \\\"29.530723\\\", \\\"1593688384\\\", \\\"0.0\\\"], [\\\"112.569889\\\", \\\"29.530871\\\", \\\"1593700594\\\", \\\"0.0\\\"], [\\\"112.795917\\\", \\\"29.665807\\\", \\\"1593690694\\\", \\\"81.0\\\"], [\\\"112.573198\\\", \\\"29.531745\\\", \\\"1593693724\\\", \\\"13.0\\\"], [\\\"112.578163\\\", \\\"29.533483\\\", \\\"1593701890\\\", \\\"8.0\\\"], [\\\"112.564297\\\", \\\"29.528371\\\", \\\"1593699046\\\", \\\"38.0\\\"], [\\\"112.564955\\\", \\\"29.528621\\\", \\\"1593699040\\\", \\\"45.0\\\"], [\\\"112.577922\\\", \\\"29.53336\\\", \\\"1593701896\\\", \\\"18.0\\\"], [\\\"112.529023\\\", \\\"29.533802\\\", \\\"1593704920\\\", \\\"60.0\\\"], [\\\"112.572463\\\", \\\"29.531436\\\", \\\"1593693736\\\", \\\"15.0\\\"], [\\\"112.568133\\\", \\\"29.532407\\\", \\\"1593700564\\\", \\\"47.0\\\"], [\\\"112.570723\\\", \\\"29.53013\\\", \\\"1593688396\\\", \\\"30.0\\\"], [\\\"112.572798\\\", \\\"29.531563\\\", \\\"1593693730\\\", \\\"25.0\\\"], [\\\"112.570438\\\", \\\"29.530512\\\", \\\"1593688390\\\", \\\"25.0\\\"], [\\\"112.751139\\\", \\\"29.585057\\\", \\\"1593692404\\\", \\\"52.0\\\"], [\\\"112.597207\\\", \\\"29.541954\\\", \\\"1593707194\\\", \\\"57.0\\\"], [\\\"112.563399\\\", \\\"29.528264\\\", \\\"1593699058\\\", \\\"13.0\\\"], [\\\"112.563758\\\", \\\"29.528343\\\", \\\"1593699052\\\", \\\"27.0\\\"], [\\\"112.531107\\\", \\\"29.534032\\\", \\\"1593704932\\\", \\\"64.0\\\"], [\\\"112.54384\\\", \\\"29.530151\\\", \\\"1593703600\\\", `
... more long
