### PR TITLE
Support for the remote debugging of local E2E testing framework 

### DIFF
--- a/test/e2e/e2e-common/src/main/java/org/apache/skywalking/e2e/docker/DockerComposeFile.java
+++ b/test/e2e/e2e-common/src/main/java/org/apache/skywalking/e2e/docker/DockerComposeFile.java
@@ -18,12 +18,48 @@
 
 package org.apache.skywalking.e2e.docker;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import lombok.Data;
+
+import static org.apache.skywalking.e2e.utils.Yamls.load;
 
 @Data
 public final class DockerComposeFile {
     private String version;
     private Map<String, Map<String, Object>> services;
     private Map<String, Map<String, Object>> networks;
+
+    public static DockerComposeFile getAllConfigInfo(String composeFile) throws IOException, InterruptedException {
+        String shStr = String.format("docker-compose -f %s config", composeFile);
+        Process process = Runtime.getRuntime().exec(shStr, null, null);
+        InputStreamReader ir = new InputStreamReader(process.getInputStream());
+        LineNumberReader input = new LineNumberReader(ir);
+        String line;
+        StringBuilder result = new StringBuilder();
+        process.waitFor();
+        while ((line = input.readLine()) != null) {
+            result.append(line).append("\n");
+        }
+        return load(result).as(DockerComposeFile.class);
+    }
+
+    public List<String> getServiceExposedPorts(String serviceName) {
+        Map<String, Object> service = services.get(serviceName);
+        List<String> ports = (List<String>) service.get("expose");
+        if (ports == null) {
+            ports = new LinkedList<>();
+        }
+        return ports;
+    }
+
+    public boolean isExposedPort(String serviceName, Integer port) {
+        List<String> ports = getServiceExposedPorts(serviceName);
+        return ports.contains(String.valueOf(port));
+    }
+
 }

--- a/test/e2e/e2e-common/src/main/java/org/apache/skywalking/e2e/utils/Yamls.java
+++ b/test/e2e/e2e-common/src/main/java/org/apache/skywalking/e2e/utils/Yamls.java
@@ -59,4 +59,13 @@ public final class Yamls {
             }
         };
     }
+
+    public static AsTypeBuilder load(final StringBuilder content) {
+        return new AsTypeBuilder() {
+            @Override
+            public <T> T as(final Class<T> klass) {
+                return new Yaml().loadAs(content.toString(), klass);
+            }
+        };
+    }
 }

--- a/test/e2e/e2e-common/src/test/java/org/apache/skywalking/e2e/docker/DockerComposeFileTest.java
+++ b/test/e2e/e2e-common/src/test/java/org/apache/skywalking/e2e/docker/DockerComposeFileTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.e2e.docker;
+
+import org.apache.skywalking.e2e.utils.Yamls;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+
+class DockerComposeFileTest {
+    private static DockerComposeFile COMPOSE_FILE = null;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        COMPOSE_FILE = Yamls.load("docker-compose.yml").as(DockerComposeFile.class);
+    }
+
+    @Test
+    void getAllConfigInfo() throws IOException, InterruptedException, URISyntaxException {
+        File file = new File(DockerComposeFileTest.class
+                .getClassLoader()
+                .getResource("docker-compose.yml")
+                .toURI());
+        DockerComposeFile testFile = DockerComposeFile.getAllConfigInfo(file.getAbsolutePath());
+        Assert.assertNotNull(testFile);
+        Assert.assertNotNull(testFile.getServices());
+        Assert.assertEquals(COMPOSE_FILE.getServices().size(), testFile.getServices().size());
+        Assert.assertEquals(COMPOSE_FILE.getVersion(), testFile.getVersion());
+    }
+
+    @Test
+    void getServiceExposedPort() {
+        List<String> ports = COMPOSE_FILE.getServiceExposedPorts("oap");
+        Assert.assertNotNull(ports);
+        Assert.assertEquals(3, ports.size());
+    }
+
+    @Test
+    void isExposedPort() {
+        boolean result = COMPOSE_FILE.isExposedPort("oap", 5005);
+        Assert.assertTrue(result);
+        result = COMPOSE_FILE.isExposedPort("oap", 5006);
+        Assert.assertFalse(result);
+    }
+}

