### PR TITLE
fix to release incorrectly lock when it is failed to obtain lock

### DIFF
--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumeDriver.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumeDriver.java
@@ -73,8 +73,8 @@ public class ConsumeDriver<T> implements IDriver {
         if (running) {
             return;
         }
+        lock.lock();
         try {
-            lock.lock();
             this.allocateBuffer2Thread();
             for (ConsumerThread consumerThread : consumerThreads) {
                 consumerThread.start();
@@ -111,8 +111,8 @@ public class ConsumeDriver<T> implements IDriver {
 
     @Override
     public void close(Channels channels) {
+        lock.lock();
         try {
-            lock.lock();
             this.running = false;
             for (ConsumerThread consumerThread : consumerThreads) {
                 consumerThread.shutdown();


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

Report on [here](https://console.muse.dev/result/TomMD/skywalking/01EHQHJ02AQZNKB6JN80X17XHA?search=locknotbeforetry&tab=results)

