### PR TITLE
Fix issue #5795

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ Release Notes.
 * Fix deadlock problem when using elasticsearch-client-7.0.0.
 * Fix storage-jdbc isExists not set dbname.
 * Fix `searchService` bug in the InfluxDB storage implementation.
-
+* Fix NPE in the nutz plugin.
 #### UI
 
 #### Documentation

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/nutz/http/sync/SenderSendInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/nutz/http/sync/SenderSendInterceptor.java
@@ -65,9 +65,9 @@ public class SenderSendInterceptor implements InstanceMethodsAroundInterceptor {
         Response response = (Response) ret;
         AbstractSpan span = ContextManager.activeSpan();
 
-        if ( response == null || response.getStatus() >= 400) {
+        if (response == null || response.getStatus() >= 400) {
             span.errorOccurred();
-            if ( response != null)
+            if (response != null)
                 Tags.STATUS_CODE.set(span, Integer.toString(response.getStatus()));
         }
         ContextManager.stopSpan();

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/nutz/http/sync/SenderSendInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/nutz/http/sync/SenderSendInterceptor.java
@@ -63,11 +63,12 @@ public class SenderSendInterceptor implements InstanceMethodsAroundInterceptor {
     public Object afterMethod(final EnhancedInstance objInst, final Method method, final Object[] allArguments,
         final Class<?>[] argumentsTypes, Object ret) throws Throwable {
         Response response = (Response) ret;
-        int statusCode = response.getStatus();
         AbstractSpan span = ContextManager.activeSpan();
-        if (statusCode >= 400) {
+
+        if ( response == null || response.getStatus() >= 400) {
             span.errorOccurred();
-            Tags.STATUS_CODE.set(span, Integer.toString(statusCode));
+            if ( response != null)
+                Tags.STATUS_CODE.set(span, Integer.toString(response.getStatus()));
         }
         ContextManager.stopSpan();
         return ret;


### PR DESCRIPTION
Fix the issue: nutz plugin throw NPE at afterMethod, cause traceid keep unchange for the thread

<!--
    ⚠️ Please make sure to read this template first, pull requests that doesn't accord with this template
    may be closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->


### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly about why the bug exists and how to fix it.

- [x] Closes #5795.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/c2141978d1039375598a32418b75161a78da22c1/CHANGES.md).