--- a/test/e2e/e2e-common/src/test/resources/docker-compose.yml
+++ b/test/e2e/e2e-common/src/test/resources/docker-compose.yml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+version: '2.1'
+
+services:
+  oap:
+    environment:
+      JAVA_OPTS: -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap,destfile=/jacoco/oap.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+      SW_CLUSTER_ZK_HOST_PORT: zk:2181
+      SW_JDBC_URL: jdbc:mysql://mysql:3306/swtest
+      SW_STORAGE_ES_CLUSTER_NODES: es:9200
+      SW_STORAGE_INFLUXDB_URL: http://influxdb:8086
+    expose:
+      - '11800'
+      - '12800'
+      - '5005'
+    healthcheck:
+      interval: 5s
+      retries: 120
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9090"]
+      timeout: 1m
+    image: skywalking/oap:latest
+    networks:
+      - e2e
+    restart: on-failure
+    volumes:
+      - /root/skywalking/test/e2e/e2e-test/docker/download-mysql.sh:/download-mysql.sh:rw
+      - /root/skywalking/test/jacoco:/jacoco:rw
+  provider:
+    build:
+      args:
+        SW_AGENT_JDK_VERSION: ''
+      context: /root/skywalking/test/e2e
+      dockerfile: e2e-test/docker/Dockerfile.provider
+    depends_on:
+      oap:
+        condition: service_healthy
+    environment:
+      JAVA_OPTS: -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/provider,destfile=/jacoco/provider.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.apm.dependencies.*
+        -javaagent:/skywalking/agent/skywalking-agent.jar=logging.output=CONSOLE -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+    expose:
+      - '5005'
+      - '9090'
+    healthcheck:
+      interval: 5s
+      retries: 120
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9090"]
+      timeout: 1m
+    networks:
+      - e2e
+    volumes:
+      - /root/skywalking/test/jacoco:/jacoco:rw
+  ui:
+    depends_on:
+      oap:
+        condition: service_healthy
+    environment:
+      SW_OAP_ADDRESS: oap:12800
+    expose:
+      - '8080'
+    image: skywalking/ui:latest
+    networks:
+      - e2e
+
+networks:
+  e2e: {}

--- a/test/e2e/e2e-test/docker/base-compose.yml
+++ b/test/e2e/e2e-test/docker/base-compose.yml
@@ -21,6 +21,7 @@ services:
     expose:
       - 11800
       - 12800
+      - 5005
     networks:
       - e2e
     restart: on-failure
@@ -34,6 +35,7 @@ services:
       SW_STORAGE_INFLUXDB_URL: http://influxdb:8086
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap,destfile=/jacoco/oap.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -zn 127.0.0.1 11800"]
       interval: 5s
@@ -45,6 +47,7 @@ services:
     expose:
       - 11800
       - 12800
+      - 5005
     networks:
       - e2e
     restart: on-failure
@@ -58,6 +61,7 @@ services:
       SW_STORAGE_INFLUXDB_URL: http://influxdb:8086
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap,destfile=/jacoco/oap.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -zn 127.0.0.1 11800"]
       interval: 5s
@@ -83,6 +87,7 @@ services:
       - e2e
     expose:
       - 9090
+      - 5005
     volumes:
       - ../../../jacoco:/jacoco
     environment:
@@ -90,6 +95,7 @@ services:
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/provider,destfile=/jacoco/provider.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.apm.dependencies.*
         -javaagent:/skywalking/agent/skywalking-agent.jar=logging.output=CONSOLE
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9090"]
       interval: 5s
@@ -106,6 +112,7 @@ services:
       - e2e
     expose:
       - 9092
+      - 5005
     volumes:
       - ../../../jacoco:/jacoco
     environment:
@@ -113,6 +120,7 @@ services:
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/consumer,destfile=/jacoco/consumer.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.apm.dependencies.*
         -javaagent:/skywalking/agent/skywalking-agent.jar=logging.output=CONSOLE
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9092"]
       interval: 5s

--- a/test/e2e/e2e-test/docker/cluster/docker-compose.yml
+++ b/test/e2e/e2e-test/docker/cluster/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/provider1,destfile=/jacoco/provider1.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.apm.dependencies.*
         -javaagent:/skywalking/agent/skywalking-agent.jar=logging.output=CONSOLE,agent.instance_name=provider1
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       oap1:
         condition: service_healthy
