### PR TITLE
Revert "Make the duration error message more specific"

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/DurationUtils.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/DurationUtils.java
@@ -30,8 +30,6 @@ import org.joda.time.format.DateTimeFormatter;
 public enum DurationUtils {
     INSTANCE;
 
-    private static final int MAX_TIME_SPAN = 500;
-
     private static final DateTimeFormatter YYYY_MM_DD = DateTimeFormat.forPattern("yyyy-MM-dd");
     private static final DateTimeFormatter YYYY_MM_DD_HH = DateTimeFormat.forPattern("yyyy-MM-dd HH");
     private static final DateTimeFormatter YYYY_MM_DD_HHMM = DateTimeFormat.forPattern("yyyy-MM-dd HHmm");
@@ -121,11 +119,9 @@ public enum DurationUtils {
                     break;
             }
             i++;
-            if (i > MAX_TIME_SPAN) {
+            if (i > 500) {
                 throw new UnexpectedException(
-                    "Duration data error, the span between the start time and the end time is too large, step: "
-                            + step.name() + ", start: " + startTimeBucket + ", end: " + endTimeBucket
-                            + ", max time span: " + MAX_TIME_SPAN);
+                    "Duration data error, step: " + step.name() + ", start: " + startTimeBucket + ", end: " + endTimeBucket);
             }
         }
         while (endTimeBucket != durations.get(durations.size() - 1).getPoint());


### PR DESCRIPTION
Reverts apache/skywalking#5755

I don't think this is the correct fix. Span should have consistent and only meaning in the SkyWalking. You could say time range with given step, or something.