### PR TITLE
Fix apdex threshold config bug when dynamic configuration is enabled.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/ApdexThresholdConfig.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/ApdexThresholdConfig.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.configuration.api.ConfigChangeWatcher;
-import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.CoreModuleProvider;
 import org.apache.skywalking.oap.server.library.util.ResourceUtils;
@@ -43,7 +42,7 @@ public class ApdexThresholdConfig extends ConfigChangeWatcher implements Configu
 
     private Map<String, Integer> dictionary = Collections.emptyMap();
 
-    private String rawConfig = Const.EMPTY_STRING;
+    private String rawConfig;
 
     public ApdexThresholdConfig(final CoreModuleProvider provider) {
         super(CoreModule.NAME, provider, "apdexThreshold");
@@ -73,7 +72,7 @@ public class ApdexThresholdConfig extends ConfigChangeWatcher implements Configu
     @Override
     public void notify(ConfigChangeEvent value) {
         if (EventType.DELETE.equals(value.getEventType())) {
-            activeSetting("");
+            activeSetting(null);
         } else {
             activeSetting(value.getNewValue());
         }
@@ -89,7 +88,16 @@ public class ApdexThresholdConfig extends ConfigChangeWatcher implements Configu
             log.debug("Updating using new static config: {}", config);
         }
         rawConfig = config;
-        updateConfig(new StringReader(config));
+        if (config == null) {
+            try {
+                updateConfig(ResourceUtils.read(CONFIG_FILE_NAME));
+                return;
+            } catch (final FileNotFoundException e) {
+                log.error("Cannot config from: {}", CONFIG_FILE_NAME, e);
+            }
+        } else {
+            updateConfig(new StringReader(config));
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

   Fix apdex threshold config bug when dynamic configuration is enabled.
   This bug will result in a large number of warn logs, even if the service-apdex-threshold.yml file exist.
![image](https://user-images.githubusercontent.com/28091237/87415751-274ed980-c600-11ea-91b8-72cc5ee89909.png)


- How to fix?

   Optimize processing logic.
   If there is a core.default.apdexThreshold in the dynamic configuration, use it.
   If there is no core.default.apdexThreshold in the dynamic configuration, the service-apdex-threshold.yml file is read. And it is read only once when the configuration is switched. For example, delete core.default.apdexThreshold in the dynamic configuration.
   Only print the warn log if the service-apdex-threshold.yml file does not exist.

___
### New feature or improvement
- Describe the details and related test reports.
