### PR TITLE
[MySQL storage] Make the column length of slow DB statement having the good default value

### DIFF
--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/AnalyzerModuleConfig.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/AnalyzerModuleConfig.java
@@ -68,7 +68,9 @@ public class AnalyzerModuleConfig extends ModuleConfig {
     @Getter
     private boolean traceAnalysis = true;
     /**
-     * Slow Sql string length can't beyond this limit
+     * Slow Sql string length can't beyond this limit. This value should be as same as the length annotation at the
+     * {@code org.apache.skywalking.oap.server.core.analysis.manual.database.TopNDatabaseStatement#statement}. And share
+     * the system env name, SW_SLOW_DB_THRESHOLD
      */
     @Setter
     @Getter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/database/TopNDatabaseStatement.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/database/TopNDatabaseStatement.java
@@ -21,23 +21,28 @@ package org.apache.skywalking.oap.server.core.analysis.manual.database;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import lombok.Getter;
 import lombok.Setter;
 import org.apache.skywalking.oap.server.core.analysis.Stream;
 import org.apache.skywalking.oap.server.core.analysis.topn.TopN;
 import org.apache.skywalking.oap.server.core.analysis.worker.TopNStreamProcessor;
 import org.apache.skywalking.oap.server.core.source.DefaultScopeDefine;
 import org.apache.skywalking.oap.server.core.storage.StorageBuilder;
+import org.apache.skywalking.oap.server.core.storage.annotation.Column;
 
 /**
  * Database TopN statement, including Database SQL statement, mongoDB and Redis commands.
  */
 @Stream(name = TopNDatabaseStatement.INDEX_NAME, scopeId = DefaultScopeDefine.DATABASE_SLOW_STATEMENT, builder = TopNDatabaseStatement.Builder.class, processor = TopNStreamProcessor.class)
 public class TopNDatabaseStatement extends TopN {
-
     public static final String INDEX_NAME = "top_n_database_statement";
 
     @Setter
     private String id;
+    @Getter
+    @Setter
+    @Column(columnName = STATEMENT, length = 2000, lengthEnvVariable = "SW_SLOW_DB_THRESHOLD", storageOnly = true)
+    private String statement;
 
     @Override
     public String id() {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/topn/TopN.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/topn/TopN.java
@@ -32,11 +32,7 @@ public abstract class TopN extends Record implements ComparableStorageData {
     public static final String LATENCY = "latency";
     public static final String TRACE_ID = "trace_id";
     public static final String SERVICE_ID = "service_id";
-
-    @Getter
-    @Setter
-    @Column(columnName = STATEMENT, storageOnly = true)
-    private String statement;
+    
     @Getter
     @Setter
     @Column(columnName = LATENCY, dataType = Column.ValueDataType.SAMPLED_RECORD)

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/Column.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/Column.java
@@ -70,6 +70,14 @@ public @interface Column {
     int length() default 200;
 
     /**
+     * The return name of system environment could provide an override value of the length limitation.
+     * @return the variable name of system environment.
+     *
+     * @since 8.2.0
+     */
+    String lengthEnvVariable() default "";
+
+    /**
      * Column with data type != {@link ValueDataType#NOT_VALUE} represents this is a value column. Indicate it would be
      * queried by UI/CLI.
      *

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
@@ -23,9 +23,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
-
 import lombok.extern.slf4j.Slf4j;
-
+import org.apache.skywalking.apm.util.StringUtil;
 import org.apache.skywalking.oap.server.core.source.DefaultScopeDefine;
 import org.apache.skywalking.oap.server.core.storage.StorageException;
 import org.apache.skywalking.oap.server.core.storage.annotation.Column;
@@ -105,10 +104,26 @@ public class StorageModels implements IModelManager, ModelCreator, ModelManipula
         for (Field field : fields) {
             if (field.isAnnotationPresent(Column.class)) {
                 Column column = field.getAnnotation(Column.class);
+                // Use the column#length as the default column length, as read the system env as the override mechanism.
+                // Log the error but don't block the startup sequence.
+                int columnLength = column.length();
+                final String lengthEnvVariable = column.lengthEnvVariable();
+                if (StringUtil.isNotEmpty(lengthEnvVariable)) {
+                    final String envValue = System.getenv(lengthEnvVariable);
+                    if (StringUtil.isNotEmpty(envValue)) {
+                        try {
+                            columnLength = Integer.parseInt(envValue);
+                        } catch (NumberFormatException e) {
+                            log.error("Model [{}] Column [{}], illegal value {} of column length from system env [{}]",
+                                      modelName, column.columnName(), envValue, lengthEnvVariable
+                            );
+                        }
+                    }
+                }
                 modelColumns.add(
                     new ModelColumn(
                         new ColumnName(modelName, column.columnName()), field.getType(), column.matchQuery(),
-                        column.storageOnly(), column.dataType().isValue(), column.length()
+                        column.storageOnly(), column.dataType().isValue(), columnLength
                     ));
                 if (log.isDebugEnabled()) {
                     log.debug("The field named {} with the {} type", column.columnName(), field.getType());


### PR DESCRIPTION
Resolves #5236(@CodingOX), resovles #5133 and provide a better way than #5135(@zshit). 

This PR 
1. Make the default value consistently the same. 2000 should be enough for most cases. And the length truncation mechanism should work as expected.
1. Provide a consistent way for overriding the default value through system env.