### PR TITLE
Fix issue 4965

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/PreparedStatementExecuteMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/PreparedStatementExecuteMethodsInterceptor.java
@@ -43,7 +43,8 @@ public class PreparedStatementExecuteMethodsInterceptor implements InstanceMetho
         /**
          * For avoid NPE. In this particular case, Execute sql inside the {@link com.mysql.jdbc.ConnectionImpl} constructor,
          * before the interceptor sets the connectionInfo.
-         * Fixed https://github.com/apache/skywalking/issues/4965. When invoking prepareCall, cacheObject is null. Because it will determine procedures's parameter types by querying the table of proc in mysql.
+         * When invoking prepareCall, cacheObject is null. Because it will determine procedures's parameter types by executing sql in mysql 
+         * before the interceptor sets the statementEnhanceInfos.
          * @see JDBCDriverInterceptor#afterMethod(EnhancedInstance, Method, Object[], Class[], Object)
          */
         if (cacheObject != null && cacheObject.getConnectionInfo() != null) {

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/PreparedStatementExecuteMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/PreparedStatementExecuteMethodsInterceptor.java
@@ -72,7 +72,7 @@ public class PreparedStatementExecuteMethodsInterceptor implements InstanceMetho
     public final Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments,
                                     Class<?>[] argumentsTypes, Object ret) {
         StatementEnhanceInfos cacheObject = (StatementEnhanceInfos) objInst.getSkyWalkingDynamicField();
-        if (cacheObject.getConnectionInfo() != null) {
+        if (cacheObject != null && cacheObject.getConnectionInfo() != null) {
             ContextManager.stopSpan();
         }
         return ret;
@@ -82,7 +82,7 @@ public class PreparedStatementExecuteMethodsInterceptor implements InstanceMetho
     public final void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
                                             Class<?>[] argumentsTypes, Throwable t) {
         StatementEnhanceInfos cacheObject = (StatementEnhanceInfos) objInst.getSkyWalkingDynamicField();
-        if (cacheObject.getConnectionInfo() != null) {
+        if (cacheObject != null && cacheObject.getConnectionInfo() != null) {
             ContextManager.activeSpan().errorOccurred().log(t);
         }
     }

--- a/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
@@ -142,7 +142,7 @@ segmentItems:
     - operationName: Mysql/JDBI/Connection/close
       operationId: eq 0
       parentSpanId: 0
-      spanId: 7
+      spanId: 8
       tags:
       - {key: db.type, value: sql}
       - {key: db.instance, value: test}

--- a/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
@@ -72,10 +72,77 @@ segmentItems:
       componentId: 33
       peer: mysql-server:3306
       skipAnalysis: 'false'
-    - operationName: Mysql/JDBI/Connection/close
+    - operationName: Mysql/JDBI/Statement/execute
       operationId: eq 0
       parentSpanId: 0
       spanId: 4
+      tags:
+        - {key: db.type, value: sql}
+        - {key: db.instance, value: test}
+        - {key: db.statement, value: "create procedure testProcedure(IN id varchar(10)) \n begin \n select id; \n end"}
+      logs: []
+      startTime: nq 0
+      endTime: nq 0
+      isError: false
+      spanLayer: Database
+      spanType: Exit
+      componentId: 33
+      peer: mysql-server:3306
+      skipAnalysis: 'false'  
+    - operationName: Mysql/JDBI/Statement/executeQuery
+      operationId: eq 0
+      parentSpanId: 0
+      spanId: 5
+      spanLayer: Database
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 33
+      isError: false
+      spanType: Exit
+      peer: mysql-server:3306
+      skipAnalysis: false
+      tags:
+        - {key: db.type, value: sql}
+        - {key: db.instance, value: test}
+        - {key: db.statement, value: SHOW CREATE PROCEDURE `test`.`testProcedure`}
+    - operationName: Mysql/JDBI/CallableStatement/execute
+      operationId: eq 0
+      parentSpanId: 0
+      spanId: 6
+      tags:
+        - {key: db.type, value: sql}
+        - {key: db.instance, value: test}
+        - {key: db.statement, value: "call testProcedure( ? )"}
+      logs: []
+      startTime: nq 0
+      endTime: nq 0
+      isError: false
+      spanLayer: Database
+      spanType: Exit
+      componentId: 33
+      peer: mysql-server:3306
+      skipAnalysis: 'false'
+    - operationName: Mysql/JDBI/Statement/execute
+      operationId: eq 0
+      parentSpanId: 0
+      spanId: 7
+      tags:
+        - {key: db.type, value: sql}
+        - {key: db.instance, value: test}
+        - {key: db.statement, value: "drop procedure testProcedure"}
+      logs: []
+      startTime: nq 0
+      endTime: nq 0
+      isError: false
+      spanLayer: Database
+      spanType: Exit
+      componentId: 33
+      peer: mysql-server:3306
+      skipAnalysis: 'false'  
+    - operationName: Mysql/JDBI/Connection/close
+      operationId: eq 0
+      parentSpanId: 0
+      spanId: 7
       tags:
       - {key: db.type, value: sql}
       - {key: db.instance, value: test}

--- a/test/plugin/scenarios/mysql-scenario/src/main/java/org/apache/skywalking/apm/testcase/mysql/SQLExecutor.java
+++ b/test/plugin/scenarios/mysql-scenario/src/main/java/org/apache/skywalking/apm/testcase/mysql/SQLExecutor.java
@@ -51,11 +51,30 @@ public class SQLExecutor implements AutoCloseable {
     }
 
     public void dropTable(String sql) throws SQLException {
+        executeStatement(sql);
+    }
+    
+    public void createProcedure(String sql) throws SQLException {
+        executeStatement(sql);
+    }
+    
+    public void dropProcedure(String sql) throws SQLException {
+        executeStatement(sql);
+    }
+    
+    public void callProcedure(String sql, String id) throws SQLException {
+        PreparedStatement preparedStatement = connection.prepareCall(sql);
+        preparedStatement.setString(1, id);
+        preparedStatement.execute();
+        preparedStatement.close();
+    }
+    
+    public void executeStatement(String sql) throws SQLException {
         Statement preparedStatement = connection.createStatement();
         preparedStatement.execute(sql);
         preparedStatement.close();
     }
-
+    
     public void closeConnection() throws SQLException {
         if (this.connection != null) {
             this.connection.close();

--- a/test/plugin/scenarios/mysql-scenario/src/main/java/org/apache/skywalking/apm/testcase/mysql/controller/CaseController.java
+++ b/test/plugin/scenarios/mysql-scenario/src/main/java/org/apache/skywalking/apm/testcase/mysql/controller/CaseController.java
@@ -40,7 +40,10 @@ public class CaseController {
     private static final String QUERY_DATA_SQL = "SELECT id, value FROM test_007 WHERE id=?";
     private static final String DELETE_DATA_SQL = "DELETE FROM test_007 WHERE id=?";
     private static final String DROP_TABLE_SQL = "DROP table test_007";
-
+    private static final String CREATE_PROCEDURE_SQL = "create procedure testProcedure(IN id varchar(10)) \n begin \n select id; \n end";
+    private static final String CALL_PROCEDURE_SQL = "call testProcedure( ? )";
+    private static final String DROP_PROCEDURE_SQL = "drop procedure testProcedure";
+    
     @RequestMapping("/mysql-scenario")
     @ResponseBody
     public String testcase() throws Exception {
@@ -48,6 +51,9 @@ public class CaseController {
             sqlExecute.createTable(CREATE_TABLE_SQL);
             sqlExecute.insertData(INSERT_DATA_SQL, "1", "1");
             sqlExecute.dropTable(DROP_TABLE_SQL);
+            sqlExecute.createProcedure(CREATE_PROCEDURE_SQL);
+            sqlExecute.callProcedure(CALL_PROCEDURE_SQL, "nihao");
+            sqlExecute.dropProcedure(DROP_PROCEDURE_SQL);
         } catch (Exception e) {
             logger.error("Failed to execute sql.", e);
             throw e;


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#4965 
___
### Bug fix
- Bug description.
When invoking prepareCall, it will determine procedures's parameter types by execute sql. `StatementEnhanceInfos` is set after prepareCall, so `StatementEnhanceInfos` is null in `PreparedStatementExecuteMethodsInterceptor.beforeMethod`, the NPE was happen.
- How to fix?
I suggest to avoid NPE. We don't need to record sql which determine procedures's parameter.
___
### New feature or improvement
- Describe the details and related test reports.