@@ -52,6 +53,7 @@ services:
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/provider2,destfile=/jacoco/provider2.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.apm.dependencies.*
         -javaagent:/skywalking/agent/skywalking-agent.jar=logging.output=CONSOLE,agent.instance_name=provider2
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       oap2:
         condition: service_healthy
@@ -67,6 +69,7 @@ services:
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/consumer,destfile=/jacoco/consumer.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.apm.dependencies.*
         -javaagent:/skywalking/agent/skywalking-agent.jar=logging.output=CONSOLE,agent.instance_name=consumer
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       oap1:
         condition: service_healthy

--- a/test/e2e/e2e-test/docker/cluster/docker-compose.zk.es6.yml
+++ b/test/e2e/e2e-test/docker/cluster/docker-compose.zk.es6.yml
@@ -40,6 +40,7 @@ services:
       SW_STORAGE: elasticsearch
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap1,destfile=/jacoco/oap1.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       zk:
         condition: service_healthy
@@ -55,6 +56,7 @@ services:
       SW_STORAGE: elasticsearch
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap2,destfile=/jacoco/oap2.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       zk:
         condition: service_healthy

--- a/test/e2e/e2e-test/docker/cluster/docker-compose.zk.es7.yml
+++ b/test/e2e/e2e-test/docker/cluster/docker-compose.zk.es7.yml
@@ -40,6 +40,7 @@ services:
       SW_STORAGE: elasticsearch7
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap1,destfile=/jacoco/oap1.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       zk:
         condition: service_healthy
@@ -55,6 +56,7 @@ services:
       SW_STORAGE: elasticsearch7
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap2,destfile=/jacoco/oap2.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       zk:
         condition: service_healthy

--- a/test/e2e/e2e-test/docker/cluster/docker-compose.zk.influxdb.yml
+++ b/test/e2e/e2e-test/docker/cluster/docker-compose.zk.influxdb.yml
@@ -37,6 +37,7 @@ services:
       SW_STORAGE: influxdb
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap1,destfile=/jacoco/oap1.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       zk:
         condition: service_healthy
@@ -52,6 +53,7 @@ services:
       SW_STORAGE: influxdb
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap2,destfile=/jacoco/oap2.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       zk:
         condition: service_healthy

--- a/test/e2e/e2e-test/docker/cluster/docker-compose.zk.mysql.yml
+++ b/test/e2e/e2e-test/docker/cluster/docker-compose.zk.mysql.yml
@@ -41,6 +41,7 @@ services:
       SW_STORAGE: mysql
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap1,destfile=/jacoco/oap1.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     entrypoint: ['sh', '-c', '/download-mysql.sh && /skywalking/docker-entrypoint.sh']
     depends_on:
       zk:
@@ -57,6 +58,7 @@ services:
       SW_STORAGE: mysql
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap2,destfile=/jacoco/oap2.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     entrypoint: ['sh', '-c', '/download-mysql.sh && /skywalking/docker-entrypoint.sh']
     depends_on:
       zk:

--- a/test/e2e/e2e-test/docker/gateway/docker-compose.yml
+++ b/test/e2e/e2e-test/docker/gateway/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       SW_STORAGE: elasticsearch
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap1,destfile=/jacoco/oap1.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     volumes:
       - ./gateways.yml:/skywalking/config/gateways.yml
     depends_on:
@@ -69,6 +70,7 @@ services:
       SW_STORAGE: elasticsearch
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap2,destfile=/jacoco/oap2.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     volumes:
       - ./gateways.yml:/skywalking/config/gateways.yml
     depends_on:

