### PR TITLE
Add a muse configuration file

### DIFF
--- a/.muse/config.toml
+++ b/.muse/config.toml
@@ -1,0 +1,2 @@
+jdk11 = true
+setup = ".muse/setup.sh"

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+git submodule update --init --recursive

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,7 @@
                         <exclude>**/.git/**</exclude>
 
                         <!-- CI files -->
+                        <exclude>**/.muse/**</exclude>
                         <exclude>**/.travis.yml</exclude>
 
                         <!-- GitHub files -->


### PR DESCRIPTION
Skywalking is going to be part of the ApacheCon bug bash.  As part of that, ASF Infra will be installing the github app "muse-dev" in this repository.  While there will certainly be a list of issues provided, scores can be kept track of automated via the bot.  Beyond ApacheCon, the muse app is much like other CI serves in that there are actions taking on PRs and those actions need some minor amount of configuration.

In short: This PR adds a muse configuration and file, sufficient to allow running Muse CI on Skywalking.
