### PR TITLE
optimization MetricsEsDAO multiGet

### DIFF
--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
@@ -44,8 +44,8 @@ public class MetricsEsDAO extends EsDAO implements IMetricsDAO {
     public List<Metrics> multiGet(Model model, List<String> ids) throws IOException {
         SearchResponse response = getClient().ids(model.getName(), ids.toArray(new String[0]));
 
-        List<Metrics> result = new ArrayList<>((int) response.getHits().totalHits);
-        for (int i = 0; i < response.getHits().totalHits; i++) {
+        List<Metrics> result = new ArrayList<>(response.getHits().getHits().length);
+        for (int i = 0; i < response.getHits().getHits().length; i++) {
             Metrics source = storageBuilder.map2Data(response.getHits().getAt(i).getSourceAsMap());
             result.add(source);
         }

--- a/oap-server/server-storage-plugin/storage-elasticsearch7-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch7/dao/MetricsEs7DAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch7-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch7/dao/MetricsEs7DAO.java
@@ -39,8 +39,8 @@ public class MetricsEs7DAO extends MetricsEsDAO {
     public List<Metrics> multiGet(Model model, List<String> ids) throws IOException {
         SearchResponse response = getClient().ids(model.getName(), ids.toArray(new String[0]));
 
-        List<Metrics> result = new ArrayList<>((int) response.getHits().getTotalHits().value);
-        for (int i = 0; i < response.getHits().getTotalHits().value; i++) {
+        List<Metrics> result = new ArrayList<>(response.getHits().getHits().length);
+        for (int i = 0; i < response.getHits().getHits().length; i++) {
             Metrics source = storageBuilder.map2Data(response.getHits().getAt(i).getSourceAsMap());
             result.add(source);
         }


### PR DESCRIPTION
See this issues [#5039](https://github.com/apache/skywalking/issues/5039)

The problem is because the es query times out
![image](https://user-images.githubusercontent.com/8274512/87400840-ed73d800-c5eb-11ea-8225-c5cd1e92d5a6.png)
Cause duplicate service_traffic
```
{
  "_index": "sw8_service_traffic-20200704",
  "_type": "type",
  "_id": "bWJwLWJvbnVzLWNhbGN1bGF0ZQ==.1",
  "_version": 1,
  "_score": 2,
  "_source": {
    "node_type": 0,
    "name": "mbp-bonus-calculate"
  }
}

{
  "_index": "sw8_service_traffic-20200706",
  "_type": "type",
  "_id": "bWJwLWJvbnVzLWNhbGN1bGF0ZQ==.1",
  "_version": 1,
  "_score": 2,
  "_source": {
    "node_type": 0,
    "name": "mbp-bonus-calculate"
  }
}
```
Then the server starts throw exception
![image](https://user-images.githubusercontent.com/8274512/87401584-e6999500-c5ec-11ea-99b6-d41aff1e4f7e.png)

View server source code, under normal circumstances method "ids" the return should be less than or equal to the length of String[] ids. However, because service_traffic is repeated, one id can search two results, resulting in totalHits greater than the actual. So throw ArrayIndexOutOfBoundsException.
![image](https://user-images.githubusercontent.com/8274512/87401937-69225480-c5ed-11ea-9505-7a26640e0b7c.png)
![image](https://user-images.githubusercontent.com/8274512/87401899-5c056580-c5ed-11ea-9459-25627617e36c.png)

***We should guarantee the stability of es, but there will always be unexpected situations, hoping that skywalking is fault-tolerant. Because in the previous version, at most only some trace data was lost.***