### PR TITLE
Use explicit charset instead of default charset

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/avro-plugin/src/main/java/org/apache/skywalking/apm/plugin/avro/SWClientRPCPlugin.java
+++ b/apm-sniffer/apm-sdk-plugin/avro-plugin/src/main/java/org/apache/skywalking/apm/plugin/avro/SWClientRPCPlugin.java
@@ -25,6 +25,7 @@ import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A SkyWalking tracing plugin for Avro Client. Inject CarrierItems into RPC's metadata from cross-process propagation.
@@ -39,7 +40,7 @@ public class SWClientRPCPlugin extends RPCPlugin {
         CarrierItem items = carrier.items();
         while (items.hasNext()) {
             items = items.next();
-            context.requestCallMeta().put(items.getHeadKey(), ByteBuffer.wrap(items.getHeadValue().getBytes()));
+            context.requestCallMeta().put(items.getHeadKey(), ByteBuffer.wrap(items.getHeadValue().getBytes(StandardCharsets.UTF_8)));
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/avro-plugin/src/main/java/org/apache/skywalking/apm/plugin/avro/SWServerRPCPlugin.java
+++ b/apm-sniffer/apm-sdk-plugin/avro-plugin/src/main/java/org/apache/skywalking/apm/plugin/avro/SWServerRPCPlugin.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.apm.plugin.avro;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.avro.ipc.RPCContext;
 import org.apache.avro.ipc.RPCPlugin;
@@ -50,7 +51,7 @@ public class SWServerRPCPlugin extends RPCPlugin {
         while (items.hasNext()) {
             items = items.next();
             ByteBuffer buffer = (ByteBuffer) meta.get(new Utf8(items.getHeadKey()));
-            items.setHeadValue(new String(buffer.array()));
+            items.setHeadValue(new String(buffer.array(), StandardCharsets.UTF_8));
         }
 
         String operationName = prefix + context.getMessage().getName();

--- a/apm-sniffer/apm-sdk-plugin/hbase-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/hbase/HTableInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/hbase-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/hbase/HTableInterceptor.java
@@ -37,6 +37,7 @@ import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -74,10 +75,10 @@ public class HTableInterceptor implements InstanceMethodsAroundInterceptor, Inst
             while (next.hasNext()) {
                 next = next.next();
                 if (operation != null) {
-                    operation.setAttribute(next.getHeadKey(), next.getHeadValue().getBytes());
+                    operation.setAttribute(next.getHeadKey(), next.getHeadValue().getBytes(StandardCharsets.UTF_8));
                 } else {
                     for (OperationWithAttributes o : operations) {
-                        o.setAttribute(next.getHeadKey(), next.getHeadValue().getBytes());
+                        o.setAttribute(next.getHeadKey(), next.getHeadValue().getBytes(StandardCharsets.UTF_8));
                     }
                 }
             }

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/KafkaConsumerInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/KafkaConsumerInterceptor.java
@@ -35,6 +35,7 @@ import org.apache.skywalking.apm.plugin.kafka.define.Constants;
 import org.apache.skywalking.apm.plugin.kafka.define.KafkaContext;
 
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +89,7 @@ public class KafkaConsumerInterceptor implements InstanceMethodsAroundIntercepto
                         next = next.next();
                         Iterator<Header> iterator = record.headers().headers(next.getHeadKey()).iterator();
                         if (iterator.hasNext()) {
-                            next.setHeadValue(new String(iterator.next().value()));
+                            next.setHeadValue(new String(iterator.next().value(), StandardCharsets.UTF_8));
                         }
                     }
                     ContextManager.extract(contextCarrier);

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/KafkaProducerInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/KafkaProducerInterceptor.java
@@ -32,6 +32,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 
 public class KafkaProducerInterceptor implements InstanceMethodsAroundInterceptor {
 
@@ -57,7 +58,7 @@ public class KafkaProducerInterceptor implements InstanceMethodsAroundIntercepto
         CarrierItem next = contextCarrier.items();
         while (next.hasNext()) {
             next = next.next();
-            record.headers().add(next.getHeadKey(), next.getHeadValue().getBytes());
+            record.headers().add(next.getHeadKey(), next.getHeadValue().getBytes(StandardCharsets.UTF_8));
         }
 
         //when use lambda expression, not to generate inner class,


### PR DESCRIPTION
Implicit use of the platform default charset, which can result in differing behaviour between JVM executions or incorrect behavior if the encoding of the data source doesn't match expectations.
