### PR TITLE
Fix okhttp-3.x and async-http-client-2.x did not overwrite the old trace header.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Release Notes.
 
 #### Java Agent
 
+
 #### UI
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,6 @@ Release Notes.
 
 
 #### Java Agent
-* Fix okhttp-3.x and async-http-client-2.x did not overwrite the old trace header.
 
 #### UI
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Release Notes.
 
 
 #### Java Agent
-
+* Fix okhttp-3.x and async-http-client-2.x did not overwrite the old trace header.
 
 #### UI
 

--- a/apm-sniffer/apm-sdk-plugin/asynchttpclient-2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/asynchttpclient/v2/ExecuteInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/asynchttpclient-2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/asynchttpclient/v2/ExecuteInterceptor.java
@@ -65,7 +65,7 @@ public class ExecuteInterceptor implements InstanceMethodsAroundInterceptor {
         CarrierItem next = contextCarrier.items();
         while (next.hasNext()) {
             next = next.next();
-            headers.add(next.getHeadKey(), next.getHeadValue());
+            headers.set(next.getHeadKey(), next.getHeadValue());
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/okhttp/v3/AsyncCallInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/okhttp/v3/AsyncCallInterceptor.java
@@ -78,7 +78,7 @@ public class AsyncCallInterceptor implements InstanceConstructorInterceptor, Ins
         CarrierItem next = contextCarrier.items();
         while (next.hasNext()) {
             next = next.next();
-            headerBuilder.add(next.getHeadKey(), next.getHeadValue());
+            headerBuilder.set(next.getHeadKey(), next.getHeadValue());
         }
         headersField.set(request, headerBuilder.build());
 

--- a/changes/changes-8.3.0.md
+++ b/changes/changes-8.3.0.md
@@ -23,6 +23,7 @@ Release Notes.
 * Fix the default ignore mechanism isn't accurate enough bug.
 * Add the plugin for spring-kafka 1.3.x.
 * Add the plugin for Apache CXF 3.x.
+* Fix okhttp-3.x and async-http-client-2.x did not overwrite the old trace header.
 
 #### OAP-Backend
 * Add the `@SuperDataset` annotation for BrowserErrorLog.


### PR DESCRIPTION
### Fix okhttp-3.x and async-http-client-2.x did not overwrite the old trace header.
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly about why the bug exists and how to fix it.

Fix okhttp-3.x and async-http-client-2.x did not overwrite the old trace header, May cause data confusion in some scenarios such as gateway