### PR TITLE
Add `MOUNT` config in the agent core.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
@@ -18,7 +18,9 @@
 
 package org.apache.skywalking.apm.agent.core.conf;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
 import org.apache.skywalking.apm.agent.core.logging.core.LogLevel;
@@ -122,7 +124,6 @@ public class Config {
          * Keep tracing even the backend is not available.
          */
         public static boolean KEEP_TRACING = false;
-
     }
 
     public static class OsInfo {
@@ -292,6 +293,11 @@ public class Config {
          * Exclude activated plugins
          */
         public static String EXCLUDE_PLUGINS = "";
+
+        /**
+         * Mount the folders of the plugins. The folder path is relative to agent.jar.
+         */
+        public static List<String> MOUNT = Arrays.asList("plugins", "activations");
     }
 
     public static class Correlation {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
@@ -35,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.skywalking.apm.agent.core.boot.AgentPackageNotFoundException;
 import org.apache.skywalking.apm.agent.core.boot.AgentPackagePath;
 import org.apache.skywalking.apm.agent.core.boot.PluginConfig;
+import org.apache.skywalking.apm.agent.core.conf.Config;
 import org.apache.skywalking.apm.agent.core.conf.SnifferConfigInitializer;
 import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
@@ -85,8 +86,7 @@ public class AgentClassLoader extends ClassLoader {
         super(parent);
         File agentDictionary = AgentPackagePath.getPath();
         classpath = new LinkedList<>();
-        classpath.add(new File(agentDictionary, "plugins"));
-        classpath.add(new File(agentDictionary, "activations"));
+        Config.Plugin.MOUNT.forEach(mountFolder -> classpath.add(new File(agentDictionary, mountFolder)));
     }
 
     @Override

--- a/apm-sniffer/config/agent.config
+++ b/apm-sniffer/config/agent.config
@@ -92,14 +92,17 @@ logging.level=${SW_LOGGING_LEVEL:INFO}
 # The max recursive depth when checking the exception traced by the agent. Typically, we don't recommend setting this more than 10, which could cause a performance issue. Negative value and 0 would be ignored, which means all exceptions would make the span tagged in error status.
 # statuscheck.max_recursive_depth=${SW_STATUSCHECK_MAX_RECURSIVE_DEPTH:1}
 
+# Mount the specific folders of the plugins. Plugins in mounted folders would work.
+plugin.mount=${SW_MOUNT_FOLDERS:plugins,activations}
+
+# Exclude activated plugins
+# plugin.exclude_plugins=${SW_EXCLUDE_PLUGINS:}
+
 # mysql plugin configuration
 # plugin.mysql.trace_sql_parameters=${SW_MYSQL_TRACE_SQL_PARAMETERS:false}
 
 # Kafka producer configuration
 # plugin.kafka.bootstrap_servers=${SW_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-
-# Exclude activated plugins
-# plugin.exclude_plugins=${SW_EXCLUDE_PLUGINS:}
 
 # Match spring bean with regex expression for classname
 # plugin.springannotation.classname_match_regex=${SW_SPRINGANNOTATION_CLASSNAME_MATCH_REGEX:}

--- a/docs/en/setup/service-agent/java-agent/README.md
+++ b/docs/en/setup/service-agent/java-agent/README.md
@@ -113,6 +113,7 @@ property key | Description | Default |
 `meter.active`|If true, the agent collects and reports metrics to the backend.|`true`|
 `meter.report_interval`|Report meters interval. The unit is second|`20`|
 `meter.max_meter_size`| Max size of the meter pool |`500`|
+`plugin.mount` | Mount the specific folders of the plugins. Plugins in mounted folders would work. | `plugins,activations` |
 `plugin.peer_max_length `|Peer maximum description limit.|`200`|
 `plugin.exclude_plugins `|Exclude some plugins define in plugins dir.Plugin names is defined in [Agent plugin list](Plugin-list.md)|`""`|
 `plugin.mongodb.trace_param`|If true, trace all the parameters in MongoDB access, default is false. Only trace the operation, not include parameters.|`false`|


### PR DESCRIPTION
We are preparing to accept the server-side plugins, starting with ShardingSphere. @mrproliu is providing the meter APIs for this kind of plugins in #4816. 

In the ShardingSphere server plugin, it would only work when the agent installed in the ShardingSphere proxy. In this case, I hope we could mount the whole metrics plugin like this, `java -javaagent:skywalking-agent.jar -jar proxy.jar -Dskywalking.plugin.mount=server-plugins/shardingsphere`. Then all default plugins would not work, but plugins in `server-plugins/shardingsphere` would be loaded.

Also, this could be required when we have more server side plugins, rather than plugins for client libraries in the business applications.

WDYT? @apache/skywalking-committers 