### PR TITLE
 add a commons config API for get config key/value by: Config.getProperty

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.apm.agent.core.conf;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
 import org.apache.skywalking.apm.agent.core.logging.core.LogLevel;
 import org.apache.skywalking.apm.agent.core.logging.core.LogOutput;
@@ -278,5 +279,18 @@ public class Config {
          * Max value length of each element.
          */
         public static int VALUE_MAX_LENGTH = 128;
+    }
+
+    /**
+     * Commons config API for get config property value for the key.
+     * @param key - config key
+     * @param defaultValue -  default value for the key
+     * @return the value in this property list with the specified key value.
+     */
+    public static String getProperty(final String key, final String defaultValue) {
+        if (SnifferConfigInitializer.AGENT_SETTINGS == null) {//safe for invoke before init
+            return defaultValue;
+        }
+        return SnifferConfigInitializer.AGENT_SETTINGS.getProperty(key, defaultValue);
     }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/SnifferConfigInitializer.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/SnifferConfigInitializer.java
@@ -44,7 +44,7 @@ public class SnifferConfigInitializer {
     private static final String SPECIFIED_CONFIG_PATH = "skywalking_config";
     private static final String DEFAULT_CONFIG_FILE_NAME = "/config/agent.config";
     private static final String ENV_KEY_PREFIX = "skywalking.";
-    private static Properties AGENT_SETTINGS;
+    static Properties AGENT_SETTINGS;
     private static boolean IS_INIT_COMPLETED = false;
 
     /**


### PR DESCRIPTION
with this config API, the external plugin can get config without change the apm-agent-core Config.java.

then using as below:
````
  private static final int CUSTOM_CMP_ID = Integer.parseInt(Config.getProperty("ex_plugin_comp_id", "100"));
````

Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [*] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
添加此通用配置API的目的：
* 为外部扩展插件提供一种统一的方式来存取配置项
* 原来的方式添加配置项要修改Config类的方式不适用于外部插件
