### PR TITLE
Change the intercept bootstrap class to the same way as intercept the normal class

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapConstructorInter.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapConstructorInter.java
@@ -27,14 +27,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedI
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor;
 
 /**
- * --------CLASS TEMPLATE---------
- * <p>Author, Wu Sheng </p>
- * <p>Comment, don't change this unless you are 100% sure the agent core mechanism for bootstrap class
- * instrumentation.</p>
- * <p>Date, 24th July 2019</p>
- * -------------------------------
- * <p>
- * This class wouldn't be loaded in real env. This is a class template for dynamic class generation.
+ * The actual byte-buddy's interceptor to intercept bootstrap class constructor methods. In this class, it provide a bridge between
+ * byte-buddy and sky-walking plugin.
  */
 public class BootstrapConstructorInter {
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapInstMethodsInter.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapInstMethodsInter.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.apm.agent.core.plugin.bootstrap.template;
+package org.apache.skywalking.apm.agent.core.plugin.bootstrap.interceptor;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
@@ -24,10 +24,12 @@ import net.bytebuddy.implementation.bind.annotation.AllArguments;
 import net.bytebuddy.implementation.bind.annotation.Origin;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import net.bytebuddy.implementation.bind.annotation.This;
 import org.apache.skywalking.apm.agent.core.plugin.bootstrap.IBootstrapLog;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.BootstrapInterRuntimeAssist;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
 
 /**
  * --------CLASS TEMPLATE---------
@@ -39,38 +41,40 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMet
  * <p>
  * This class wouldn't be loaded in real env. This is a class template for dynamic class generation.
  */
-public class StaticMethodInterTemplate {
-    /**
-     * This field is never set in the template, but has value in the runtime.
-     */
-    private static String TARGET_INTERCEPTOR;
+public class BootstrapInstMethodsInter {
 
-    private static StaticMethodsAroundInterceptor INTERCEPTOR;
+    private InstanceMethodsAroundInterceptor interceptor;
     private static IBootstrapLog LOGGER;
 
+    public BootstrapInstMethodsInter(String interceptorClassName) {
+        prepare(interceptorClassName);
+    }
+
     /**
-     * Intercept the target static method.
+     * Intercept the target instance method.
      *
-     * @param clazz        target class
+     * @param obj          target class instance.
      * @param allArguments all method arguments
      * @param method       method description.
      * @param zuper        the origin call ref.
-     * @return the return value of target static method.
+     * @return the return value of target instance method.
      * @throws Exception only throw exception because of zuper.call() or unexpected exception in sky-walking ( This is a
      *                   bug, if anything triggers this condition ).
      */
     @RuntimeType
-    public static Object intercept(@Origin Class<?> clazz, @AllArguments Object[] allArguments, @Origin Method method,
-        @SuperCall Callable<?> zuper) throws Throwable {
-        prepare();
+    public Object intercept(@This Object obj, @AllArguments Object[] allArguments, @SuperCall Callable<?> zuper,
+                            @Origin Method method) throws Throwable {
+        EnhancedInstance targetObject = (EnhancedInstance) obj;
 
         MethodInterceptResult result = new MethodInterceptResult();
         try {
-            if (INTERCEPTOR != null) {
-                INTERCEPTOR.beforeMethod(clazz, method, allArguments, method.getParameterTypes(), result);
+            if (interceptor != null) {
+                interceptor.beforeMethod(targetObject, method, allArguments, method.getParameterTypes(), result);
             }
         } catch (Throwable t) {
-            LOGGER.error(t, "class[{}] before static method[{}] intercept failure", clazz, method.getName());
+            if (LOGGER != null) {
+                LOGGER.error(t, "class[{}] before method[{}] intercept failure", obj.getClass(), method.getName());
+            }
         }
 
         Object ret = null;
@@ -82,42 +86,49 @@ public class StaticMethodInterTemplate {
             }
         } catch (Throwable t) {
             try {
-                if (INTERCEPTOR != null) {
-                    INTERCEPTOR.handleMethodException(clazz, method, allArguments, method.getParameterTypes(), t);
+                if (interceptor != null) {
+                    interceptor.handleMethodException(
+                        targetObject, method, allArguments, method.getParameterTypes(), t);
                 }
             } catch (Throwable t2) {
-                LOGGER.error(t2, "class[{}] handle static method[{}] exception failure", clazz, method.getName(), t2.getMessage());
+                if (LOGGER != null) {
+                    LOGGER.error(t2, "class[{}] handle method[{}] exception failure", obj.getClass(), method.getName());
+                }
             }
             throw t;
         } finally {
             try {
-                if (INTERCEPTOR != null) {
-                    ret = INTERCEPTOR.afterMethod(clazz, method, allArguments, method.getParameterTypes(), ret);
+                if (interceptor != null) {
+                    ret = interceptor.afterMethod(targetObject, method, allArguments, method.getParameterTypes(), ret);
                 }
             } catch (Throwable t) {
-                LOGGER.error(t, "class[{}] after static method[{}] intercept failure:{}", clazz, method.getName(), t.getMessage());
+                if (LOGGER != null) {
+                    LOGGER.error(t, "class[{}] after method[{}] intercept failure", obj.getClass(), method.getName());
+                }
             }
         }
+
         return ret;
     }
 
     /**
      * Prepare the context. Link to the agent core in AppClassLoader.
      */
-    private static void prepare() {
-        if (INTERCEPTOR == null) {
+    private void prepare(String interceptorClassName) {
+        if (interceptor == null) {
             ClassLoader loader = BootstrapInterRuntimeAssist.getAgentClassLoader();
 
             if (loader != null) {
-                IBootstrapLog logger = BootstrapInterRuntimeAssist.getLogger(loader, TARGET_INTERCEPTOR);
+                IBootstrapLog logger = BootstrapInterRuntimeAssist.getLogger(loader, interceptorClassName);
                 if (logger != null) {
                     LOGGER = logger;
 
-                    INTERCEPTOR = BootstrapInterRuntimeAssist.createInterceptor(loader, TARGET_INTERCEPTOR, LOGGER);
+                    interceptor = BootstrapInterRuntimeAssist.createInterceptor(loader, interceptorClassName, LOGGER);
                 }
             } else {
-                LOGGER.error("Runtime ClassLoader not found when create {}." + TARGET_INTERCEPTOR);
+                LOGGER.error("Runtime ClassLoader not found when create {}." + interceptorClassName);
             }
         }
     }
 }
+

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapInstMethodsInter.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapInstMethodsInter.java
@@ -32,14 +32,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 
 /**
- * --------CLASS TEMPLATE---------
- * <p>Author, Wu Sheng </p>
- * <p>Comment, don't change this unless you are 100% sure the agent core mechanism for bootstrap class
- * instrumentation.</p>
- * <p>Date, 24th July 2019</p>
- * -------------------------------
- * <p>
- * This class wouldn't be loaded in real env. This is a class template for dynamic class generation.
+ * The actual byte-buddy's interceptor to intercept bootstrap class instance methods. In this class, it provide a bridge between
+ * byte-buddy and sky-walking plugin.
  */
 public class BootstrapInstMethodsInter {
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapInstMethodsInterWithOverrideArgs.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapInstMethodsInterWithOverrideArgs.java
@@ -32,14 +32,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.OverrideCallable;
 
 /**
- * --------CLASS TEMPLATE---------
- * <p>Author, Wu Sheng </p>
- * <p>Comment, don't change this unless you are 100% sure the agent core mechanism for bootstrap class
- * instrumentation.</p>
- * <p>Date, 24th July 2019</p>
- * -------------------------------
- * <p>
- * This class wouldn't be loaded in real env. This is a class template for dynamic class generation.
+ * The actual byte-buddy's interceptor to intercept bootstrap class instance methods. In this class, it provide a bridge between
+ * byte-buddy and sky-walking plugin.
  */
 public class BootstrapInstMethodsInterWithOverrideArgs {
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapStaticMethodsInter.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapStaticMethodsInter.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.apm.agent.core.plugin.bootstrap.template;
+package org.apache.skywalking.apm.agent.core.plugin.bootstrap.interceptor;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
@@ -24,12 +24,10 @@ import net.bytebuddy.implementation.bind.annotation.AllArguments;
 import net.bytebuddy.implementation.bind.annotation.Origin;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
-import net.bytebuddy.implementation.bind.annotation.This;
 import org.apache.skywalking.apm.agent.core.plugin.bootstrap.IBootstrapLog;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.BootstrapInterRuntimeAssist;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
 
 /**
  * --------CLASS TEMPLATE---------
@@ -41,42 +39,37 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
  * <p>
  * This class wouldn't be loaded in real env. This is a class template for dynamic class generation.
  */
-public class InstanceMethodInterTemplate {
-    /**
-     * This field is never set in the template, but has value in the runtime.
-     */
-    private static String TARGET_INTERCEPTOR;
+public class BootstrapStaticMethodsInter {
 
-    private static InstanceMethodsAroundInterceptor INTERCEPTOR;
+    private StaticMethodsAroundInterceptor interceptor;
     private static IBootstrapLog LOGGER;
 
+    public BootstrapStaticMethodsInter(String interceptorClassName) {
+        prepare(interceptorClassName);
+    }
+
     /**
-     * Intercept the target instance method.
+     * Intercept the target static method.
      *
-     * @param obj          target class instance.
+     * @param clazz        target class
      * @param allArguments all method arguments
      * @param method       method description.
      * @param zuper        the origin call ref.
-     * @return the return value of target instance method.
+     * @return the return value of target static method.
      * @throws Exception only throw exception because of zuper.call() or unexpected exception in sky-walking ( This is a
      *                   bug, if anything triggers this condition ).
      */
     @RuntimeType
-    public static Object intercept(@This Object obj, @AllArguments Object[] allArguments, @SuperCall Callable<?> zuper,
-        @Origin Method method) throws Throwable {
-        EnhancedInstance targetObject = (EnhancedInstance) obj;
-
-        prepare();
+    public Object intercept(@Origin Class<?> clazz, @AllArguments Object[] allArguments, @Origin Method method,
+                            @SuperCall Callable<?> zuper) throws Throwable {
 
         MethodInterceptResult result = new MethodInterceptResult();
         try {
-            if (INTERCEPTOR != null) {
-                INTERCEPTOR.beforeMethod(targetObject, method, allArguments, method.getParameterTypes(), result);
+            if (interceptor != null) {
+                interceptor.beforeMethod(clazz, method, allArguments, method.getParameterTypes(), result);
             }
         } catch (Throwable t) {
-            if (LOGGER != null) {
-                LOGGER.error(t, "class[{}] before method[{}] intercept failure", obj.getClass(), method.getName());
-            }
+            LOGGER.error(t, "class[{}] before static method[{}] intercept failure", clazz, method.getName());
         }
 
         Object ret = null;
@@ -88,48 +81,48 @@ public class InstanceMethodInterTemplate {
             }
         } catch (Throwable t) {
             try {
-                if (INTERCEPTOR != null) {
-                    INTERCEPTOR.handleMethodException(targetObject, method, allArguments, method.getParameterTypes(), t);
+                if (interceptor != null) {
+                    interceptor.handleMethodException(clazz, method, allArguments, method.getParameterTypes(), t);
                 }
             } catch (Throwable t2) {
-                if (LOGGER != null) {
-                    LOGGER.error(t2, "class[{}] handle method[{}] exception failure", obj.getClass(), method.getName());
-                }
+                LOGGER.error(
+                    t2, "class[{}] handle static method[{}] exception failure", clazz, method.getName(),
+                    t2.getMessage()
+                );
             }
             throw t;
         } finally {
             try {
-                if (INTERCEPTOR != null) {
-                    ret = INTERCEPTOR.afterMethod(targetObject, method, allArguments, method.getParameterTypes(), ret);
+                if (interceptor != null) {
+                    ret = interceptor.afterMethod(clazz, method, allArguments, method.getParameterTypes(), ret);
                 }
             } catch (Throwable t) {
-                if (LOGGER != null) {
-                    LOGGER.error(t, "class[{}] after method[{}] intercept failure", obj.getClass(), method.getName());
-                }
+                LOGGER.error(
+                    t, "class[{}] after static method[{}] intercept failure:{}", clazz, method.getName(),
+                    t.getMessage()
+                );
             }
         }
-
         return ret;
     }
 
     /**
      * Prepare the context. Link to the agent core in AppClassLoader.
      */
-    private static void prepare() {
-        if (INTERCEPTOR == null) {
+    private void prepare(String interceptorClassName) {
+        if (interceptor == null) {
             ClassLoader loader = BootstrapInterRuntimeAssist.getAgentClassLoader();
 
             if (loader != null) {
-                IBootstrapLog logger = BootstrapInterRuntimeAssist.getLogger(loader, TARGET_INTERCEPTOR);
+                IBootstrapLog logger = BootstrapInterRuntimeAssist.getLogger(loader, interceptorClassName);
                 if (logger != null) {
                     LOGGER = logger;
 
-                    INTERCEPTOR = BootstrapInterRuntimeAssist.createInterceptor(loader, TARGET_INTERCEPTOR, LOGGER);
+                    interceptor = BootstrapInterRuntimeAssist.createInterceptor(loader, interceptorClassName, LOGGER);
                 }
             } else {
-                LOGGER.error("Runtime ClassLoader not found when create {}." + TARGET_INTERCEPTOR);
+                LOGGER.error("Runtime ClassLoader not found when create {}." + interceptorClassName);
             }
         }
     }
 }
-

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapStaticMethodsInter.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapStaticMethodsInter.java
@@ -30,14 +30,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
 
 /**
- * --------CLASS TEMPLATE---------
- * <p>Author, Wu Sheng </p>
- * <p>Comment, don't change this unless you are 100% sure the agent core mechanism for bootstrap class
- * instrumentation.</p>
- * <p>Date, 24th July 2019</p>
- * -------------------------------
- * <p>
- * This class wouldn't be loaded in real env. This is a class template for dynamic class generation.
+ * The actual byte-buddy's interceptor to intercept bootstrap class instance methods. In this class, it provide a bridge between
+ * byte-buddy and sky-walking plugin.
  */
 public class BootstrapStaticMethodsInter {
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapStaticMethodsInterWithOverrideArgs.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapStaticMethodsInterWithOverrideArgs.java
@@ -30,14 +30,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.OverrideC
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
 
 /**
- * --------CLASS TEMPLATE---------
- * <p>Author, Wu Sheng </p>
- * <p>Comment, don't change this unless you are 100% sure the agent core mechanism for bootstrap class
- * instrumentation.</p>
- * <p>Date, 24th July 2019</p>
- * -------------------------------
- * <p>
- * This class wouldn't be loaded in real env. This is a class template for dynamic class generation.
+ * The actual byte-buddy's interceptor to intercept class instance methods. In this class, it provide a bridge between
+ * byte-buddy and sky-walking plugin.
  */
 public class BootstrapStaticMethodsInterWithOverrideArgs {
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapStaticMethodsInterWithOverrideArgs.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bootstrap/interceptor/BootstrapStaticMethodsInterWithOverrideArgs.java
@@ -16,20 +16,18 @@
  *
  */
 
-package org.apache.skywalking.apm.agent.core.plugin.bootstrap.template;
+package org.apache.skywalking.apm.agent.core.plugin.bootstrap.interceptor;
 
 import java.lang.reflect.Method;
 import net.bytebuddy.implementation.bind.annotation.AllArguments;
 import net.bytebuddy.implementation.bind.annotation.Morph;
 import net.bytebuddy.implementation.bind.annotation.Origin;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
-import net.bytebuddy.implementation.bind.annotation.This;
 import org.apache.skywalking.apm.agent.core.plugin.bootstrap.IBootstrapLog;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.BootstrapInterRuntimeAssist;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.OverrideCallable;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
 
 /**
  * --------CLASS TEMPLATE---------
@@ -41,42 +39,37 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.OverrideC
  * <p>
  * This class wouldn't be loaded in real env. This is a class template for dynamic class generation.
  */
-public class InstanceMethodInterWithOverrideArgsTemplate {
-    /**
-     * This field is never set in the template, but has value in the runtime.
-     */
-    private static String TARGET_INTERCEPTOR;
+public class BootstrapStaticMethodsInterWithOverrideArgs {
 
-    private static InstanceMethodsAroundInterceptor INTERCEPTOR;
+    private StaticMethodsAroundInterceptor interceptor;
     private static IBootstrapLog LOGGER;
 
+    public BootstrapStaticMethodsInterWithOverrideArgs(String interceptorClassName) {
+        prepare(interceptorClassName);
+    }
+
     /**
-     * Intercept the target instance method.
+     * Intercept the target static method.
      *
-     * @param obj          target class instance.
+     * @param clazz        target class
      * @param allArguments all method arguments
      * @param method       method description.
      * @param zuper        the origin call ref.
-     * @return the return value of target instance method.
+     * @return the return value of target static method.
      * @throws Exception only throw exception because of zuper.call() or unexpected exception in sky-walking ( This is a
      *                   bug, if anything triggers this condition ).
      */
     @RuntimeType
-    public static Object intercept(@This Object obj, @AllArguments Object[] allArguments, @Morph OverrideCallable zuper,
-        @Origin Method method) throws Throwable {
-        EnhancedInstance targetObject = (EnhancedInstance) obj;
-
-        prepare();
+    public Object intercept(@Origin Class<?> clazz, @AllArguments Object[] allArguments, @Origin Method method,
+                            @Morph OverrideCallable zuper) throws Throwable {
 
         MethodInterceptResult result = new MethodInterceptResult();
         try {
-            if (INTERCEPTOR != null) {
-                INTERCEPTOR.beforeMethod(targetObject, method, allArguments, method.getParameterTypes(), result);
+            if (interceptor != null) {
+                interceptor.beforeMethod(clazz, method, allArguments, method.getParameterTypes(), result);
             }
         } catch (Throwable t) {
-            if (LOGGER != null) {
-                LOGGER.error(t, "class[{}] before method[{}] intercept failure", obj.getClass(), method.getName());
-            }
+            LOGGER.error(t, "class[{}] before static method[{}] intercept failure", clazz, method.getName());
         }
 
         Object ret = null;
@@ -88,48 +81,48 @@ public class InstanceMethodInterWithOverrideArgsTemplate {
             }
         } catch (Throwable t) {
             try {
-                if (INTERCEPTOR != null) {
-                    INTERCEPTOR.handleMethodException(targetObject, method, allArguments, method.getParameterTypes(), t);
+                if (interceptor != null) {
+                    interceptor.handleMethodException(clazz, method, allArguments, method.getParameterTypes(), t);
                 }
             } catch (Throwable t2) {
-                if (LOGGER != null) {
-                    LOGGER.error(t2, "class[{}] handle method[{}] exception failure", obj.getClass(), method.getName());
-                }
+                LOGGER.error(
+                    t2, "class[{}] handle static method[{}] exception failure", clazz, method.getName(),
+                    t2.getMessage()
+                );
             }
             throw t;
         } finally {
             try {
-                if (INTERCEPTOR != null) {
-                    ret = INTERCEPTOR.afterMethod(targetObject, method, allArguments, method.getParameterTypes(), ret);
+                if (interceptor != null) {
+                    ret = interceptor.afterMethod(clazz, method, allArguments, method.getParameterTypes(), ret);
                 }
             } catch (Throwable t) {
-                if (LOGGER != null) {
-                    LOGGER.error(t, "class[{}] after method[{}] intercept failure", obj.getClass(), method.getName());
-                }
+                LOGGER.error(
+                    t, "class[{}] after static method[{}] intercept failure:{}", clazz, method.getName(),
+                    t.getMessage()
+                );
             }
         }
-
         return ret;
     }
 
     /**
      * Prepare the context. Link to the agent core in AppClassLoader.
      */
-    private static void prepare() {
-        if (INTERCEPTOR == null) {
+    private void prepare(String interceptorClassName) {
+        if (interceptor == null) {
             ClassLoader loader = BootstrapInterRuntimeAssist.getAgentClassLoader();
 
             if (loader != null) {
-                IBootstrapLog logger = BootstrapInterRuntimeAssist.getLogger(loader, TARGET_INTERCEPTOR);
+                IBootstrapLog logger = BootstrapInterRuntimeAssist.getLogger(loader, interceptorClassName);
                 if (logger != null) {
                     LOGGER = logger;
 
-                    INTERCEPTOR = BootstrapInterRuntimeAssist.createInterceptor(loader, TARGET_INTERCEPTOR, LOGGER);
+                    interceptor = BootstrapInterRuntimeAssist.createInterceptor(loader, interceptorClassName, LOGGER);
                 }
             } else {
-                LOGGER.error("Runtime ClassLoader not found when create {}." + TARGET_INTERCEPTOR);
+                LOGGER.error("Runtime ClassLoader not found when create {}." + interceptorClassName);
             }
         }
     }
 }
-

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ClassEnhancePluginDefine.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ClassEnhancePluginDefine.java
@@ -32,7 +32,11 @@ import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 import org.apache.skywalking.apm.agent.core.plugin.AbstractClassEnhancePluginDefine;
 import org.apache.skywalking.apm.agent.core.plugin.EnhanceContext;
 import org.apache.skywalking.apm.agent.core.plugin.PluginException;
-import org.apache.skywalking.apm.agent.core.plugin.bootstrap.BootstrapInstrumentBoost;
+import org.apache.skywalking.apm.agent.core.plugin.bootstrap.interceptor.BootstrapConstructorInter;
+import org.apache.skywalking.apm.agent.core.plugin.bootstrap.interceptor.BootstrapInstMethodsInter;
+import org.apache.skywalking.apm.agent.core.plugin.bootstrap.interceptor.BootstrapInstMethodsInterWithOverrideArgs;
+import org.apache.skywalking.apm.agent.core.plugin.bootstrap.interceptor.BootstrapStaticMethodsInter;
+import org.apache.skywalking.apm.agent.core.plugin.bootstrap.interceptor.BootstrapStaticMethodsInterWithOverrideArgs;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.DeclaredInstanceMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.EnhanceException;
@@ -130,14 +134,13 @@ public abstract class ClassEnhancePluginDefine extends AbstractClassEnhancePlugi
                 if (isBootstrapInstrumentation()) {
                     newClassBuilder = newClassBuilder.constructor(constructorInterceptPoint.getConstructorMatcher())
                                                      .intercept(SuperMethodCall.INSTANCE.andThen(MethodDelegation.withDefaultConfiguration()
-                                                                                                                 .to(BootstrapInstrumentBoost
-                                                                                                                     .forInternalDelegateClass(constructorInterceptPoint
-                                                                                                                         .getConstructorInterceptor()))));
+                                                                                                                 .to(new BootstrapConstructorInter(
+                                                                                                                     constructorInterceptPoint.getConstructorInterceptor()))));
                 } else {
                     newClassBuilder = newClassBuilder.constructor(constructorInterceptPoint.getConstructorMatcher())
                                                      .intercept(SuperMethodCall.INSTANCE.andThen(MethodDelegation.withDefaultConfiguration()
-                                                                                                                 .to(new ConstructorInter(constructorInterceptPoint
-                                                                                                                     .getConstructorInterceptor(), classLoader))));
+                                                                                                                 .to(new ConstructorInter(
+                                                                                                                     constructorInterceptPoint.getConstructorInterceptor(), classLoader))));
                 }
             }
         }
@@ -160,7 +163,7 @@ public abstract class ClassEnhancePluginDefine extends AbstractClassEnhancePlugi
                         newClassBuilder = newClassBuilder.method(junction)
                                                          .intercept(MethodDelegation.withDefaultConfiguration()
                                                                                     .withBinders(Morph.Binder.install(OverrideCallable.class))
-                                                                                    .to(BootstrapInstrumentBoost.forInternalDelegateClass(interceptor)));
+                                                                                    .to(new BootstrapInstMethodsInterWithOverrideArgs(interceptor)));
                     } else {
                         newClassBuilder = newClassBuilder.method(junction)
                                                          .intercept(MethodDelegation.withDefaultConfiguration()
@@ -171,7 +174,7 @@ public abstract class ClassEnhancePluginDefine extends AbstractClassEnhancePlugi
                     if (isBootstrapInstrumentation()) {
                         newClassBuilder = newClassBuilder.method(junction)
                                                          .intercept(MethodDelegation.withDefaultConfiguration()
-                                                                                    .to(BootstrapInstrumentBoost.forInternalDelegateClass(interceptor)));
+                                                                                    .to(new BootstrapInstMethodsInter(interceptor)));
                     } else {
                         newClassBuilder = newClassBuilder.method(junction)
                                                          .intercept(MethodDelegation.withDefaultConfiguration()
@@ -210,7 +213,7 @@ public abstract class ClassEnhancePluginDefine extends AbstractClassEnhancePlugi
                     newClassBuilder = newClassBuilder.method(isStatic().and(staticMethodsInterceptPoint.getMethodsMatcher()))
                                                      .intercept(MethodDelegation.withDefaultConfiguration()
                                                                                 .withBinders(Morph.Binder.install(OverrideCallable.class))
-                                                                                .to(BootstrapInstrumentBoost.forInternalDelegateClass(interceptor)));
+                                                                                .to(new BootstrapStaticMethodsInterWithOverrideArgs(interceptor)));
                 } else {
                     newClassBuilder = newClassBuilder.method(isStatic().and(staticMethodsInterceptPoint.getMethodsMatcher()))
                                                      .intercept(MethodDelegation.withDefaultConfiguration()
@@ -221,7 +224,7 @@ public abstract class ClassEnhancePluginDefine extends AbstractClassEnhancePlugi
                 if (isBootstrapInstrumentation()) {
                     newClassBuilder = newClassBuilder.method(isStatic().and(staticMethodsInterceptPoint.getMethodsMatcher()))
                                                      .intercept(MethodDelegation.withDefaultConfiguration()
-                                                                                .to(BootstrapInstrumentBoost.forInternalDelegateClass(interceptor)));
+                                                                                .to(new BootstrapStaticMethodsInter(interceptor)));
                 } else {
                     newClassBuilder = newClassBuilder.method(isStatic().and(staticMethodsInterceptPoint.getMethodsMatcher()))
                                                      .intercept(MethodDelegation.withDefaultConfiguration()

--- a/test/plugin/scenarios/jdk-threading-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jdk-threading-scenario/config/expectedData.yaml
@@ -36,7 +36,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /apache/skywalking
+    - operationName: /healthCheck
       operationId: 0
       parentSpanId: 0
       spanId: 1
@@ -46,9 +46,9 @@ segmentItems:
       componentId: 13
       isError: false
       spanType: Exit
-      peer: github.com:443
+      peer: localhost:8080
       tags:
-      - {key: url, value: 'https://github.com:-1/apache/skywalking'}
+      - {key: url, value: 'http://localhost:8080/healthCheck'}
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: Threading/test.org.apache.skywalking.apm.testcase.jdk.threading.Application$TestController$1/run
@@ -69,7 +69,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /apache/skywalking
+    - operationName: /healthCheck
       operationId: 0
       parentSpanId: 0
       spanId: 1
@@ -79,9 +79,9 @@ segmentItems:
       componentId: 13
       isError: false
       spanType: Exit
-      peer: github.com:443
+      peer: localhost:8080
       tags:
-      - {key: url, value: 'https://github.com:-1/apache/skywalking'}
+      - {key: url, value: 'http://localhost:8080/healthCheck'}
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: Threading/test.org.apache.skywalking.apm.testcase.jdk.threading.Application$TestController$2/call

--- a/test/plugin/scenarios/jdk-threading-scenario/src/main/java/test/org/apache/skywalking/apm/testcase/jdk/threading/Application.java
+++ b/test/plugin/scenarios/jdk-threading-scenario/src/main/java/test/org/apache/skywalking/apm/testcase/jdk/threading/Application.java
@@ -61,7 +61,7 @@ public class Application {
             Runnable runnable = new Runnable() {
                 @Override
                 public void run() {
-                    restTemplate.getForEntity("https://github.com/apache/skywalking", String.class);
+                    restTemplate.getForEntity("http://localhost:8080/healthCheck", String.class);
                 }
             };
 
@@ -70,7 +70,7 @@ public class Application {
             executorService.submit(new Callable<String>() {
                 @Override
                 public String call() {
-                    return restTemplate.getForEntity("https://github.com/apache/skywalking", String.class).getBody();
+                    return restTemplate.getForEntity("http://localhost:8080/healthCheck", String.class).getBody();
                 }
             }).get();
 


### PR DESCRIPTION
### Change the intercept boot class to the same way as intercept the regular class
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly about why the bug exists and how to fix it.

We now use the bootstrap interceptor to generate an interceptor of xxx_internal, and then call the real interceptor in the interceptor. For example
![image](https://user-images.githubusercontent.com/16839929/98517669-3e998d00-22a9-11eb-843b-244950658bf2.png)

After the modification, we will not generate the xxx_internal class, For example

![image](https://user-images.githubusercontent.com/16839929/98520814-90dcad00-22ad-11eb-8e8c-7b7c8eaddcc5.png)
![image](https://user-images.githubusercontent.com/16839929/98520936-be295b00-22ad-11eb-857a-2dfa72b12a97.png)

1. In order to reduce the use of metaspace space, avoid java.lang.OutOfMemoryError: Metaspace
2. For the readability of the code, it is easy to modify in the future.
3. For the next plugin dynamic switch.