--- a/test/e2e/e2e-test/docker/simple/auth/docker-compose.yml
+++ b/test/e2e/e2e-test/docker/simple/auth/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       JAVA_OPTS: >-
         -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/provider,destfile=/jacoco/provider.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.apm.dependencies.*
         -javaagent:/skywalking/agent/skywalking-agent.jar=logging.output=CONSOLE,agent.authentication=test-token
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
     depends_on:
       oap:
         condition: service_healthy


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
### Motivation
If a developer fails to execute the E2E test locally, he needs to judge the bug through the log output, correct the code, and executing the E2E test again to check whether the bug is fixed. This process is time-consuming, especially in finding bugs and re-deploying the E2E test environment. If the test framework allows developers to debug remotely during local E2E testing, a lot of time will be saved.
### Goals
1. Open the container debugging port in the local E2E test environment to bind with the host port to support remote debugging.
2. The remote debugging is simple and easy to use.
3. The remote debugging should be off in the ci environment.
### Method
#### Judging the environment
In the original code, the variable `IS_CI` is used to judge the environment whether is a ci environment. Thus, we also use it to judge the environment.

#### Remote debugging port
We designated `5005` as the remote debugging port of a container. If a container requires the remote debugging,  it needs to expose the port `5005`. The program judges a container whether exposes the port `5005` by using the command `docker-compose config`.  The command `docker-compose config` can get the all config information even if the `docker-compose.yml` inherits other configuration files, like [skywalking/test/e2e/e2e-test/docker/simple/jdk/docker-compose.yml](https://github.com/apache/skywalking/blob/master/test/e2e/e2e-test/docker/simple/jdk/docker-compose.yml). 

#### Getting Remote debugging containers
If the container exposes the port `5005`, the program will add it to a list. Containers in this list need the remote debugging.

#### Binding the remote debugging port
After getting the remote debugging containers, the program uses the `testcontainers` framework to map the port `5005` of containers to the ports not used by the host and write the mapping information to a file `remote_real_port`.

### Compatibility
Because no previous container configuration exposed the port `5005`, the change is no effect on previous versions.
### Using remote debugging
For the developers, if they want to use remote debugging, they only need to add the remote debugging parameters to the configuration file `docker-compose.yml` and expose the port `5005`. For example, this is the configuration of a container in the [skywalking/test/e2e/e2e-test/docker/base-compose.yml](https://github.com/apache/skywalking/blob/master/test/e2e/e2e-test/docker/base-compose.yml).
```yml
oap:
    image: skywalking/oap:latest
    expose:
      - 11800
      - 12800
    networks:
      - e2e
    restart: on-failure
    volumes:
      - ../../../jacoco:/jacoco
      - ./download-mysql.sh:/download-mysql.sh
    environment:
      SW_CLUSTER_ZK_HOST_PORT: zk:2181
      SW_STORAGE_ES_CLUSTER_NODES: es:9200
      SW_JDBC_URL: jdbc:mysql://mysql:3306/swtest
      SW_STORAGE_INFLUXDB_URL: http://influxdb:8086
      JAVA_OPTS: >-
        -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap,destfile=/jacoco/oap.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
    healthcheck:
      test: ["CMD", "sh", "-c", "nc -zn 127.0.0.1 11800"]
      interval: 5s
      timeout: 60s
      retries: 120
```
To using remote debugging, the configuration adds the debugging parameters `agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005` of JAVA and exposes the port `5005`.
```yml
oap:
    image: skywalking/oap:latest
    expose:
      - 11800
      - 12800
      - 5005
    networks:
      - e2e
    restart: on-failure
    volumes:
      - ../../../jacoco:/jacoco
      - ./download-mysql.sh:/download-mysql.sh
    environment:
      SW_CLUSTER_ZK_HOST_PORT: zk:2181
      SW_STORAGE_ES_CLUSTER_NODES: es:9200
      SW_JDBC_URL: jdbc:mysql://mysql:3306/swtest
      SW_STORAGE_INFLUXDB_URL: http://influxdb:8086
      JAVA_OPTS: >-
        -javaagent:/jacoco/jacocoagent.jar=classdumpdir=/jacoco/classes/oap,destfile=/jacoco/oap.exec,includes=org.apache.skywalking.*,excludes=org.apache.skywalking.oap.query.*:org.apache.skywalking.oap.server.core.query.*
        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
    healthcheck:
      test: ["CMD", "sh", "-c", "nc -zn 127.0.0.1 11800"]
      interval: 5s
      timeout: 60s
      retries: 120
```
Then, if the E2E test failed and is retrying， the developer can get the ports mapping in the file `skywalking/test/e2e/e2e-test/remote_real_port` and selects the host port of the corresponding service for remote debugging.