### PR TITLE
The Cancel step is now optimised in one job

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -28,34 +28,144 @@ jobs:
   cancel-outdated-builds:
     runs-on: ubuntu-18.04
     timeout-minutes: 10
-    strategy:
-      max-parallel: 4
-      matrix:
-        workflowFileName:
-          - ci-it.yaml
-          - docker-ci.yaml
-          - e2e.cluster.yaml
-          - e2e.go.yaml
-          - e2e.istio.yaml
-          - e2e.jdk-versions.yaml
-          - e2e.js.yaml
-          - e2e.kafka.yaml
-          - e2e.php.yaml
-          - e2e.profiling.yaml
-          - e2e.python.yaml
-          - e2e.storages.yaml
-          - e2e.ttl.yaml
-          - e2e.yaml
-          - plugins-jdk14-test.0.yaml
-          - plugins-test.0.yaml
-          - plugins-test.1.yaml
-          - plugins-test.2.yaml
-          - plugins-test.3.yaml
     steps:
       - uses: potiuk/cancel-workflow-runs@v4_7
-        name: Cancel Outdated Builds ${{ matrix.workflowFileName }}
+        name: Cancel Outdated Builds ci-it.yaml
         with:
           cancelMode: allDuplicates
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
-          workflowFileName: ${{ matrix.workflowFileName }}
+          workflowFileName: ci-it.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds docker-ci.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: docker-ci.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.cluster.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.cluster.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.go.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.go.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.istio.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.istio.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.jdk-versions.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.jdk-versions.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.js.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.js.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.kafka.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.kafka.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.php.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.php.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.php.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.php.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.profiling.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.profiling.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.python.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.python.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.storages.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.storages.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.ttl.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.ttl.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds e2e.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: e2e.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds plugins-jdk14-test.0.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: plugins-jdk14-test.0.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds plugins-test.0.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: plugins-test.0.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds plugins-test.1.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: plugins-test.1.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds plugins-test.2.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: plugins-test.2.yaml
+      - uses: potiuk/cancel-workflow-runs@v4_7
+        name: Cancel Outdated Builds plugins-test.3.yaml
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          workflowFileName: plugins-test.3.yaml


### PR DESCRIPTION
The cancel steps were tried in separate jobs but it causes
an unnecessary increase in the number of jobs blocking the queue
even if we limited parallelism. This PR combines all the cancel
actions into a single job with multiple steps.

While this is a bit more copy&pasting and less DRY it is also
far more optimised and "aggressive" - i.e. once any cancel
job starts to be running it will immediately cancel all duplicates
for all workflows.
