### PR TITLE
resttemplate plugin concurrency scenario data mistake problem  fix

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/async/RestExecuteInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/async/RestExecuteInterceptor.java
@@ -26,8 +26,6 @@ import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
-import org.apache.skywalking.apm.agent.core.logging.api.ILog;
-import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
@@ -37,8 +35,6 @@ import org.apache.skywalking.apm.plugin.spring.resttemplate.helper.RestTemplateR
 import org.springframework.http.HttpMethod;
 
 public class RestExecuteInterceptor implements InstanceMethodsAroundInterceptor {
-
-    private static final ILog LOGGER = LogManager.getLogger(RestExecuteInterceptor.class);
 
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
@@ -69,12 +65,12 @@ public class RestExecuteInterceptor implements InstanceMethodsAroundInterceptor 
             ContextSnapshot contextSnapshot = ContextManager.capture();
             if (ret != null) {
                 String uri = RestTemplateRuntimeContextHelper.getUri();
-                ((EnhancedInstance) ret).setSkyWalkingDynamicField(new EnhanceCacheObjects(uri, ComponentsDefine.SPRING_REST_TEMPLATE, SpanLayer.HTTP, contextSnapshot));
+                ((EnhancedInstance) ret).setSkyWalkingDynamicField(
+                    new EnhanceCacheObjects(uri, ComponentsDefine.SPRING_REST_TEMPLATE, SpanLayer.HTTP, contextSnapshot)
+                );
             }
-        } catch (Throwable e){
-            LOGGER.warn("resttemplate plugin has error: ", e);
-        } finally {
             ContextManager.stopSpan();
+        } finally {
             RestTemplateRuntimeContextHelper.cleanUri();
             RestTemplateRuntimeContextHelper.cleanContextCarrier();
         }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/async/RestRequestInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/async/RestRequestInterceptor.java
@@ -24,6 +24,7 @@ import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.plugin.spring.resttemplate.helper.RestTemplateRuntimeContextHelper;
 import org.springframework.http.client.AsyncClientHttpRequest;
 
 public class RestRequestInterceptor implements InstanceMethodsAroundInterceptor {
@@ -39,8 +40,7 @@ public class RestRequestInterceptor implements InstanceMethodsAroundInterceptor 
         Object ret) throws Throwable {
         AsyncClientHttpRequest clientHttpRequest = (AsyncClientHttpRequest) ret;
         if (ret != null) {
-            Object[] cacheValues = (Object[]) objInst.getSkyWalkingDynamicField();
-            ContextCarrier contextCarrier = (ContextCarrier) cacheValues[1];
+            ContextCarrier contextCarrier = RestTemplateRuntimeContextHelper.getContextCarrier();
             CarrierItem next = contextCarrier.items();
             while (next.hasNext()) {
                 next = next.next();

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/helper/RestTemplateRuntimeContextHelper.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/helper/RestTemplateRuntimeContextHelper.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.skywalking.apm.plugin.spring.resttemplate.helper;
 
 import org.apache.skywalking.apm.agent.core.context.ContextCarrier;

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/helper/RestTemplateRuntimeContextHelper.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/helper/RestTemplateRuntimeContextHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.skywalking.apm.plugin.spring.resttemplate.helper;
+
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+
+public class RestTemplateRuntimeContextHelper {
+
+    private static final String REST_TEMPLATE_CONTEXT_CARRIER_KEY_IN_RUNTIME_CONTEXT = "REST_TEMPLATE_CONTEXT_CARRIER";
+
+    private static final String REST_TEMPLATE_URI_KEY_IN_RUNTIME_CONTEXT = "REST_TEMPLATE_URI";
+
+    public static void cleanUri() {
+        ContextManager.getRuntimeContext().remove(REST_TEMPLATE_URI_KEY_IN_RUNTIME_CONTEXT);
+    }
+
+    public static void cleanContextCarrier() {
+        ContextManager.getRuntimeContext().remove(REST_TEMPLATE_CONTEXT_CARRIER_KEY_IN_RUNTIME_CONTEXT);
+    }
+
+    public static void addUri(String uri) {
+        ContextManager.getRuntimeContext().put(REST_TEMPLATE_URI_KEY_IN_RUNTIME_CONTEXT, uri);
+    }
+
+    public static void addContextCarrier(ContextCarrier contextCarrier) {
+        ContextManager.getRuntimeContext().put(REST_TEMPLATE_CONTEXT_CARRIER_KEY_IN_RUNTIME_CONTEXT, contextCarrier);
+    }
+
+    public static String getUri() {
+        return (String) ContextManager.getRuntimeContext().get(REST_TEMPLATE_URI_KEY_IN_RUNTIME_CONTEXT);
+    }
+
+    public static ContextCarrier getContextCarrier() {
+        return (ContextCarrier) ContextManager.getRuntimeContext().get(REST_TEMPLATE_CONTEXT_CARRIER_KEY_IN_RUNTIME_CONTEXT);
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/sync/RestExecuteInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/sync/RestExecuteInterceptor.java
@@ -29,6 +29,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedI
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.apache.skywalking.apm.plugin.spring.resttemplate.helper.RestTemplateRuntimeContextHelper;
 import org.springframework.http.HttpMethod;
 
 public class RestExecuteInterceptor implements InstanceMethodsAroundInterceptor {
@@ -50,12 +51,13 @@ public class RestExecuteInterceptor implements InstanceMethodsAroundInterceptor 
         Tags.HTTP.METHOD.set(span, httpMethod.toString());
         SpanLayer.asHttp(span);
 
-        objInst.setSkyWalkingDynamicField(contextCarrier);
+        RestTemplateRuntimeContextHelper.addContextCarrier(contextCarrier);
     }
 
     @Override
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         Object ret) throws Throwable {
+        RestTemplateRuntimeContextHelper.cleanContextCarrier();
         ContextManager.stopSpan();
         return ret;
     }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/sync/RestRequestInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/resttemplate/sync/RestRequestInterceptor.java
@@ -24,6 +24,7 @@ import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.plugin.spring.resttemplate.helper.RestTemplateRuntimeContextHelper;
 import org.springframework.http.client.AbstractClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequest;
 
@@ -41,7 +42,7 @@ public class RestRequestInterceptor implements InstanceMethodsAroundInterceptor 
         ClientHttpRequest clientHttpRequest = (ClientHttpRequest) ret;
         if (clientHttpRequest instanceof AbstractClientHttpRequest) {
             AbstractClientHttpRequest httpRequest = (AbstractClientHttpRequest) clientHttpRequest;
-            ContextCarrier contextCarrier = (ContextCarrier) objInst.getSkyWalkingDynamicField();
+            ContextCarrier contextCarrier = RestTemplateRuntimeContextHelper.getContextCarrier();
             CarrierItem next = contextCarrier.items();
             while (next.hasNext()) {
                 next = next.next();


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bug fix

- Related issues
https://github.com/apache/skywalking/issues/5657

___
### Bug fix
- Bug description:
sometimes, we use RestTemplate as singleton ,  like this:
```
    @Autowired
    private RestTemplate restTemplate;

    @Autowired
    private AsyncRestTemplate asyncRestTemplate;
```

but  now, skywalking RestTemplate plugin use SkyWalkingDynamicField to transfer the data during the request, 
this SkyWalkingDynamicField is a volatile field in the RestTemplate/AsyncRestTemplate object , if we use RestTemplate/AsyncRestTemplate object as singleton, we will have data mistake in concurrency scenario



- How to fix?
use RuntimeContext implement replace SkyWalkingDynamicField implement on RestTemplate/AsyncRestTemplate object
