### PR TITLE
update `Supported-list.md`, support Aliyun ONS 1.x.

### DIFF
--- a/docs/en/setup/service-agent/java-agent/Supported-list.md
+++ b/docs/en/setup/service-agent/java-agent/Supported-list.md
@@ -62,6 +62,7 @@ metrics based on the tracing data.
   * [ActiveMQ](https://github.com/apache/activemq) 5.10.0 -> 5.15.4
   * [RabbitMQ](https://www.rabbitmq.com/) 5.x
   * [Pulsar](http://pulsar.apache.org) 2.2.x -> 2.4.x
+  * [Aliyun ONS](https://help.aliyun.com/document_detail/114448.html) 1.x (Optional¹)
 * NoSQL
   * Redis
     * [Jedis](https://github.com/xetorthio/jedis) 2.x


### PR DESCRIPTION
### Add an agent plugin to support Aliyun ONS 1.x.
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)

Aliyun ONS does not have an open source code repository. Because of LICENSE issues, it is placed in SkyAPM/java-plugin-extensions, this plugin component and icon can be shared with rocketmq.
Support Aliyun ONS 1.x, see https://github.com/SkyAPM/java-plugin-extensions