### PR TITLE
Concurrent accessing allJars causes the plugin to fail to load

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
@@ -173,7 +173,7 @@ public class AgentClassLoader extends ClassLoader {
         if (allJars == null) {
             jarScanLock.lock();
             try {
-                if (allJars == null){
+                if (allJars == null) {
                     allJars = doGetJars();
                 }
             } finally {
@@ -184,7 +184,7 @@ public class AgentClassLoader extends ClassLoader {
         return allJars;
     }
 
-    private LinkedList<Jar> doGetJars(){
+    private LinkedList<Jar> doGetJars() {
         LinkedList<Jar> jars = new LinkedList<>();
         for (File path : classpath) {
             if (path.exists() && path.isDirectory()) {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
@@ -173,23 +173,8 @@ public class AgentClassLoader extends ClassLoader {
         if (allJars == null) {
             jarScanLock.lock();
             try {
-                if (allJars == null) {
-                    allJars = new LinkedList<>();
-                    for (File path : classpath) {
-                        if (path.exists() && path.isDirectory()) {
-                            String[] jarFileNames = path.list((dir, name) -> name.endsWith(".jar"));
-                            for (String fileName : jarFileNames) {
-                                try {
-                                    File file = new File(path, fileName);
-                                    Jar jar = new Jar(new JarFile(file), file);
-                                    allJars.add(jar);
-                                    logger.info("{} loaded.", file.toString());
-                                } catch (IOException e) {
-                                    logger.error(e, "{} jar file can't be resolved", fileName);
-                                }
-                            }
-                        }
-                    }
+                if (allJars == null){
+                    allJars = doGetJars();
                 }
             } finally {
                 jarScanLock.unlock();
@@ -197,6 +182,26 @@ public class AgentClassLoader extends ClassLoader {
         }
 
         return allJars;
+    }
+
+    private LinkedList<Jar> doGetJars(){
+        LinkedList<Jar> jars = new LinkedList<>();
+        for (File path : classpath) {
+            if (path.exists() && path.isDirectory()) {
+                String[] jarFileNames = path.list((dir, name) -> name.endsWith(".jar"));
+                for (String fileName : jarFileNames) {
+                    try {
+                        File file = new File(path, fileName);
+                        Jar jar = new Jar(new JarFile(file), file);
+                        jars.add(jar);
+                        logger.info("{} loaded.", file.toString());
+                    } catch (IOException e) {
+                        logger.error(e, "{} jar file can't be resolved", fileName);
+                    }
+                }
+            }
+        }
+        return jars;
     }
 
     @RequiredArgsConstructor


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
___
### Bug fix
- Bug description.

```
ERROR 2020-07-22 18:55:04:723 SkywalkingAgent-4-GRPCChannelManager-0 SkyWalkingAgent : Enhance class org.apache.skywalking.apm.toolkit.log.logback.v1.x.mdc.LogbackMDCPatternConverter error. 
org.apache.skywalking.apm.agent.core.plugin.PluginException: Can't create InstanceMethodsAroundInterceptor.
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.<init>(InstMethodsInter.java:54)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassEnhancePluginDefine.enhanceInstance(ClassEnhancePluginDefine.java:177)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassEnhancePluginDefine.enhance(ClassEnhancePluginDefine.java:74)
	at org.apache.skywalking.apm.agent.core.plugin.AbstractClassEnhancePluginDefine.define(AbstractClassEnhancePluginDefine.java:77)
	at org.apache.skywalking.apm.agent.SkyWalkingAgent$Transformer.transform(SkyWalkingAgent.java:135)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:10325)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10263)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1600(AgentBuilder.java:10029)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:10648)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:10595)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10186)
	at sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:428)
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at org.apache.skywalking.apm.toolkit.log.logback.v1.x.mdc.TraceIdMDCPatternLogbackLayout.<clinit>(TraceIdMDCPatternLogbackLayout.java:28)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at ch.qos.logback.core.joran.action.NestedComplexPropertyIA.begin(NestedComplexPropertyIA.java:121)
	at ch.qos.logback.core.joran.spi.Interpreter.callBeginAction(Interpreter.java:269)
	at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:145)
	at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:128)
	at ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:50)
	at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:165)
	at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:152)
	at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:110)
	at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:53)
	at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:75)
	at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:150)
	at org.slf4j.impl.StaticLoggerBinder.init(StaticLoggerBinder.java:84)
	at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:55)
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:412)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.Slf4JLoggerFactory.<init>(Slf4JLoggerFactory.java:42)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.InternalLoggerFactory.newDefaultFactory(InternalLoggerFactory.java:42)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.InternalLoggerFactory.getDefaultFactory(InternalLoggerFactory.java:67)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.InternalLoggerFactory.getInstance(InternalLoggerFactory.java:93)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.InternalLoggerFactory.getInstance(InternalLoggerFactory.java:86)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:80)
	at org.apache.skywalking.apm.dependencies.io.netty.util.AsciiString.<init>(AsciiString.java:222)
	at org.apache.skywalking.apm.dependencies.io.netty.util.AsciiString.<init>(AsciiString.java:209)
	at org.apache.skywalking.apm.dependencies.io.netty.util.AsciiString.cached(AsciiString.java:1406)
	at org.apache.skywalking.apm.dependencies.io.netty.util.AsciiString.<clinit>(AsciiString.java:47)
	at org.apache.skywalking.apm.dependencies.io.grpc.netty.Utils.<clinit>(Utils.java:72)
	at org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyChannelBuilder.<clinit>(NettyChannelBuilder.java:74)
	at org.apache.skywalking.apm.agent.core.remote.GRPCChannel.<init>(GRPCChannel.java:38)
	at org.apache.skywalking.apm.agent.core.remote.GRPCChannel.<init>(GRPCChannel.java:29)
	at org.apache.skywalking.apm.agent.core.remote.GRPCChannel$Builder.build(GRPCChannel.java:101)
	at org.apache.skywalking.apm.agent.core.remote.GRPCChannelManager.run(GRPCChannelManager.java:115)
	at org.apache.skywalking.apm.util.RunnableWithExceptionProtection.run(RunnableWithExceptionProtection.java:33)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ClassNotFoundException: Can't find org.apache.skywalking.apm.toolkit.activation.log.logback.v1.x.mdc.PrintMDCTraceIdInterceptor
	at org.apache.skywalking.apm.agent.core.plugin.loader.AgentClassLoader.findClass(AgentClassLoader.java:115)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at org.apache.skywalking.apm.agent.core.plugin.loader.InterceptorInstanceLoader.load(InterceptorInstanceLoader.java:71)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.<init>(InstMethodsInter.java:52)
	... 71 more
```



```
ERROR 2020-07-22 18:46:19:963 SkywalkingAgent-4-GRPCChannelManager-0 SkyWalkingAgent : Enhance class org.apache.skywalking.apm.toolkit.log.logback.v1.x.mdc.LogbackMDCPatternConverter error. 
org.apache.skywalking.apm.agent.core.plugin.PluginException: Can't create InstanceMethodsAroundInterceptor.
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.<init>(InstMethodsInter.java:54)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassEnhancePluginDefine.enhanceInstance(ClassEnhancePluginDefine.java:177)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassEnhancePluginDefine.enhance(ClassEnhancePluginDefine.java:74)
	at org.apache.skywalking.apm.agent.core.plugin.AbstractClassEnhancePluginDefine.define(AbstractClassEnhancePluginDefine.java:77)
	at org.apache.skywalking.apm.agent.SkyWalkingAgent$Transformer.transform(SkyWalkingAgent.java:135)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:10325)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10263)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1600(AgentBuilder.java:10029)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:10648)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:10595)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10186)
	at sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:428)
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at org.apache.skywalking.apm.toolkit.log.logback.v1.x.mdc.TraceIdMDCPatternLogbackLayout.<clinit>(TraceIdMDCPatternLogbackLayout.java:28)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at ch.qos.logback.core.joran.action.NestedComplexPropertyIA.begin(NestedComplexPropertyIA.java:121)
	at ch.qos.logback.core.joran.spi.Interpreter.callBeginAction(Interpreter.java:269)
	at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:145)
	at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:128)
	at ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:50)
	at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:165)
	at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:152)
	at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:110)
	at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:53)
	at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:75)
	at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:150)
	at org.slf4j.impl.StaticLoggerBinder.init(StaticLoggerBinder.java:84)
	at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:55)
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:412)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.Slf4JLoggerFactory.<init>(Slf4JLoggerFactory.java:42)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.InternalLoggerFactory.newDefaultFactory(InternalLoggerFactory.java:42)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.InternalLoggerFactory.getDefaultFactory(InternalLoggerFactory.java:67)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.InternalLoggerFactory.getInstance(InternalLoggerFactory.java:93)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.logging.InternalLoggerFactory.getInstance(InternalLoggerFactory.java:86)
	at org.apache.skywalking.apm.dependencies.io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:80)
	at org.apache.skywalking.apm.dependencies.io.netty.util.AsciiString.<init>(AsciiString.java:222)
	at org.apache.skywalking.apm.dependencies.io.netty.util.AsciiString.<init>(AsciiString.java:209)
	at org.apache.skywalking.apm.dependencies.io.netty.util.AsciiString.cached(AsciiString.java:1406)
	at org.apache.skywalking.apm.dependencies.io.netty.util.AsciiString.<clinit>(AsciiString.java:47)
	at org.apache.skywalking.apm.dependencies.io.grpc.netty.Utils.<clinit>(Utils.java:72)
	at org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyChannelBuilder.<clinit>(NettyChannelBuilder.java:74)
	at org.apache.skywalking.apm.agent.core.remote.GRPCChannel.<init>(GRPCChannel.java:38)
	at org.apache.skywalking.apm.agent.core.remote.GRPCChannel.<init>(GRPCChannel.java:29)
	at org.apache.skywalking.apm.agent.core.remote.GRPCChannel$Builder.build(GRPCChannel.java:101)
	at org.apache.skywalking.apm.agent.core.remote.GRPCChannelManager.run(GRPCChannelManager.java:115)
	at org.apache.skywalking.apm.util.RunnableWithExceptionProtection.run(RunnableWithExceptionProtection.java:33)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.util.ConcurrentModificationException
	at java.util.LinkedList$ListItr.checkForComodification(LinkedList.java:966)
	at java.util.LinkedList$ListItr.next(LinkedList.java:888)
	at org.apache.skywalking.apm.agent.core.plugin.loader.AgentClassLoader.findClass(AgentClassLoader.java:94)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at org.apache.skywalking.apm.agent.core.plugin.loader.InterceptorInstanceLoader.load(InterceptorInstanceLoader.java:71)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.<init>(InstMethodsInter.java:52)
	... 71 more
```

any plugins can fail to load as allJars don't add all jar in the classpath.
- How to fix?
get allJars serially
