### PR TITLE
Fix bug caused by setting SW_OAL_ENGINE_DEBUG=Y.

### DIFF
--- a/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/OALRuntime.java
+++ b/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/OALRuntime.java
@@ -99,6 +99,7 @@ public class OALRuntime implements OALEngine {
         "data2Map",
         "map2Data"
     };
+    private static boolean IS_RT_TEMP_FOLDER_INIT_COMPLETED = false;
 
     private final OALDefine oalDefine;
     private final ClassPool classPool;
@@ -135,7 +136,10 @@ public class OALRuntime implements OALEngine {
 
     @Override
     public void start(ClassLoader currentClassLoader) throws ModuleStartException, OALCompileException {
-        prepareRTTempFolder();
+        if (!IS_RT_TEMP_FOLDER_INIT_COMPLETED) {
+            prepareRTTempFolder();
+            IS_RT_TEMP_FOLDER_INIT_COMPLETED = true;
+        }
 
         this.currentClassLoader = currentClassLoader;
         Reader read;


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

  Only envoy related classes are generated after setting SW_OAL_ENGINE_DEBUG=Y at system env.

- How to fix?

  Create a oal-rt folder only when the first oal script is loaded.

___
### New feature or improvement
- Describe the details and related test reports.
