### PR TITLE
test: fix flaky LUA E2E test by working around the testcontainers (potential) bug

### DIFF
--- a/test/e2e/e2e-test/docker/lua/Dockerfile.nginx
+++ b/test/e2e/e2e-test/docker/lua/Dockerfile.nginx
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openresty/openresty
+FROM openresty/openresty:1.17.8.2-5-alpine-fat
 
 ENV COMMIT_HASH=cda47ae0a507ab86a378a298325c3c94d9a773c2
 

--- a/test/e2e/e2e-test/docker/lua/docker-compose.yml
+++ b/test/e2e/e2e-test/docker/lua/docker-compose.yml
@@ -66,7 +66,7 @@ services:
         condition: service_healthy
     volumes:
       - ../lua/nginx.conf:/var/nginx/conf.d/nginx.conf
-    entrypoint: ['bash', '-c', 'sleep 5 && /usr/bin/openresty -c /var/nginx/conf.d/nginx.conf']
+    entrypoint: ['bash', '-c', 'sleep 5 && openresty -c /var/nginx/conf.d/nginx.conf']
 
 networks:
   e2e:


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that doesn't accord with this template
    may be closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly about why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

### Fix flaky LUA E2E test by working around the testcontainers bug

The LUA E2E tests failed frequently after upgrading to testcontainers 1.15.0, the log shows  that there is no enough disk space in GitHub Actions, and I found out that it's because we didn't specify the `openresty/openresty` tag in the `Dockerfile`, testcontainers pulls all images, hence run out of the disk space. I've filed an issue in testcontainers repo to confirm whether it's a bug or not, and work around this problem by specify the tag explicitly. ([Details](https://github.com/testcontainers/testcontainers-java/issues/3442))

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>. **NO**, but ref to https://github.com/testcontainers/testcontainers-java/issues/3442
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/c2141978d1039375598a32418b75161a78da22c1/CHANGES.md). NO NEED because it happens within this version
