### PR TITLE
Better witness class for mongo3.8.x

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/mongodb/v3/define/v38/MongoDBOperationExecutorInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/mongodb/v3/define/v38/MongoDBOperationExecutorInstrumentation.java
@@ -35,7 +35,7 @@ import org.apache.skywalking.apm.agent.core.plugin.match.NameMatch;
  */
 public class MongoDBOperationExecutorInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
 
-    private static final String WITNESS_CLASS = "com.mongodb.client.ClientSession";
+    private static final String WITNESS_CLASS = "com.mongodb.operation.AggregateOperationImpl";
 
     private static final String ENHANCE_CLASS = "com.mongodb.client.internal.MongoClientDelegate$DelegateOperationExecutor";
 

--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/mongodb/v3/support/MongoSpanHelper.java
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/mongodb/v3/support/MongoSpanHelper.java
@@ -39,7 +39,7 @@ public class MongoSpanHelper {
         SpanLayer.asDB(span);
 
         if (MongoPluginConfig.Plugin.MongoDB.TRACE_PARAM) {
-            Tags.DB_STATEMENT.set(span, executeMethod + " " + MongoOperationHelper.getTraceParam(operation));
+            Tags.DB_BIND_VARIABLES.set(span, MongoOperationHelper.getTraceParam(operation));
         }
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/mongodb/v3/interceptor/v30/MongoDBInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/mongodb/v3/interceptor/v30/MongoDBInterceptorTest.java
@@ -128,7 +128,7 @@ public class MongoDBInterceptorTest {
         assertThat(span.getOperationName(), is("MongoDB/FindOperation"));
         assertThat(SpanHelper.getComponentId(span), is(42));
         List<TagValuePair> tags = SpanHelper.getTags(span);
-        assertThat(tags.get(1).getValue(), is("FindOperation {\"name\": \"by\"}"));
+        assertThat(tags.get(1).getValue(), is("{\"name\": \"by\"}"));
         assertThat(tags.get(0).getValue(), is("MongoDB"));
         assertThat(span.isExit(), is(true));
         assertThat(SpanHelper.getLayer(span), CoreMatchers.is(SpanLayer.DB));

--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/mongodb/v3/interceptor/v37/MongoDBOperationExecutorInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/mongodb/v3/interceptor/v37/MongoDBOperationExecutorInterceptorTest.java
@@ -127,7 +127,7 @@ public class MongoDBOperationExecutorInterceptorTest {
         assertThat(span.getOperationName(), is("MongoDB/FindOperation"));
         assertThat(SpanHelper.getComponentId(span), is(42));
         List<TagValuePair> tags = SpanHelper.getTags(span);
-        assertThat(tags.get(1).getValue(), is("FindOperation {\"name\": \"by\"}"));
+        assertThat(tags.get(1).getValue(), is("{\"name\": \"by\"}"));
         assertThat(tags.get(0).getValue(), is("MongoDB"));
         assertThat(span.isExit(), is(true));
         assertThat(SpanHelper.getLayer(span), CoreMatchers.is(SpanLayer.DB));

--- a/test/plugin/scenarios/mongodb-3.x-scenario/bin/startup.sh
+++ b/test/plugin/scenarios/mongodb-3.x-scenario/bin/startup.sh
@@ -18,4 +18,4 @@
 
 home="$(cd "$(dirname $0)"; pwd)"
 
-java -jar ${agent_opts} ${home}/../libs/mongodb-3.x-scenario.jar &
+java -jar -Dskywalking.plugin.mongodb.trace_param=true ${agent_opts} ${home}/../libs/mongodb-3.x-scenario.jar &

--- a/test/plugin/scenarios/mongodb-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mongodb-3.x-scenario/config/expectedData.yaml
@@ -32,7 +32,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
-      - {key: db.statement, value: not null}
+      - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/MixedBulkWriteOperation
       operationId: 0
@@ -47,7 +47,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
-      - {key: db.statement, value: not null}
+      - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/FindOperation
       operationId: 0
@@ -62,7 +62,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
-      - {key: db.statement, value: not null}
+      - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/MixedBulkWriteOperation
       operationId: 0
@@ -77,7 +77,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
-      - {key: db.statement, value: not null}
+      - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/FindOperation
       operationId: 0
@@ -92,7 +92,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
-      - {key: db.statement, value: not null}
+      - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/MixedBulkWriteOperation
       operationId: 0
@@ -107,7 +107,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
-      - {key: db.statement, value: not null}
+      - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/DropDatabaseOperation
       operationId: 0
@@ -122,7 +122,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
-      - {key: db.statement, value: not null}
+      - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: /mongodb-case/case/mongodb
       operationId: 0

--- a/test/plugin/scenarios/mongodb-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mongodb-3.x-scenario/config/expectedData.yaml
@@ -32,6 +32,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
+      - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/MixedBulkWriteOperation
       operationId: 0
@@ -46,6 +47,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
+      - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/FindOperation
       operationId: 0
@@ -60,6 +62,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
+      - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/MixedBulkWriteOperation
       operationId: 0
@@ -74,6 +77,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
+      - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/FindOperation
       operationId: 0
@@ -88,6 +92,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
+      - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/MixedBulkWriteOperation
       operationId: 0
@@ -102,6 +107,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
+      - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/DropDatabaseOperation
       operationId: 0
@@ -116,6 +122,7 @@ segmentItems:
       peer: mongodb-server:27017
       tags:
       - {key: db.type, value: MongoDB}
+      - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: /mongodb-case/case/mongodb
       operationId: 0


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement

com.mongodb.operation.AggregateOperationImpl may be more suitable as a witness class for mongodb-3.8, because com.mongodb.client.ClientSession also exists in 4.x. There is a high probability that 3.x and 4.x coexist will lead to 4. The plug-in of x is invalid, I will submit pr to prove it.

com.mongodb.operation.AggregateOperationImpl detail info
![image](https://user-images.githubusercontent.com/16585330/93711498-71fd4c80-fb81-11ea-80ff-013bfb72e895.png)

