### PR TITLE
Fix no telemetry metrics when the oap role is receiver.

### DIFF
--- a/oap-server/server-cluster-plugin/cluster-consul-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/consul/ConsulCoordinator.java
+++ b/oap-server/server-cluster-plugin/cluster-consul-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/consul/ConsulCoordinator.java
@@ -33,7 +33,6 @@ import org.apache.skywalking.oap.server.core.cluster.RemoteInstance;
 import org.apache.skywalking.oap.server.core.cluster.ServiceRegisterException;
 import org.apache.skywalking.oap.server.core.remote.client.Address;
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
-import org.apache.skywalking.oap.server.telemetry.api.TelemetryRelatedContext;
 
 public class ConsulCoordinator implements ClusterRegister, ClusterNodesQuery {
 
@@ -79,7 +78,6 @@ public class ConsulCoordinator implements ClusterRegister, ClusterNodesQuery {
         AgentClient agentClient = client.agentClient();
 
         this.selfAddress = remoteInstance.getAddress();
-        TelemetryRelatedContext.INSTANCE.setId(selfAddress.toString());
 
         Registration registration = ImmutableRegistration.builder()
                                                          .id(remoteInstance.getAddress().toString())

--- a/oap-server/server-cluster-plugin/cluster-consul-plugin/src/test/java/org/apache/skywalking/oap/server/cluster/plugin/consul/ITClusterModuleConsulProviderFunctionalTest.java
+++ b/oap-server/server-cluster-plugin/cluster-consul-plugin/src/test/java/org/apache/skywalking/oap/server/cluster/plugin/consul/ITClusterModuleConsulProviderFunctionalTest.java
@@ -31,7 +31,6 @@ import org.apache.skywalking.oap.server.core.cluster.ClusterRegister;
 import org.apache.skywalking.oap.server.core.cluster.RemoteInstance;
 import org.apache.skywalking.oap.server.core.remote.client.Address;
 import org.apache.skywalking.oap.server.library.module.ModuleProvider;
-import org.apache.skywalking.oap.server.telemetry.api.TelemetryRelatedContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
@@ -196,7 +195,6 @@ public class ITClusterModuleConsulProviderFunctionalTest {
             Consul client = Whitebox.getInternalState(consulCoordinator, "client");
             AgentClient agentClient = client.agentClient();
             Whitebox.setInternalState(consulCoordinator, "selfAddress", remoteInstance.getAddress());
-            TelemetryRelatedContext.INSTANCE.setId(remoteInstance.getAddress().toString());
             Registration registration = ImmutableRegistration.builder()
                                                              .id(remoteInstance.getAddress().toString())
                                                              .name(serviceName)

--- a/oap-server/server-cluster-plugin/cluster-etcd-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/etcd/EtcdCoordinator.java
+++ b/oap-server/server-cluster-plugin/cluster-etcd-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/etcd/EtcdCoordinator.java
@@ -33,7 +33,6 @@ import org.apache.skywalking.oap.server.core.cluster.ClusterRegister;
 import org.apache.skywalking.oap.server.core.cluster.RemoteInstance;
 import org.apache.skywalking.oap.server.core.cluster.ServiceRegisterException;
 import org.apache.skywalking.oap.server.core.remote.client.Address;
-import org.apache.skywalking.oap.server.telemetry.api.TelemetryRelatedContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,7 +92,6 @@ public class EtcdCoordinator implements ClusterRegister, ClusterNodesQuery {
         }
 
         this.selfAddress = remoteInstance.getAddress();
-        TelemetryRelatedContext.INSTANCE.setId(selfAddress.toString());
 
         EtcdEndpoint endpoint = new EtcdEndpoint.Builder().serviceName(serviceName)
                                                           .host(selfAddress.getHost())

--- a/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/kubernetes/KubernetesCoordinator.java
+++ b/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/kubernetes/KubernetesCoordinator.java
@@ -33,7 +33,6 @@ import org.apache.skywalking.oap.server.core.cluster.ServiceRegisterException;
 import org.apache.skywalking.oap.server.core.config.ConfigService;
 import org.apache.skywalking.oap.server.core.remote.client.Address;
 import org.apache.skywalking.oap.server.library.module.ModuleDefineHolder;
-import org.apache.skywalking.oap.server.telemetry.api.TelemetryRelatedContext;
 
 /**
  * Read collector pod info from api-server of kubernetes, then using all containerIp list to construct the list of
@@ -81,7 +80,6 @@ public class KubernetesCoordinator implements ClusterRegister, ClusterNodesQuery
     @Override
     public void registerRemote(final RemoteInstance remoteInstance) throws ServiceRegisterException {
         this.port = remoteInstance.getAddress().getPort();
-        TelemetryRelatedContext.INSTANCE.setId(remoteInstance.toString());
     }
 
     private List<V1Pod> selfPod() {

--- a/oap-server/server-cluster-plugin/cluster-standalone-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/standalone/StandaloneManager.java
+++ b/oap-server/server-cluster-plugin/cluster-standalone-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/standalone/StandaloneManager.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.apache.skywalking.oap.server.core.cluster.ClusterNodesQuery;
 import org.apache.skywalking.oap.server.core.cluster.ClusterRegister;
 import org.apache.skywalking.oap.server.core.cluster.RemoteInstance;
-import org.apache.skywalking.oap.server.telemetry.api.TelemetryRelatedContext;
 
 /**
  * A cluster manager simulator. Work in memory only. Also return the current instance.
@@ -36,7 +35,6 @@ public class StandaloneManager implements ClusterNodesQuery, ClusterRegister {
     public void registerRemote(RemoteInstance remoteInstance) {
         this.remoteInstance = remoteInstance;
         this.remoteInstance.getAddress().setSelf(true);
-        TelemetryRelatedContext.INSTANCE.setId("standalone");
     }
 
     @Override

--- a/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/zookeeper/ZookeeperCoordinator.java
+++ b/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/zookeeper/ZookeeperCoordinator.java
@@ -30,7 +30,6 @@ import org.apache.skywalking.oap.server.core.cluster.ClusterRegister;
 import org.apache.skywalking.oap.server.core.cluster.RemoteInstance;
 import org.apache.skywalking.oap.server.core.cluster.ServiceRegisterException;
 import org.apache.skywalking.oap.server.core.remote.client.Address;
-import org.apache.skywalking.oap.server.telemetry.api.TelemetryRelatedContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +73,6 @@ public class ZookeeperCoordinator implements ClusterRegister, ClusterNodesQuery 
             serviceDiscovery.registerService(thisInstance);
 
             this.selfAddress = remoteInstance.getAddress();
-            TelemetryRelatedContext.INSTANCE.setId(selfAddress.toString());
         } catch (Exception e) {
             throw new ServiceRegisterException(e.getMessage());
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
@@ -92,6 +92,7 @@ import org.apache.skywalking.oap.server.library.server.grpc.GRPCServer;
 import org.apache.skywalking.oap.server.library.server.jetty.JettyServer;
 import org.apache.skywalking.oap.server.library.util.ResourceUtils;
 import org.apache.skywalking.oap.server.telemetry.TelemetryModule;
+import org.apache.skywalking.oap.server.telemetry.api.TelemetryRelatedContext;
 
 /**
  * Core module provider includes the recommended and default implementations of {@link CoreModule#services()}. All

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
@@ -282,14 +282,15 @@ public class CoreModuleProvider extends ModuleProvider {
             throw new ModuleStartException(e.getMessage(), e);
         }
 
+        Address gRPCServerInstanceAddress = new Address(moduleConfig.getGRPCHost(), moduleConfig.getGRPCPort(), true);
+        TelemetryRelatedContext.INSTANCE.setId(gRPCServerInstanceAddress.toString());
         if (CoreModuleConfig.Role.Mixed.name()
                 .equalsIgnoreCase(
                         moduleConfig.getRole())
                 || CoreModuleConfig.Role.Aggregator.name()
                 .equalsIgnoreCase(
                         moduleConfig.getRole())) {
-            RemoteInstance gRPCServerInstance = new RemoteInstance(
-                    new Address(moduleConfig.getGRPCHost(), moduleConfig.getGRPCPort(), true));
+            RemoteInstance gRPCServerInstance = new RemoteInstance(gRPCServerInstanceAddress);
             this.getManager()
                     .find(ClusterModule.NAME)
                     .provider()


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

  No telemetry metrics when the oap role is receiver. Only jvm metrics is exposed.
```
# HELP jvm_info JVM version info
# TYPE jvm_info gauge
jvm_info{version="1.8.0_231-b11",vendor="Oracle Corporation",runtime="Java(TM) SE Runtime Environment",} 1.0
# HELP jvm_threads_current Current thread count of a JVM
# TYPE jvm_threads_current gauge
jvm_threads_current 118.0
# HELP jvm_threads_daemon Daemon thread count of a JVM
# TYPE jvm_threads_daemon gauge
jvm_threads_daemon 83.0
# HELP jvm_threads_peak Peak thread count of a JVM
# TYPE jvm_threads_peak gauge
jvm_threads_peak 121.0
# HELP jvm_threads_started_total Started thread count of a JVM
# TYPE jvm_threads_started_total counter
jvm_threads_started_total 124.0
# HELP jvm_threads_deadlocked Cycles of JVM-threads that are in deadlock waiting to acquire object monitors or ownable synchronizers
# TYPE jvm_threads_deadlocked gauge
jvm_threads_deadlocked 0.0
# HELP jvm_threads_deadlocked_monitor Cycles of JVM-threads that are in deadlock waiting to acquire object monitors
# TYPE jvm_threads_deadlocked_monitor gauge
jvm_threads_deadlocked_monitor 0.0
# HELP jvm_threads_state Current count of threads by state
# TYPE jvm_threads_state gauge
jvm_threads_state{state="WAITING",} 9.0
jvm_threads_state{state="NEW",} 0.0
jvm_threads_state{state="TERMINATED",} 0.0
jvm_threads_state{state="TIMED_WAITING",} 68.0
jvm_threads_state{state="RUNNABLE",} 41.0
jvm_threads_state{state="BLOCKED",} 0.0
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 35.110968
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.594015769031E9
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 322.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 10240.0
# HELP jvm_memory_bytes_used Used bytes of a given JVM memory area.
# TYPE jvm_memory_bytes_used gauge
jvm_memory_bytes_used{area="heap",} 2.72458E8
jvm_memory_bytes_used{area="nonheap",} 9.034496E7
# HELP jvm_memory_bytes_committed Committed (bytes) of a given JVM memory area.
# TYPE jvm_memory_bytes_committed gauge
jvm_memory_bytes_committed{area="heap",} 8.98629632E8
jvm_memory_bytes_committed{area="nonheap",} 9.33888E7
# HELP jvm_memory_bytes_max Max (bytes) of a given JVM memory area.
# TYPE jvm_memory_bytes_max gauge
jvm_memory_bytes_max{area="heap",} 3.817865216E9
jvm_memory_bytes_max{area="nonheap",} -1.0
# HELP jvm_memory_bytes_init Initial bytes of a given JVM memory area.
# TYPE jvm_memory_bytes_init gauge
jvm_memory_bytes_init{area="heap",} 2.68435456E8
jvm_memory_bytes_init{area="nonheap",} 2555904.0
# HELP jvm_memory_pool_bytes_used Used bytes of a given JVM memory pool.
# TYPE jvm_memory_pool_bytes_used gauge
jvm_memory_pool_bytes_used{pool="Code Cache",} 1.794784E7
jvm_memory_pool_bytes_used{pool="Metaspace",} 6.4289096E7
jvm_memory_pool_bytes_used{pool="Compressed Class Space",} 8108024.0
jvm_memory_pool_bytes_used{pool="PS Eden Space",} 2.41183192E8
jvm_memory_pool_bytes_used{pool="PS Survivor Space",} 0.0
jvm_memory_pool_bytes_used{pool="PS Old Gen",} 3.1274808E7
# HELP jvm_memory_pool_bytes_committed Committed bytes of a given JVM memory pool.
# TYPE jvm_memory_pool_bytes_committed gauge
jvm_memory_pool_bytes_committed{pool="Code Cache",} 1.867776E7
jvm_memory_pool_bytes_committed{pool="Metaspace",} 6.6060288E7
jvm_memory_pool_bytes_committed{pool="Compressed Class Space",} 8650752.0
jvm_memory_pool_bytes_committed{pool="PS Eden Space",} 6.67418624E8
jvm_memory_pool_bytes_committed{pool="PS Survivor Space",} 1.6252928E7
jvm_memory_pool_bytes_committed{pool="PS Old Gen",} 2.1495808E8
# HELP jvm_memory_pool_bytes_max Max bytes of a given JVM memory pool.
# TYPE jvm_memory_pool_bytes_max gauge
jvm_memory_pool_bytes_max{pool="Code Cache",} 2.5165824E8
jvm_memory_pool_bytes_max{pool="Metaspace",} -1.0
jvm_memory_pool_bytes_max{pool="Compressed Class Space",} 1.073741824E9
jvm_memory_pool_bytes_max{pool="PS Eden Space",} 1.379926016E9
jvm_memory_pool_bytes_max{pool="PS Survivor Space",} 1.6252928E7
jvm_memory_pool_bytes_max{pool="PS Old Gen",} 2.863661056E9
# HELP jvm_memory_pool_bytes_init Initial bytes of a given JVM memory pool.
# TYPE jvm_memory_pool_bytes_init gauge
jvm_memory_pool_bytes_init{pool="Code Cache",} 2555904.0
jvm_memory_pool_bytes_init{pool="Metaspace",} 0.0
jvm_memory_pool_bytes_init{pool="Compressed Class Space",} 0.0
jvm_memory_pool_bytes_init{pool="PS Eden Space",} 6.7108864E7
jvm_memory_pool_bytes_init{pool="PS Survivor Space",} 1.1010048E7
jvm_memory_pool_bytes_init{pool="PS Old Gen",} 1.79306496E8
# HELP jvm_buffer_pool_used_bytes Used bytes of a given JVM buffer pool.
# TYPE jvm_buffer_pool_used_bytes gauge
jvm_buffer_pool_used_bytes{pool="direct",} 76424.0
jvm_buffer_pool_used_bytes{pool="mapped",} 0.0
# HELP jvm_buffer_pool_capacity_bytes Bytes capacity of a given JVM buffer pool.
# TYPE jvm_buffer_pool_capacity_bytes gauge
jvm_buffer_pool_capacity_bytes{pool="direct",} 76423.0
jvm_buffer_pool_capacity_bytes{pool="mapped",} 0.0
# HELP jvm_buffer_pool_used_buffers Used buffers of a given JVM buffer pool.
# TYPE jvm_buffer_pool_used_buffers gauge
jvm_buffer_pool_used_buffers{pool="direct",} 12.0
jvm_buffer_pool_used_buffers{pool="mapped",} 0.0
# HELP jvm_classes_loaded The number of classes that are currently loaded in the JVM
# TYPE jvm_classes_loaded gauge
jvm_classes_loaded 11775.0
# HELP jvm_classes_loaded_total The total number of classes that have been loaded since the JVM has started execution
# TYPE jvm_classes_loaded_total counter
jvm_classes_loaded_total 11779.0
# HELP jvm_classes_unloaded_total The total number of classes that have been unloaded since the JVM has started execution
# TYPE jvm_classes_unloaded_total counter
jvm_classes_unloaded_total 4.0
# HELP jvm_memory_pool_allocated_bytes_total Total bytes allocated in a given JVM memory pool. Only updated after GC, not continuously.
# TYPE jvm_memory_pool_allocated_bytes_total counter
jvm_memory_pool_allocated_bytes_total{pool="Code Cache",} 1.8067072E7
jvm_memory_pool_allocated_bytes_total{pool="PS Eden Space",} 1.571292488E9
jvm_memory_pool_allocated_bytes_total{pool="PS Old Gen",} 3.132976E7
jvm_memory_pool_allocated_bytes_total{pool="PS Survivor Space",} 3.655128E7
jvm_memory_pool_allocated_bytes_total{pool="Compressed Class Space",} 7514864.0
jvm_memory_pool_allocated_bytes_total{pool="Metaspace",} 5.9126248E7
# HELP jvm_gc_collection_seconds Time spent in a given JVM garbage collector in seconds.
# TYPE jvm_gc_collection_seconds summary
jvm_gc_collection_seconds_count{gc="PS Scavenge",} 16.0
jvm_gc_collection_seconds_sum{gc="PS Scavenge",} 0.158
jvm_gc_collection_seconds_count{gc="PS MarkSweep",} 3.0
jvm_gc_collection_seconds_sum{gc="PS MarkSweep",} 0.148
```

- How to fix?

  Setting id for telemetry related context. After setting, you can see the telemetry metrics.
  For example, metrics_aggregation, persistence_timer_bulk_execute_latency, and so on.
```
# HELP jvm_buffer_pool_used_bytes Used bytes of a given JVM buffer pool.
# TYPE jvm_buffer_pool_used_bytes gauge
jvm_buffer_pool_used_bytes{pool="direct",} 72389.0
jvm_buffer_pool_used_bytes{pool="mapped",} 0.0
# HELP jvm_buffer_pool_capacity_bytes Bytes capacity of a given JVM buffer pool.
# TYPE jvm_buffer_pool_capacity_bytes gauge
jvm_buffer_pool_capacity_bytes{pool="direct",} 72388.0
jvm_buffer_pool_capacity_bytes{pool="mapped",} 0.0
# HELP jvm_buffer_pool_used_buffers Used buffers of a given JVM buffer pool.
# TYPE jvm_buffer_pool_used_buffers gauge
jvm_buffer_pool_used_buffers{pool="direct",} 11.0
jvm_buffer_pool_used_buffers{pool="mapped",} 0.0
# HELP jvm_classes_loaded The number of classes that are currently loaded in the JVM
# TYPE jvm_classes_loaded gauge
jvm_classes_loaded 11800.0
# HELP jvm_classes_loaded_total The total number of classes that have been loaded since the JVM has started execution
# TYPE jvm_classes_loaded_total counter
jvm_classes_loaded_total 11804.0
# HELP jvm_classes_unloaded_total The total number of classes that have been unloaded since the JVM has started execution
# TYPE jvm_classes_unloaded_total counter
jvm_classes_unloaded_total 4.0
# HELP persistence_timer_bulk_execute_latency Latency of the execute stage in persistence timer
# TYPE persistence_timer_bulk_execute_latency histogram
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.005",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.01",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.025",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.05",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.075",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.1",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.25",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.5",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.75",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="1.0",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="2.5",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="5.0",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="7.5",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="10.0",} 8.0
persistence_timer_bulk_execute_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="+Inf",} 8.0
persistence_timer_bulk_execute_latency_count{sw_backend_instance="192.168.46.203_11800",} 8.0
persistence_timer_bulk_execute_latency_sum{sw_backend_instance="192.168.46.203_11800",} 2.2112E-5
# HELP metrics_aggregation The number of rows in aggregation
# TYPE metrics_aggregation counter
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_jvm_young_gc_count",level="1",dimensionality="minute",} 2.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_jvm_old_gc_time",level="1",dimensionality="minute",} 2.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="service_traffic",level="1",dimensionality="minute",} 15.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_metrics_first_aggregation",level="1",dimensionality="minute",} 1.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="instance_traffic",level="1",dimensionality="minute",} 15.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_jvm_young_gc_time",level="1",dimensionality="minute",} 2.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_persistence_timer_execute_latency_percentile",level="1",dimensionality="minute",} 1.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_persistence_timer_prepare_latency_percentile",level="1",dimensionality="minute",} 1.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_persistence_timer_execute_count",level="1",dimensionality="minute",} 1.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_jvm_memory_bytes_used",level="1",dimensionality="minute",} 2.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_cpu_percentage",level="1",dimensionality="minute",} 2.0
metrics_aggregation{sw_backend_instance="192.168.46.203_11800",metricName="meter_instance_persistence_timer_prepare_count",level="1",dimensionality="minute",} 1.0
# HELP jvm_info JVM version info
# TYPE jvm_info gauge
jvm_info{version="1.8.0_231-b11",vendor="Oracle Corporation",runtime="Java(TM) SE Runtime Environment",} 1.0
# HELP jvm_threads_current Current thread count of a JVM
# TYPE jvm_threads_current gauge
jvm_threads_current 117.0
# HELP jvm_threads_daemon Daemon thread count of a JVM
# TYPE jvm_threads_daemon gauge
jvm_threads_daemon 82.0
# HELP jvm_threads_peak Peak thread count of a JVM
# TYPE jvm_threads_peak gauge
jvm_threads_peak 117.0
# HELP jvm_threads_started_total Started thread count of a JVM
# TYPE jvm_threads_started_total counter
jvm_threads_started_total 119.0
# HELP jvm_threads_deadlocked Cycles of JVM-threads that are in deadlock waiting to acquire object monitors or ownable synchronizers
# TYPE jvm_threads_deadlocked gauge
jvm_threads_deadlocked 0.0
# HELP jvm_threads_deadlocked_monitor Cycles of JVM-threads that are in deadlock waiting to acquire object monitors
# TYPE jvm_threads_deadlocked_monitor gauge
jvm_threads_deadlocked_monitor 0.0
# HELP jvm_threads_state Current count of threads by state
# TYPE jvm_threads_state gauge
jvm_threads_state{state="WAITING",} 9.0
jvm_threads_state{state="NEW",} 0.0
jvm_threads_state{state="TERMINATED",} 0.0
jvm_threads_state{state="TIMED_WAITING",} 71.0
jvm_threads_state{state="RUNNABLE",} 37.0
jvm_threads_state{state="BLOCKED",} 0.0
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 28.321699
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.594016020813E9
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 321.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 10240.0
# HELP jvm_memory_bytes_used Used bytes of a given JVM memory area.
# TYPE jvm_memory_bytes_used gauge
jvm_memory_bytes_used{area="heap",} 2.90464424E8
jvm_memory_bytes_used{area="nonheap",} 8.9843344E7
# HELP jvm_memory_bytes_committed Committed (bytes) of a given JVM memory area.
# TYPE jvm_memory_bytes_committed gauge
jvm_memory_bytes_committed{area="heap",} 9.00202496E8
jvm_memory_bytes_committed{area="nonheap",} 9.3585408E7
# HELP jvm_memory_bytes_max Max (bytes) of a given JVM memory area.
# TYPE jvm_memory_bytes_max gauge
jvm_memory_bytes_max{area="heap",} 3.817865216E9
jvm_memory_bytes_max{area="nonheap",} -1.0
# HELP jvm_memory_bytes_init Initial bytes of a given JVM memory area.
# TYPE jvm_memory_bytes_init gauge
jvm_memory_bytes_init{area="heap",} 2.68435456E8
jvm_memory_bytes_init{area="nonheap",} 2555904.0
# HELP jvm_memory_pool_bytes_used Used bytes of a given JVM memory pool.
# TYPE jvm_memory_pool_bytes_used gauge
jvm_memory_pool_bytes_used{pool="Code Cache",} 1.7494464E7
jvm_memory_pool_bytes_used{pool="Metaspace",} 6.4223896E7
jvm_memory_pool_bytes_used{pool="Compressed Class Space",} 8124984.0
jvm_memory_pool_bytes_used{pool="PS Eden Space",} 2.57842816E8
jvm_memory_pool_bytes_used{pool="PS Survivor Space",} 0.0
jvm_memory_pool_bytes_used{pool="PS Old Gen",} 3.2621608E7
# HELP jvm_memory_pool_bytes_committed Committed bytes of a given JVM memory pool.
# TYPE jvm_memory_pool_bytes_committed gauge
jvm_memory_pool_bytes_committed{pool="Code Cache",} 1.8874368E7
jvm_memory_pool_bytes_committed{pool="Metaspace",} 6.6060288E7
jvm_memory_pool_bytes_committed{pool="Compressed Class Space",} 8650752.0
jvm_memory_pool_bytes_committed{pool="PS Eden Space",} 6.28621312E8
jvm_memory_pool_bytes_committed{pool="PS Survivor Space",} 3.4603008E7
jvm_memory_pool_bytes_committed{pool="PS Old Gen",} 2.36978176E8
# HELP jvm_memory_pool_bytes_max Max bytes of a given JVM memory pool.
# TYPE jvm_memory_pool_bytes_max gauge
jvm_memory_pool_bytes_max{pool="Code Cache",} 2.5165824E8
jvm_memory_pool_bytes_max{pool="Metaspace",} -1.0
jvm_memory_pool_bytes_max{pool="Compressed Class Space",} 1.073741824E9
jvm_memory_pool_bytes_max{pool="PS Eden Space",} 1.352138752E9
jvm_memory_pool_bytes_max{pool="PS Survivor Space",} 3.4603008E7
jvm_memory_pool_bytes_max{pool="PS Old Gen",} 2.863661056E9
# HELP jvm_memory_pool_bytes_init Initial bytes of a given JVM memory pool.
# TYPE jvm_memory_pool_bytes_init gauge
jvm_memory_pool_bytes_init{pool="Code Cache",} 2555904.0
jvm_memory_pool_bytes_init{pool="Metaspace",} 0.0
jvm_memory_pool_bytes_init{pool="Compressed Class Space",} 0.0
jvm_memory_pool_bytes_init{pool="PS Eden Space",} 6.7108864E7
jvm_memory_pool_bytes_init{pool="PS Survivor Space",} 1.1010048E7
jvm_memory_pool_bytes_init{pool="PS Old Gen",} 1.79306496E8
# HELP uptime oap server start up time
# TYPE uptime gauge
uptime{sw_backend_instance="192.168.46.203_11800",} 1.594016039539E9
# HELP remote_out_count The number(client side) of inside remote inside aggregate rpc.
# TYPE remote_out_count counter
remote_out_count{sw_backend_instance="192.168.46.203_11800",dest="10.81.84.89_11800",self="N",} 23.0
# HELP cluster_size Cluster size of current oap node
# TYPE cluster_size gauge
cluster_size{sw_backend_instance="192.168.46.203_11800",} 1.0
# HELP jvm_memory_pool_allocated_bytes_total Total bytes allocated in a given JVM memory pool. Only updated after GC, not continuously.
# TYPE jvm_memory_pool_allocated_bytes_total counter
jvm_memory_pool_allocated_bytes_total{pool="Code Cache",} 1.8737152E7
jvm_memory_pool_allocated_bytes_total{pool="PS Eden Space",} 1.554529624E9
jvm_memory_pool_allocated_bytes_total{pool="PS Old Gen",} 8.0695104E7
jvm_memory_pool_allocated_bytes_total{pool="PS Survivor Space",} 3.5909448E7
jvm_memory_pool_allocated_bytes_total{pool="Compressed Class Space",} 7496080.0
jvm_memory_pool_allocated_bytes_total{pool="Metaspace",} 5.9130136E7
# HELP jvm_gc_collection_seconds Time spent in a given JVM garbage collector in seconds.
# TYPE jvm_gc_collection_seconds summary
jvm_gc_collection_seconds_count{gc="PS Scavenge",} 16.0
jvm_gc_collection_seconds_sum{gc="PS Scavenge",} 0.176
jvm_gc_collection_seconds_count{gc="PS MarkSweep",} 3.0
jvm_gc_collection_seconds_sum{gc="PS MarkSweep",} 0.15
# HELP persistence_timer_bulk_prepare_latency Latency of the prepare stage in persistence timer
# TYPE persistence_timer_bulk_prepare_latency histogram
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.005",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.01",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.025",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.05",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.075",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.1",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.25",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.5",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="0.75",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="1.0",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="2.5",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="5.0",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="7.5",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="10.0",} 8.0
persistence_timer_bulk_prepare_latency_bucket{sw_backend_instance="192.168.46.203_11800",le="+Inf",} 8.0
persistence_timer_bulk_prepare_latency_count{sw_backend_instance="192.168.46.203_11800",} 8.0
persistence_timer_bulk_prepare_latency_sum{sw_backend_instance="192.168.46.203_11800",} 0.006293092
```

___
### New feature or improvement
- Describe the details and related test reports.
