### PR TITLE
Fix server-starter-es7 missing dependencies

### DIFF
--- a/oap-server/server-starter-es7/pom.xml
+++ b/oap-server/server-starter-es7/pom.xml
@@ -44,6 +44,21 @@
             <artifactId>storage-elasticsearch7-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>storage-zipkin-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>jaeger-receiver-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>zipkin-receiver-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- profile exporter -->
         <dependency>


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

Binary distribution for ElasticSearch 7 are missing dependent jars. If we enable `receiver_zipkin` or `receiver_jaeger`, we will get an exception of `Module not found`.
- How to fix?

Add the dependent jars.
___
### New feature or improvement
- Describe the details and related test reports.
