### PR TITLE
Fix sampling and Kafka reporter conflicting.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManagerExtendService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManagerExtendService.java
@@ -65,7 +65,7 @@ public class ContextManagerExtendService implements BootService, GRPCChannelList
             context = new IgnoredTracerContext();
         } else {
             SamplingService samplingService = ServiceManager.INSTANCE.findService(SamplingService.class);
-            if (forceSampling || samplingService.trySampling()) {
+            if (forceSampling || samplingService.trySampling(operationName)) {
                 context = new TracingContext(operationName);
             } else {
                 context = new IgnoredTracerContext();

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -40,7 +40,6 @@ import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 import org.apache.skywalking.apm.agent.core.profile.ProfileStatusReference;
 import org.apache.skywalking.apm.agent.core.profile.ProfileTaskExecutionService;
-import org.apache.skywalking.apm.agent.core.sampling.SamplingService;
 import org.apache.skywalking.apm.util.StringUtil;
 
 /**
@@ -62,11 +61,6 @@ public class TracingContext implements AbstractTracerContext {
      * @see ProfileTaskExecutionService
      */
     private static ProfileTaskExecutionService PROFILE_TASK_EXECUTION_SERVICE;
-
-    /**
-     * @see SamplingService
-     */
-    private static SamplingService SAMPLING_SERVICE;
 
     /**
      * The final {@link TraceSegment}, which includes all finished spans.
@@ -122,10 +116,6 @@ public class TracingContext implements AbstractTracerContext {
         isRunningInAsyncMode = false;
         createTime = System.currentTimeMillis();
         running = true;
-
-        if (SAMPLING_SERVICE == null) {
-            SAMPLING_SERVICE = ServiceManager.INSTANCE.findService(SamplingService.class);
-        }
 
         // profiling status
         if (PROFILE_TASK_EXECUTION_SERVICE == null) {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/AbstractTracingSpan.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/AbstractTracingSpan.java
@@ -39,7 +39,13 @@ import org.apache.skywalking.apm.network.trace.component.Component;
  * distributed trace.
  */
 public abstract class AbstractTracingSpan implements AbstractSpan {
+    /**
+     * Span id starts from 0.
+     */
     protected int spanId;
+    /**
+     * Parent span id starts from 0. -1 means no parent span.
+     */
     protected int parentSpanId;
     protected List<TagValuePair> tags;
     protected String operationName;

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/sampling/SamplingService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/sampling/SamplingService.java
@@ -86,9 +86,10 @@ public class SamplingService implements BootService {
     }
 
     /**
+     * @param operationName The first operation name of the new tracing context.
      * @return true, if sampling mechanism is on, and getDefault the sampling factor successfully.
      */
-    public boolean trySampling() {
+    public boolean trySampling(String operationName) {
         if (on) {
             int factor = samplingFactorHolder.get();
             if (factor < Config.Agent.SAMPLE_N_PER_3_SECS) {


### PR DESCRIPTION
@peng-yongsheng reported this conflict. As they used to extend the same core service, when both of them are active, which could happen, they can't work together.

But, from the design perspective, I notice, ignore plugin actually is just a sampling service. It used `ContextManagerExtendService` extension, just because only sampling service API doesn't provide the operation name.

In this PR, I changed the sampling service API, and move `TraceIgnoreExtendService` to extend it. So conflict goes away.