### PR TITLE
Simplifies canceling workflow

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -18,22 +18,44 @@ name: Cancel
 
 on:
   workflow_run:
-    workflows:
-      - CI AND IT
-      - E2E
-      - PluginsTest
+    workflows: [CI AND IT]
     types:
       - requested
 
 jobs:
   # Cancel outdated builds in the repo, including all action tasks of all commits.
+  # It runs for all workflow types
   cancel-outdated-builds:
     runs-on: ubuntu-18.04
     timeout-minutes: 10
+    strategy:
+      max-parallel: 4
+      matrix:
+        workflowFileName:
+          - ci-it.yaml
+          - docker-ci.yaml
+          - e2e.cluster.yaml
+          - e2e.go.yaml
+          - e2e.istio.yaml
+          - e2e.jdk-versions.yaml
+          - e2e.js.yaml
+          - e2e.kafka.yaml
+          - e2e.php.yaml
+          - e2e.profiling.yaml
+          - e2e.python.yaml
+          - e2e.storages.yaml
+          - e2e.ttl.yaml
+          - e2e.yaml
+          - plugins-jdk14-test.0.yaml
+          - plugins-test.0.yaml
+          - plugins-test.1.yaml
+          - plugins-test.2.yaml
+          - plugins-test.3.yaml
     steps:
       - uses: potiuk/cancel-workflow-runs@v4_7
-        name: Cancel Outdated Builds
+        name: Cancel Outdated Builds ${{ matrix.workflowFileName }}
         with:
           cancelMode: allDuplicates
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: ${{ matrix.workflowFileName }}


### PR DESCRIPTION
Instead of multiple workflow-runs generated for different workflows
this change replaces it with single workflow, cancelling all others.
It is triggered by only one CI-IT workflow, because this one is
always triggered when all others are. It also sets parallelism
of the matrix to 4, so that there are not too many jobs in
parallel taken when this workflow runs.
