### PR TITLE
Remove doc links for releases of v2 protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ Version Series | Version |
 8.x| [8.x dev](docs/README.md)|
 | | [8.1.0](https://github.com/apache/skywalking/blob/v8.1.0/docs/README.md) |
 | | [8.0.1](https://github.com/apache/skywalking/blob/v8.0.1/docs/README.md) |
-| | [8.0.0](https://github.com/apache/skywalking/blob/v8.0.0/docs/README.md) |
-7.x | [7.0](https://github.com/apache/skywalking/blob/v7.0.0/docs/README.md) |
-6.x | [6.6](https://github.com/apache/skywalking/blob/v6.6.0/docs/README.md) |
-| | [6.5](https://github.com/apache/skywalking/blob/v6.5.0/docs/README.md) |
 
 
 NOTICE, SkyWalking 8.0+ uses [v3 protocols](docs/en/protocols/README.md). They are incompatible with previous releases.


### PR DESCRIPTION
Remove 6.5, 6.6, 7.0, and 8.0 doc links. 8.0.0 is not recommended as it has a serious bug in the booting stage.