### PR TITLE
change alarm module silence-period default value as same as period.

### DIFF
--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RulesReader.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RulesReader.java
@@ -76,7 +76,8 @@ public class RulesReader {
                         alarmRule.setOp((String) settings.get("op"));
                         alarmRule.setPeriod((Integer) settings.getOrDefault("period", 1));
                         alarmRule.setCount((Integer) settings.getOrDefault("count", 1));
-                        alarmRule.setSilencePeriod((Integer) settings.getOrDefault("silence-period", -1));
+                        // How many times of checks, the alarm keeps silence after alarm triggered, default as same as period.
+                        alarmRule.setSilencePeriod((Integer) settings.getOrDefault("silence-period", alarmRule.getPeriod()));
                         alarmRule.setMessage(
                             (String) settings.getOrDefault("message", "Alarm caused by Rule " + alarmRule
                                 .getAlarmRuleName()));


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
in alarm-settings.yml silence-period description, the silence-period default as same as period, but when parse alarm-settings.yml config, set the default value -1.
- How to fix?
change alarm module silence-period default value as same as period, when parse alarm-settings.yml config
___
### New feature or improvement
- Describe the details and related test reports.
