### PR TITLE
Upgrade the byte-buddy to 1.10.14 with asm

### DIFF
--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <guava.version>20.0</guava.version>
-        <bytebuddy.version>1.10.7</bytebuddy.version>
+        <bytebuddy.version>1.10.14</bytebuddy.version>
         <wiremock.version>2.6.0</wiremock.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>

--- a/dist-material/release-docs/LICENSE
+++ b/dist-material/release-docs/LICENSE
@@ -225,7 +225,7 @@ Apache 2.0 licenses
 The following components are provided under the Apache License. See project link for details.
 The text of each license is the standard Apache 2.0 license.
 
-    raphw (byte-buddy) 1.9.2: http://bytebuddy.net/ , Apache 2.0
+    raphw (byte-buddy) 1.10.14: http://bytebuddy.net/ , Apache 2.0
     Google: gprc-java 1.26.0: https://github.com/grpc/grpc-java, Apache 2.0
     Google: guava 28.1: https://github.com/google/guava , Apache 2.0
     Google: guice 4.1.0: https://github.com/google/guice , Apache 2.0
@@ -375,7 +375,7 @@ BSD licenses
 The following components are provided under a BSD license. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    asm 5.0.4:https://gitlab.ow2.org , BSD-3-Clause
+    asm 8.0.1:https://gitlab.ow2.org , BSD-3-Clause
     antlr4-runtime 4.5.1: http://www.antlr.org/license.html, BSD-3-Clause
     jline 0.9.94: http://mvnrepository.com/artifact/jline/jline/0.9.94, BSD
     Google: protobuf-java 3.4.0: https://github.com/google/protobuf/blob/master/java/pom.xml , BSD-3-Clause


### PR DESCRIPTION
Should be able to resolve #5336. 

@dmsolr Could you consider contributing a plugin test with JDK 14 record feature? We could name it JDK14-scenario, then use the `record` keywords for instrumentation.