### PR TITLE
fix flaky test in comsumerTest

### DIFF
--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerTest.java
@@ -35,6 +35,7 @@ public class ConsumerTest {
 
     @Test
     public void testConsumerLessThanChannel() throws IllegalAccessException {
+        BUFFER.drainTo(new ArrayList<SampleData>());
         final DataCarrier<SampleData> carrier = new DataCarrier<SampleData>(2, 100);
 
         for (int i = 0; i < 100; i++) {
@@ -56,6 +57,7 @@ public class ConsumerTest {
 
     @Test
     public void testConsumerMoreThanChannel() throws IllegalAccessException, InterruptedException {
+        BUFFER.drainTo(new ArrayList<SampleData>());
         final DataCarrier<SampleData> carrier = new DataCarrier<SampleData>(2, 100);
 
         for (int i = 0; i < 200; i++) {

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerTest.java
@@ -35,7 +35,7 @@ public class ConsumerTest {
 
     @Test
     public void testConsumerLessThanChannel() throws IllegalAccessException {
-        BUFFER.drainTo(new ArrayList<SampleData>());
+
         final DataCarrier<SampleData> carrier = new DataCarrier<SampleData>(2, 100);
 
         for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
Fixed flaky test that caused by ConsumerTest.java under skywaling-apm-datacarrier

Existing tests are flaky because the testConsumerMoreThanChannel doesn't clear channel at the beginning of this test case.

Both testConsumerLessThanChannel and testConsumerMoreThanChannel use the same carrier. In testConsumerLessThanChannel, it produces some data and store in the channel. When we run testConsumerMoreThanChannel, the data introduced by testConsumerLessThanChannel will affect this test case. 



The flaky tests are found by running https://github.com/idflakies/iDFlakies