### PR TITLE
change the length of TopN.statement from 200 to 8192 (#5133)

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/topn/TopN.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/topn/TopN.java
@@ -35,7 +35,7 @@ public abstract class TopN extends Record implements ComparableStorageData {
 
     @Getter
     @Setter
-    @Column(columnName = STATEMENT, storageOnly = true)
+    @Column(columnName = STATEMENT, length = 8192 , storageOnly = true)
     private String statement;
     @Getter
     @Setter


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#5133
___
### Bug fix
- Bug description.
```java
org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao.H2BatchDAO - 75 [pool-4-thread-1] ERROR [] - Data truncation: Data too long for column 'statement' at row 1
com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Data too long for column 'statement' at row 1
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:104) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.ServerPreparedStatement.serverExecute(ServerPreparedStatement.java:634) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.ServerPreparedStatement.executeInternal(ServerPreparedStatement.java:414) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.ClientPreparedStatement.execute(ClientPreparedStatement.java:391) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.execute(ProxyPreparedStatement.java:44) ~[HikariCP-3.1.0.jar:?]
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.execute(HikariProxyPreparedStatement.java) ~[HikariCP-3.1.0.jar:?]
	at org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLExecutor.invoke(SQLExecutor.java:53) ~[storage-jdbc-hikaricp-plugin-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao.H2BatchDAO.synchronous(H2BatchDAO.java:72) ~[storage-jdbc-hikaricp-plugin-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at org.apache.skywalking.oap.server.core.storage.PersistenceTimer.extractDataAndSave(PersistenceTimer.java:122) ~[server-core-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at org.apache.skywalking.oap.server.core.storage.PersistenceTimer.lambda$start$0(PersistenceTimer.java:78) ~[server-core-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at org.apache.skywalking.apm.util.RunnableWithExceptionProtection.run(RunnableWithExceptionProtection.java:33) [apm-util-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_77]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_77]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_77]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_77]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_77]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_77]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_77]2020-07-20 11:39:49,353 - org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao.H2BatchDAO - 75 [pool-4-thread-1] ERROR [] - Data truncation: Data too long for column 'statement' at row 1
com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Data too long for column 'statement' at row 1
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:104) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.ServerPreparedStatement.serverExecute(ServerPreparedStatement.java:634) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.ServerPreparedStatement.executeInternal(ServerPreparedStatement.java:414) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.ClientPreparedStatement.execute(ClientPreparedStatement.java:391) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.execute(ProxyPreparedStatement.java:44) ~[HikariCP-3.1.0.jar:?]
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.execute(HikariProxyPreparedStatement.java) ~[HikariCP-3.1.0.jar:?]
	at org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLExecutor.invoke(SQLExecutor.java:53) ~[storage-jdbc-hikaricp-plugin-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao.H2BatchDAO.synchronous(H2BatchDAO.java:72) ~[storage-jdbc-hikaricp-plugin-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at org.apache.skywalking.oap.server.core.storage.PersistenceTimer.extractDataAndSave(PersistenceTimer.java:122) ~[server-core-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at org.apache.skywalking.oap.server.core.storage.PersistenceTimer.lambda$start$0(PersistenceTimer.java:78) ~[server-core-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at org.apache.skywalking.apm.util.RunnableWithExceptionProtection.run(RunnableWithExceptionProtection.java:33) [apm-util-8.1.0-SNAPSHOT.jar:8.1.0-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_77]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_77]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_77]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_77]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_77]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_77]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_77]
```
- How to fix?
@Column(columnName = STATEMENT, length = 8192 , storageOnly = true)
private String statement;
___
### New feature or improvement
- Describe the details and related test reports.
