### PR TITLE
Improve ES query speed by using traceId

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Release Notes.
 * Fix CVE in the Apdex threshold configs, when activating the dynamic configuration feature.
 * Make the codes and doc consistent in sharding server and core server.
 * Fix that chunked string is incorrect while the tag contains colon
+* Improve ES query speed by using traceId
 
 #### UI
 * Fix incorrect label in radial chart in topology.


### PR DESCRIPTION
### Improve ES query speed by using traceId
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>

Because the third part of traceId has time information, we can search within the specified time slice when querying. When there are many fragments and the amount of data is large, this can greatly improve the query speed.