### PR TITLE
bugfix: Fix CLR Heap Memory metrics aggregation configuration error in ui-initialized-templates.

### DIFF
--- a/oap-server/server-bootstrap/src/main/resources/ui-initialized-templates.yml
+++ b/oap-server/server-bootstrap/src/main/resources/ui-initialized-templates.yml
@@ -403,7 +403,9 @@ templates:
                   "metricName": "instance_clr_heap_memory",
                   "queryMetricType": "readMetricsValues",
                   "chartType": "ChartLine",
-                  "unit": "MB"
+                  "unit": "MB",
+                  "aggregation": "/",
+                  "aggregationNum": "1048576"
                 },
                 {
                   "width": 3,


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

___
### Bug fix
- Bug description.
The `CLR Heap Memory (MB)` metrics in `Dashboard`->`Instance` tab  titled with `MB` unit, but actually the value shows in `byte` unit.

- How to fix?
Correct the configuration in `ui-initialized-templates.yml` file.