### PR TITLE
#5013  update  @Column(columnName = ENTITY_ID, length = 512)     private String entityId;

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/endpoint/EndpointRelationServerSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/endpoint/EndpointRelationServerSideMetrics.java
@@ -59,7 +59,7 @@ public class EndpointRelationServerSideMetrics extends Metrics {
     private int componentId;
     @Setter
     @Getter
-    @Column(columnName = ENTITY_ID)
+    @Column(columnName = ENTITY_ID, length = 512)
     private String entityId;
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationClientSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationClientSideMetrics.java
@@ -69,7 +69,7 @@ public class ServiceInstanceRelationClientSideMetrics extends Metrics {
     private int componentId;
     @Setter
     @Getter
-    @Column(columnName = ENTITY_ID)
+    @Column(columnName = ENTITY_ID, length = 512)
     private String entityId;
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationServerSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationServerSideMetrics.java
@@ -69,7 +69,7 @@ public class ServiceInstanceRelationServerSideMetrics extends Metrics {
     private int componentId;
     @Setter
     @Getter
-    @Column(columnName = ENTITY_ID)
+    @Column(columnName = ENTITY_ID, length = 512)
     private String entityId;
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationClientSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationClientSideMetrics.java
@@ -59,7 +59,7 @@ public class ServiceRelationClientSideMetrics extends Metrics {
     private int componentId;
     @Setter
     @Getter
-    @Column(columnName = ENTITY_ID)
+    @Column(columnName = ENTITY_ID, length = 512)
     private String entityId;
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationServerSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationServerSideMetrics.java
@@ -59,7 +59,7 @@ public class ServiceRelationServerSideMetrics extends Metrics {
     private int componentId;
     @Setter
     @Getter
-    @Column(columnName = ENTITY_ID)
+    @Column(columnName = ENTITY_ID, length = 512)
     private String entityId;
 
     @Override


### PR DESCRIPTION

Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

#5013

___
### Bug fix
- Bug description.

description:
insert related table exceptions when using springcloudgateway2.1.X.

table list:

endpoint_relation_server_side
service_instance_relation_client_side
service_instance_relation_server_side
service_relation_client_side
service_relation_server_side

exception list:

2020-07-02 14:38:30,876 - org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLExecutor - 52 [pool-4-thread-1] DEBUG [] - execute
 aql in batch: UPDATE endpoint_relation_server_side SET
source_endpoint= ?,dest_endpoint= ?,component_id= ?,entity_id= ?,time_bucket= ? WHERE id = ?
2020-07-02 14:38:30,909 - org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLExecutor - 52 [pool-4-thread-1] DEBUG [] - execute
 aql in batch: INSERT INTO endpoint_relation_server_side VALUES
(?,?,?,?,?,?)
2020-07-02 14:38:30,913 - org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao.H2BatchDAO - 75 [pool-4-thread-1] ERROR [] - D
ata truncation: Data too long for column 'entity_id' at row 1
com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Data too long for column 'entity_id' at row 1


2020-07-07 11:35:51,485 - org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLExecutor - 52 [pool-4-thread-1] DEBUG [] - execute
 aql in batch: UPDATE endpoint_relation_server_side SET
source_endpoint= ?,dest_endpoint= ?,component_id= ?,entity_id= ?,time_bucket= ? WHERE id = ?
2020-07-07 11:35:51,518 - org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLExecutor - 52 [pool-4-thread-1] DEBUG [] - execute
 aql in batch: INSERT INTO service_instance_relation_client_side VALUES
(?,?,?,?,?,?,?,?)
2020-07-07 11:35:51,585 - org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLExecutor - 52 [pool-4-thread-1] DEBUG [] - execute
 aql in batch: INSERT INTO service_instance_relation_client_side VALUES
(?,?,?,?,?,?,?,?)
2020-07-07 11:35:51,589 - org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao.H2BatchDAO - 75 [pool-4-thread-1] ERROR [] - D
ata truncation: Data too long for column 'entity_id' at row 1
com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Data too long for column 'entity_id' at row 1

2020-07-07 11:36:19,347 - org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLExecutor - 52 [pool-4-thread-1] DEBUG [] - execute
 aql in batch: UPDATE service_instance_relation_server_side SET
source_service_id= ?,source_service_instance_id= ?,dest_service_id= ?,dest_service_instance_id= ?,component_id= ?,entity_id= ?,time_
bucket= ? WHERE id = ?
2020-07-07 11:36:19,396 - org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLExecutor - 52 [pool-4-thread-1] DEBUG [] - execute
 aql in batch: INSERT INTO service_instance_relation_server_side VALUES
(?,?,?,?,?,?,?,?)
2020-07-07 11:36:19,400 - org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao.H2BatchDAO - 75 [pool-4-thread-1] ERROR [] - D
ata truncation: Data too long for column 'entity_id' at row 1
com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Data too long for column 'entity_id' at row 1


- How to fix?

update @Column(columnName = ENTITY_ID, length = 512)

update java list:
EndpointRelationServerSideMetrics
ServiceInstanceRelationClientSideMetrics
ServiceInstanceRelationServerSideMetrics
ServiceRelationClientSideMetrics
ServiceRelationServerSideMetrics

init table list:
endpoint_relation_server_side
service_instance_relation_client_side
service_instance_relation_server_side
service_relation_client_side
service_relation_server_side

___
### New feature or improvement
- Describe the details and related test reports.
