### PR TITLE
fix TypeParameterUnusedInFormals

### DIFF
--- a/apm-sniffer/apm-test-tools/src/main/java/org/apache/skywalking/apm/agent/test/helper/FieldGetter.java
+++ b/apm-sniffer/apm-test-tools/src/main/java/org/apache/skywalking/apm/agent/test/helper/FieldGetter.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.agent.test.helper;
 import java.lang.reflect.Field;
 
 public class FieldGetter {
+    @SuppressWarnings("TypeParameterUnusedInFormals")
     public static <T> T getValue(Object instance,
         String fieldName) throws IllegalAccessException, NoSuchFieldException {
         Field field = instance.getClass().getDeclaredField(fieldName);
@@ -28,6 +29,7 @@ public class FieldGetter {
         return (T) field.get(instance);
     }
 
+    @SuppressWarnings("TypeParameterUnusedInFormals")
     public static <T> T getParentFieldValue(Object instance,
         String fieldName) throws IllegalAccessException, NoSuchFieldException {
         Field field = instance.getClass().getSuperclass().getDeclaredField(fieldName);
@@ -35,6 +37,7 @@ public class FieldGetter {
         return (T) field.get(instance);
     }
 
+    @SuppressWarnings("TypeParameterUnusedInFormals")
     public static <T> T get2LevelParentFieldValue(Object instance,
         String fieldName) throws IllegalAccessException, NoSuchFieldException {
         Field field = instance.getClass().getSuperclass().getSuperclass().getDeclaredField(fieldName);


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

Declaring a type parameter that is only used in the return type is a misuse of generics: operations on the type parameter are unchecked, it hides unsafe casts at invocations of the method, and it interacts badly with method overload resolution.

this is false positive

- How to fix?

@SuppressWarnings("TypeParameterUnusedInFormals")
___
### New feature or improvement
- Describe the details and related test reports.
