### PR TITLE
Fix NPE for replaceParam when message is null

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/PatternLogger.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/PatternLogger.java
@@ -85,6 +85,9 @@ public class PatternLogger implements ILog {
     }
 
     private String replaceParam(String message, Object... parameters) {
+        if (message == null) {
+            return message;
+        }
         int startSize = 0;
         int parametersIndex = 0;
         int index;


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [-] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

NullPointerException‘s getMessage is null,  if we `logger.warn(ex, ex.getMessage)` by NullPointerException will case the issue
```
at org.apache.skywalking.apm.agent.core.logging.core.PatternLogger.replaceParam(PatternLogger.java:97)
at org.apache.skywalking.apm.agent.core.logging.core.PatternLogger.warn(PatternLogger.java:131)
at org.apache.skywalking.apm.plugin.websphere.HandleInterceptor.afterMethod(HandleInterceptor.java:87)
at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:105)

```

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
