### PR TITLE
Using openjdk:14-buster as base image of PluginTest

### DIFF
--- a/test/plugin/containers/jvm-container/pom.xml
+++ b/test/plugin/containers/jvm-container/pom.xml
@@ -92,7 +92,7 @@
                                 <image>
                                     <name>skywalking/agent-test-jvm:jdk14-${project.version}</name>
                                     <build>
-                                        <from>openjdk:14</from>
+                                        <from>openjdk:14-buster</from>
                                         <workdir>/usr/local/skywalking/scenario</workdir>
                                         <assembly>
                                             <mode>dir</mode>
@@ -100,7 +100,6 @@
                                             <descriptor>assembly.xml</descriptor>
                                         </assembly>
                                         <runCmds>
-                                            <run>yum install -y unzip</run>
                                             <run>chmod +x /usr/local/skywalking/run.sh</run>
                                             <run>tar -xvf ../tools/skywalking-mock-collector.tar.gz -C ../tools</run>
                                         </runCmds>

--- a/test/plugin/run.sh
+++ b/test/plugin/run.sh
@@ -140,7 +140,11 @@ if [[ ! -d ${agent_home} ]]; then
     echo "[WARN] SkyWalking Agent not exists"
     ${mvnw} --batch-mode -f ${home}/../../pom.xml -Pagent -DskipTests clean package
 fi
-[[ "$force_build" == "on" ]] && ${mvnw} --batch-mode -f ${home}/pom.xml clean package -DskipTests
+if [[ "$force_build" == "on" ]]; then
+    profile=
+    [[ $image_version =~ "jdk14-" ]] && profile="-Pjdk14"
+    ${mvnw} --batch-mode -f ${home}/pom.xml clean package -DskipTests ${profile}
+fi
 
 workspace="${home}/workspace/${scenario_name}"
 [[ -d ${workspace} ]] && rm -rf $workspace


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

Recently, it is failed to build plugintest docker image because the base image 'openjdk:14` removed the package management tools. So I change to `openjdk:14-buster` .

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
