### PR TITLE
Provide `listMetrics` GraphQL query service.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Release Notes.
 * Add the thread pool to the Kafka fetcher to increase the performance.
 * Add `contain` and `not contain` OPS in OAL.
 * Add Envoy ALS analyzer based on metadata exchange.
+* Add `listMetrics` GraphQL query. 
 * Support keeping collecting the slowly segments in the sampling mechanism.
 * Support choose files to active the meter analyzer.
 * Support nested class definition in the Service, ServiceInstance, Endpoint, ServiceRelation, and ServiceInstanceRelation sources.

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricDefinition.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricDefinition.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.query;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.skywalking.oap.server.core.query.enumeration.MetricsType;
+
+/**
+ * Define the metrics provided in the OAP server.
+ *
+ * @since 8.3.0
+ */
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MetricDefinition {
+    private String name;
+    private MetricsType type;
+    /**
+     * Catalog includes SERVICE_CATALOG,SERVICE_INSTANCE_CATALOG,ENDPOINT_CATALOG,
+     * SERVICE_RELATION_CATALOG,SERVICE_INSTANCE_RELATION_CATALOG_NAME,ENDPOINT_RELATION_CATALOG_NAME
+     */
+    private String catalog;
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricsMetadataQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetricsMetadataQueryService.java
@@ -18,8 +18,12 @@
 
 package org.apache.skywalking.oap.server.core.query;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.skywalking.apm.util.StringUtil;
 import org.apache.skywalking.oap.server.core.query.enumeration.MetricsType;
+import org.apache.skywalking.oap.server.core.source.DefaultScopeDefine;
 import org.apache.skywalking.oap.server.core.storage.annotation.ValueColumnMetadata;
 import org.apache.skywalking.oap.server.library.module.Service;
 
@@ -47,5 +51,22 @@ public class MetricsMetadataQueryService implements Service {
         } else {
             return MetricsType.UNKNOWN;
         }
+    }
+
+    public List<MetricDefinition> listMetrics(String regex) {
+        return ValueColumnMetadata.INSTANCE.getAllMetadata()
+                                           .entrySet()
+                                           .stream()
+                                           .filter(
+                                               metadata ->
+                                                   StringUtil.isNotEmpty(regex) ?
+                                                       metadata.getKey().matches(regex) : true)
+                                           .map(metadata -> new MetricDefinition(
+                                                    metadata.getKey(),
+                                                    typeOfMetrics(metadata.getKey()),
+                                                    DefaultScopeDefine.catalogOf(metadata.getValue().getScopeId())
+                                                )
+                                           )
+                                           .collect(Collectors.toList());
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DefaultScopeDefine.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DefaultScopeDefine.java
@@ -296,6 +296,34 @@ public class DefaultScopeDefine {
     }
 
     /**
+     * Get the catalog string name of the given scope
+     *
+     * @param scope id of the source scope.
+     * @return literal string name of the catalog owning the scope.
+     */
+    public static String catalogOf(int scope) {
+        if (inServiceCatalog(scope)) {
+            return SERVICE_CATALOG_NAME;
+        }
+        if (inServiceInstanceCatalog(scope)) {
+            return SERVICE_INSTANCE_CATALOG_NAME;
+        }
+        if (inEndpointCatalog(scope)) {
+            return ENDPOINT_CATALOG_NAME;
+        }
+        if (inServiceRelationCatalog(scope)) {
+            return SERVICE_RELATION_CATALOG_NAME;
+        }
+        if (inServiceInstanceRelationCatalog(scope)) {
+            return SERVICE_INSTANCE_RELATION_CATALOG_NAME;
+        }
+        if (inEndpointRelationCatalog(scope)) {
+            return ENDPOINT_RELATION_CATALOG_NAME;
+        }
+        return "UNKNOWN";
+    }
+
+    /**
      * Get the default columns defined in Scope. All those columns will forward to persistent entity.
      *
      * @param scopeName of the default columns

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/ValueColumnMetadata.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/ValueColumnMetadata.java
@@ -41,8 +41,9 @@ public enum ValueColumnMetadata {
                             String valueCName,
                             Column.ValueDataType dataType,
                             Function function,
-                            int defaultValue) {
-        mapping.putIfAbsent(modelName, new ValueColumn(valueCName, dataType, function, defaultValue));
+                            int defaultValue,
+                            int scopeId) {
+        mapping.putIfAbsent(modelName, new ValueColumn(valueCName, dataType, function, defaultValue, scopeId));
     }
 
     /**
@@ -63,8 +64,18 @@ public enum ValueColumnMetadata {
         return findColumn(metricsName).defaultValue;
     }
 
+    /**
+     * @return metric metadata if found
+     */
     public Optional<ValueColumn> readValueColumnDefinition(String metricsName) {
         return Optional.ofNullable(mapping.get(metricsName));
+    }
+
+    /**
+     * @return all metrics metadata.
+     */
+    public Map<String, ValueColumn> getAllMetadata() {
+        return mapping;
     }
 
     private ValueColumn findColumn(String metricsName) {
@@ -82,5 +93,6 @@ public enum ValueColumnMetadata {
         private final Column.ValueDataType dataType;
         private final Function function;
         private final int defaultValue;
+        private final int scopeId;
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
@@ -56,7 +56,7 @@ public class StorageModels implements IModelManager, ModelCreator, ModelManipula
 
         List<ModelColumn> modelColumns = new ArrayList<>();
         List<ExtraQueryIndex> extraQueryIndices = new ArrayList<>();
-        retrieval(aClass, storage.getModelName(), modelColumns, extraQueryIndices);
+        retrieval(aClass, storage.getModelName(), modelColumns, extraQueryIndices, scopeId);
 
         Model model = new Model(
             storage.getModelName(), modelColumns, extraQueryIndices, scopeId,
@@ -91,10 +91,11 @@ public class StorageModels implements IModelManager, ModelCreator, ModelManipula
     /**
      * Read model column metadata based on the class level definition.
      */
-    private void retrieval(Class<?> clazz,
-                           String modelName,
-                           List<ModelColumn> modelColumns,
-                           List<ExtraQueryIndex> extraQueryIndices) {
+    private void retrieval(final Class<?> clazz,
+                           final String modelName,
+                           final List<ModelColumn> modelColumns,
+                           final List<ExtraQueryIndex> extraQueryIndices,
+                           final int scopeId) {
         if (log.isDebugEnabled()) {
             log.debug("Analysis {} to generate Model.", clazz.getName());
         }
@@ -131,7 +132,7 @@ public class StorageModels implements IModelManager, ModelCreator, ModelManipula
                 if (column.dataType().isValue()) {
                     ValueColumnMetadata.INSTANCE.putIfAbsent(
                         modelName, column.columnName(), column.dataType(), column.function(),
-                        column.defaultValue()
+                        column.defaultValue(), scopeId
                     );
                 }
 
@@ -152,7 +153,7 @@ public class StorageModels implements IModelManager, ModelCreator, ModelManipula
         }
 
         if (Objects.nonNull(clazz.getSuperclass())) {
-            retrieval(clazz.getSuperclass(), modelName, modelColumns, extraQueryIndices);
+            retrieval(clazz.getSuperclass(), modelName, modelColumns, extraQueryIndices, scopeId);
         }
     }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/storage/query/MetricsQueryUtilTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/storage/query/MetricsQueryUtilTest.java
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized;
 
 import static com.google.common.collect.ImmutableMap.of;
 import static java.util.Arrays.asList;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE;
 import static org.apache.skywalking.oap.server.core.storage.annotation.Column.ValueDataType.LABELED_VALUE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -108,7 +109,7 @@ public class MetricsQueryUtilTest {
     @Before
     public void setup() {
         ValueColumnMetadata.INSTANCE.putIfAbsent(
-            MODULE_NAME, "value", LABELED_VALUE, Function.None, DEFAULT_VALUE
+            MODULE_NAME, "value", LABELED_VALUE, Function.None, DEFAULT_VALUE, SERVICE
         );
     }
 

--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/MetricsQuery.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/MetricsQuery.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.metrics.DataTable;
 import org.apache.skywalking.oap.server.core.query.AggregationQueryService;
+import org.apache.skywalking.oap.server.core.query.MetricDefinition;
 import org.apache.skywalking.oap.server.core.query.MetricsMetadataQueryService;
 import org.apache.skywalking.oap.server.core.query.MetricsQueryService;
 import org.apache.skywalking.oap.server.core.query.PointOfTime;
@@ -97,6 +98,16 @@ public class MetricsQuery implements GraphQLQueryResolver {
      */
     public MetricsType typeOfMetrics(String name) throws IOException {
         return getMetricsMetadataQueryService().typeOfMetrics(name);
+    }
+
+    /**
+     * Get the list of all available metrics in the current OAP server.
+     *
+     * @param regex to filter the metrics by name, if existing.
+     * @return all available metrics.
+     */
+    public List<MetricDefinition> listMetrics(String regex) {
+        return getMetricsMetadataQueryService().listMetrics(regex);
     }
 
     /**


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that doesn't accord with this template
    may be closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly about why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

In the SWCK 0.2.0, we intend to add supports for k8s HPA. So, I expose the metrics metadata list query service by the GraphQL to adopt the HPA requirement.

In this query
1. You could query all metrics when put `regex=`.
1. Use any regex to filter all available metrics by name.

In the response, we provide the name, type, catalog of all metrics. Here is the response for my local test
```graphql
{
  listMetrics(regex: "service.*") {
  	name,
    type,
    catalog
  }
}
```

```graphql
{
  "data": {
    "listMetrics": [
      {
        "name": "service_cpm",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE"
      },
      {
        "name": "service_instance_relation_server_resp_time",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_INSTANCE_RELATION"
      },
      {
        "name": "service_relation_server_percentile",
        "type": "LABELED_VALUE",
        "catalog": "SERVICE_RELATION"
      },
      {
        "name": "service_instance_relation_client_resp_time",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_INSTANCE_RELATION"
      },
      {
        "name": "service_apdex",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE"
      },
      {
        "name": "service_instance_relation_client_percentile",
        "type": "LABELED_VALUE",
        "catalog": "SERVICE_INSTANCE_RELATION"
      },
      {
        "name": "service_instance_relation_client_cpm",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_INSTANCE_RELATION"
      },
      {
        "name": "service_instance_relation_server_cpm",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_INSTANCE_RELATION"
      },
      {
        "name": "service_instance_cpm",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_INSTANCE"
      },
      {
        "name": "service_percentile",
        "type": "LABELED_VALUE",
        "catalog": "SERVICE"
      },
      {
        "name": "service_relation_client_percentile",
        "type": "LABELED_VALUE",
        "catalog": "SERVICE_RELATION"
      },
      {
        "name": "service_sla",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE"
      },
      {
        "name": "service_relation_client_cpm",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_RELATION"
      },
      {
        "name": "service_relation_server_resp_time",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_RELATION"
      },
      {
        "name": "service_instance_resp_time",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_INSTANCE"
      },
      {
        "name": "service_instance_sla",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_INSTANCE"
      },
      {
        "name": "service_resp_time",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE"
      },
      {
        "name": "service_relation_client_resp_time",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_RELATION"
      },
      {
        "name": "service_relation_server_call_sla",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_RELATION"
      },
      {
        "name": "service_instance_relation_server_percentile",
        "type": "LABELED_VALUE",
        "catalog": "SERVICE_INSTANCE_RELATION"
      },
      {
        "name": "service_relation_client_call_sla",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_RELATION"
      },
      {
        "name": "service_instance_relation_server_call_sla",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_INSTANCE_RELATION"
      },
      {
        "name": "service_relation_server_cpm",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_RELATION"
      },
      {
        "name": "service_instance_relation_client_call_sla",
        "type": "REGULAR_VALUE",
        "catalog": "SERVICE_INSTANCE_RELATION"
      }
    ]
  }
}
```
