### PR TITLE
fix Calling getClass() on an enum may return a subclass of the enum type

### DIFF
--- a/apm-sniffer/apm-test-tools/src/main/java/org/apache/skywalking/apm/agent/test/tools/AgentServiceRule.java
+++ b/apm-sniffer/apm-test-tools/src/main/java/org/apache/skywalking/apm/agent/test/tools/AgentServiceRule.java
@@ -38,7 +38,7 @@ public class AgentServiceRule extends ExternalResource {
         super.after();
         try {
             FieldSetter.setValue(
-                ServiceManager.INSTANCE.getClass(), "bootedServices", new HashMap<Class, BootService>());
+                ServiceManager.INSTANCE.getDeclaringClass(), "bootedServices", new HashMap<Class, BootService>());
             FieldSetter.setValue(
                 IgnoredTracerContext.ListenerManager.class, "LISTENERS", new LinkedList<TracingContextListener>());
             FieldSetter.setValue(


### PR DESCRIPTION
- Why submit this pull request?
- [x] Bug fix

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

ref: https://errorprone.info/bugpattern/GetClassOnEnum

___
### New feature or improvement
- Describe the details and related test reports.
