### PR TITLE
Update doc links for adopting the 2 nodejs agents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The core features are following.
 SkyWalking supports to collect telemetry (traces and metrics) data from multiple sources
 and multiple formats,
 including
-1. Java, [.NET Core](https://github.com/SkyAPM/SkyAPM-dotnet), [NodeJS](https://github.com/SkyAPM/SkyAPM-nodejs), [PHP](https://github.com/SkyAPM/SkyAPM-php-sdk) and [Python](https://github.com/apache/skywalking-python) auto-instrument agents.
-1. [Go agent](https://github.com/tetratelabs/go2sky).
-1. [LUA agent](https://github.com/apache/skywalking-nginx-lua), especially for Nginx, OpenResty.
+1. Java, .NET Core, NodeJS, PHP, and Python auto-instrument agents.
+1. Go agent.
+1. LUA agent especially for Nginx, OpenResty.
 1. Service Mesh Observability. Support Mixer telemetry. Recommend to use Envoy Access Log Service (ALS) for better performance, first introduced at [KubeCon 2019](https://www.youtube.com/watch?v=tERm39ju9ew).
 1. Metrics system, including Prometheus, Spring Sleuth(Micrometer).
 1. Zipkin v1/v2 and Jaeger gRPC format with limited topology and metrics analysis.(Experimental).
@@ -46,7 +46,8 @@ SkyWalking OAP is using the STAM(Streaming Topology Analysis Method) to analysis
 for better performance. Read [the paper of STAM](https://wu-sheng.github.io/STAM/) for more details.
 
 # Document
-[8.x dev](docs/README.md), 
+[8.x dev](docs/README.md),
+[8.1.0](https://github.com/apache/skywalking/blob/v8.1.0/docs/README.md),  
 [8.0.1](https://github.com/apache/skywalking/blob/v8.0.1/docs/README.md), 
 [8.0.0](https://github.com/apache/skywalking/blob/v8.0.0/docs/README.md) 
 | [7.0](https://github.com/apache/skywalking/blob/v7.0.0/docs/README.md) 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ From here you can learn all about **SkyWalking**’s architecture, how to deploy
 
 - [Concepts and Designs](en/concepts-and-designs/README.md). You'll find the the most important core ideas about SkyWalking. You can learn from here if you want to understand what is going on under our cool features and visualization.
 
-- [Setup](en/setup/README.md). Guides for installing SkyWalking in different scenarios. As a platform, it provides several ways to provide observability, including monitoring and alarm of course.
+- [Setup](en/setup/README.md). Guides for installing SkyWalking in different scenarios. As a platform, it provides several ways of the observability.
 
 - [UI Introduction](en/ui/README.md). Introduce the UI usage and features. 
 
@@ -56,6 +56,7 @@ If you are already familiar with SkyWalking, you could use this catalog to find 
 * [Setup](en/setup/README.md).
   * Backend, UI, Java agent, and CLI are Apache official release, you could find them at [Apache SkyWalking DOWNLOAD page](http://skywalking.apache.org/downloads/).
   * Language agents in Service
+    * All available [agents](en/setup/README.md#language-agents-in-service) for different languages.
     * [Java agent](en/setup/service-agent/java-agent/README.md). Introduces how to install the java agent to your service, without changing any code.
       * [Supported middleware, framework and library](en/setup/service-agent/java-agent/Supported-list.md).
       * [Agent Configuration Properties](en/setup/service-agent/java-agent/README.md#table-of-agent-configuration-properties).

--- a/docs/en/setup/README.md
+++ b/docs/en/setup/README.md
@@ -18,6 +18,8 @@ If you have any issues, please check that your issue is not already described in
 
 - [Python Agent](https://github.com/apache/skywalking-python). Introduce how to install the Python Agent in a Python service.
 
+- [Node.js agent](https://github.com/apache/skywalking-nodejs). Introduce how to install the NodeJS Agent in a NodeJS service.
+
 The following agents and SDKs are compatible with the SkyWalking's data formats and network protocols, but are maintained by 3rd-parties.
 You can go to their project repositories for additional info about guides and releases.
 


### PR DESCRIPTION
Keep community provided nodejs agent and official nodejs in the same position.