### PR TITLE
Support regular expression in labelFilter

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/metric/promethues/PrometheusMetricConverter.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/metric/promethues/PrometheusMetricConverter.java
@@ -118,7 +118,8 @@ public class PrometheusMetricConverter {
                             return true;
                         }
                         return rule._3.getLabelFilter().stream()
-                            .allMatch(matchRule -> matchRule.getOptions().contains(metric.getLabels().get(matchRule.getKey())));
+                            .allMatch(matchRule -> matchRule.getOptions().stream()
+                                .anyMatch(metric.getLabels().get(matchRule.getKey())::matches));
                     })
                     .map(rule -> Tuple.of(rule._1, rule._2, rule._3, metric))
             )


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

___
### New feature or improvement
The labelFilter supports regular expression to filter labels. This feature provides a more flexible path for users to extract and aggregate metrics.

For instance,  `http_request_count` metric has a `status` label to indicate the status code. If users want to sum all of 4xx(400, 404 and etc) request, they can configure `4\d{2}` to match them.

I don't intend to pre-compile the regular expression to improve the performance due to the low frequency of the Prometheus fetcher/receiver interval. Before some performance concerns are raised, I prefer to use cleaner and simpler implement.
