### PR TITLE
Fix the exception that is thrown without `TServiceClientReceiveInstrumentation`

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/thrift-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/thrift-plugin/src/main/resources/skywalking-plugin.def
@@ -18,7 +18,6 @@ thrift=org.apache.skywalking.apm.plugin.thrift.define.TServerInstrumentation
 thrift=org.apache.skywalking.apm.plugin.thrift.define.client.TAsyncClientInstrumentation
 thrift=org.apache.skywalking.apm.plugin.thrift.define.client.TAsyncMethodCallInstrumentation
 thrift=org.apache.skywalking.apm.plugin.thrift.define.client.TServiceClientInstrumentation
-thrift=org.apache.skywalking.apm.plugin.thrift.define.client.TServiceClientReceiveInstrumentation
 thrift=org.apache.skywalking.apm.plugin.thrift.define.TBaseProcessorInstrumentation
 thrift=org.apache.skywalking.apm.plugin.thrift.define.TBaseAsyncProcessorInstrumentation
 thrift=org.apache.skywalking.apm.plugin.thrift.define.transport.TSocketInstrumentation


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that doesn't accord with this template
    may be closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix the exception that is thrown without `TServiceClientReceiveInstrumentation`
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly about why the bug exists and how to fix it.
This exception does not affect the application, but is only displayed in the log.
![image](https://user-images.githubusercontent.com/16839929/97260831-90c5c180-1858-11eb-8fdf-09efaeb2efdc.png)
