### PR TITLE
Support Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 
 #### OAP-Backend
 * Make meter receiver support MAL.
+* Support Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters.
 
 #### UI
 * Fix un-removed tags in trace query.

--- a/docs/en/setup/backend/backend-fetcher.md
+++ b/docs/en/setup/backend/backend-fetcher.md
@@ -123,7 +123,7 @@ kafka-fetcher:
       ...
 ```
 
-When useing Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters, you can set the source Kafka Cluster alias(MM2SourceAlias) and separator(MM2SourceSeparator) according to your Kafka MirrorMaker config:
+When use Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters, you can set the source Kafka Cluster alias(MM2SourceAlias) and separator(MM2SourceSeparator) according to your Kafka MirrorMaker config.
 ```yaml
 kafka-fetcher:
   selector: ${SW_KAFKA_FETCHER:default}
@@ -140,4 +140,3 @@ kafka-fetcher:
       enable.auto.commit: true
       ...
 ```
-

--- a/docs/en/setup/backend/backend-fetcher.md
+++ b/docs/en/setup/backend/backend-fetcher.md
@@ -123,7 +123,7 @@ kafka-fetcher:
       ...
 ```
 
-When use Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters, you can set the source Kafka Cluster alias(MM2SourceAlias) and separator(MM2SourceSeparator) according to your Kafka MirrorMaker config.
+When use Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters, you can set the source Kafka Cluster alias(mm2SourceAlias) and separator(mm2SourceSeparator) according to your Kafka MirrorMaker config.
 ```yaml
 kafka-fetcher:
   selector: ${SW_KAFKA_FETCHER:default}
@@ -134,8 +134,8 @@ kafka-fetcher:
     enableMeterSystem: ${SW_KAFKA_FETCHER_ENABLE_METER_SYSTEM:false}
     isSharding: ${SW_KAFKA_FETCHER_IS_SHARDING:true}
     consumePartitions: ${SW_KAFKA_FETCHER_CONSUME_PARTITIONS:1,3,5}
-    MM2SourceAlias: ${SW_KAFKA_MM2_SOURCE_ALIAS:""}
-    MM2SourceSeparator: ${SW_KAFKA_MM2_SOURCE_SEPARATOR:""}
+    mm2SourceAlias: ${SW_KAFKA_MM2_SOURCE_ALIAS:""}
+    mm2SourceSeparator: ${SW_KAFKA_MM2_SOURCE_SEPARATOR:""}
     kafkaConsumerConfig:
       enable.auto.commit: true
       ...

--- a/docs/en/setup/backend/backend-fetcher.md
+++ b/docs/en/setup/backend/backend-fetcher.md
@@ -123,7 +123,7 @@ kafka-fetcher:
       ...
 ```
 
-When use Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters, you can set the source Kafka Cluster alias(mm2SourceAlias) and separator(mm2SourceSeparator) according to your Kafka MirrorMaker config.
+When use Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters, you can set the source Kafka Cluster alias(mm2SourceAlias) and separator(mm2SourceSeparator) according to your Kafka MirrorMaker [config](https://github.com/apache/kafka/tree/trunk/connect/mirror#remote-topics).
 ```yaml
 kafka-fetcher:
   selector: ${SW_KAFKA_FETCHER:default}

--- a/docs/en/setup/backend/backend-fetcher.md
+++ b/docs/en/setup/backend/backend-fetcher.md
@@ -122,3 +122,22 @@ kafka-fetcher:
       enable.auto.commit: true
       ...
 ```
+
+When useing Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters, you can set the source Kafka Cluster alias(MM2SourceAlias) and separator(MM2SourceSeparator) according to your Kafka MirrorMaker config:
+```yaml
+kafka-fetcher:
+  selector: ${SW_KAFKA_FETCHER:default}
+  default:
+    bootstrapServers: ${SW_KAFKA_FETCHER_SERVERS:localhost:9092}
+    partitions: ${SW_KAFKA_FETCHER_PARTITIONS:3}
+    replicationFactor: ${SW_KAFKA_FETCHER_PARTITIONS_FACTOR:2}
+    enableMeterSystem: ${SW_KAFKA_FETCHER_ENABLE_METER_SYSTEM:false}
+    isSharding: ${SW_KAFKA_FETCHER_IS_SHARDING:true}
+    consumePartitions: ${SW_KAFKA_FETCHER_CONSUME_PARTITIONS:1,3,5}
+    MM2SourceAlias: ${SW_KAFKA_MM2_SOURCE_ALIAS:""}
+    MM2SourceSeparator: ${SW_KAFKA_MM2_SOURCE_SEPARATOR:""}
+    kafkaConsumerConfig:
+      enable.auto.commit: true
+      ...
+```
+

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/module/KafkaFetcherConfig.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/module/KafkaFetcherConfig.java
@@ -85,8 +85,8 @@ public class KafkaFetcherConfig extends ModuleConfig {
 
     private int kafkaHandlerThreadPoolQueueSize;
     
-    private String MM2SourceAlias = "";
+    private String mm2SourceAlias = "";
 
-    private String MM2SourceSeparator = "";
+    private String mm2SourceSeparator = "";
     
 }

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/module/KafkaFetcherConfig.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/module/KafkaFetcherConfig.java
@@ -84,5 +84,29 @@ public class KafkaFetcherConfig extends ModuleConfig {
     private int kafkaHandlerThreadPoolSize;
 
     private int kafkaHandlerThreadPoolQueueSize;
+    
+    private String MM2SourceAlias = "";
 
+    private String MM2SourceSeparator = "";
+    
+    public String getTopicNameOfMetrics() {
+        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfMetrics;
+    }
+
+    public String getTopicNameOfProfiling() {
+        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfProfiling;
+    }
+
+    public String getTopicNameOfTracingSegments() {
+        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfTracingSegments;
+    }
+
+    public String getTopicNameOfManagements() {
+        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfManagements;
+    }
+
+    public String getTopicNameOfMeters() {
+        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfMeters;
+    }
+    
 }

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/module/KafkaFetcherConfig.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/module/KafkaFetcherConfig.java
@@ -89,24 +89,4 @@ public class KafkaFetcherConfig extends ModuleConfig {
 
     private String MM2SourceSeparator = "";
     
-    public String getTopicNameOfMetrics() {
-        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfMetrics;
-    }
-
-    public String getTopicNameOfProfiling() {
-        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfProfiling;
-    }
-
-    public String getTopicNameOfTracingSegments() {
-        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfTracingSegments;
-    }
-
-    public String getTopicNameOfManagements() {
-        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfManagements;
-    }
-
-    public String getTopicNameOfMeters() {
-        return this.getMM2SourceAlias() + this.getMM2SourceSeparator() + this.topicNameOfMeters;
-    }
-    
 }

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/JVMMetricsHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/JVMMetricsHandler.java
@@ -73,7 +73,7 @@ public class JVMMetricsHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfMetrics();
+        return config.getMm2SourceAlias() + config.getMm2SourceSeparator() + config.getTopicNameOfMetrics();
     }
 
     @Override

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/JVMMetricsHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/JVMMetricsHandler.java
@@ -73,7 +73,7 @@ public class JVMMetricsHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getTopicNameOfMetrics();
+        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfMetrics();
     }
 
     @Override

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/MeterServiceHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/MeterServiceHandler.java
@@ -57,7 +57,7 @@ public class MeterServiceHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfMeters();
+        return config.getMm2SourceAlias() + config.getMm2SourceSeparator() + config.getTopicNameOfMeters();
     }
 
     @Override

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/MeterServiceHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/MeterServiceHandler.java
@@ -57,7 +57,7 @@ public class MeterServiceHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getTopicNameOfMeters();
+        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfMeters();
     }
 
     @Override

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/ProfileTaskHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/ProfileTaskHandler.java
@@ -68,7 +68,7 @@ public class ProfileTaskHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfProfiling();
+        return config.getMm2SourceAlias() + config.getMm2SourceSeparator() + config.getTopicNameOfProfiling();
     }
 
     @Override

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/ProfileTaskHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/ProfileTaskHandler.java
@@ -68,7 +68,7 @@ public class ProfileTaskHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getTopicNameOfProfiling();
+        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfProfiling();
     }
 
     @Override

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/ServiceManagementHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/ServiceManagementHandler.java
@@ -124,7 +124,7 @@ public class ServiceManagementHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getTopicNameOfManagements();
+        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfManagements();
     }
 
     @Override

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/ServiceManagementHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/ServiceManagementHandler.java
@@ -124,7 +124,7 @@ public class ServiceManagementHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfManagements();
+        return config.getMm2SourceAlias() + config.getMm2SourceSeparator() + config.getTopicNameOfManagements();
     }
 
     @Override

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/TraceSegmentHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/TraceSegmentHandler.java
@@ -96,7 +96,7 @@ public class TraceSegmentHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfTracingSegments();
+        return config.getMm2SourceAlias() + config.getMm2SourceSeparator() + config.getTopicNameOfTracingSegments();
     }
 
     @Override

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/TraceSegmentHandler.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/handler/TraceSegmentHandler.java
@@ -96,7 +96,7 @@ public class TraceSegmentHandler implements KafkaHandler {
 
     @Override
     public String getTopic() {
-        return config.getTopicNameOfTracingSegments();
+        return config.getMM2SourceAlias() + config.getMM2SourceSeparator() + config.getTopicNameOfTracingSegments();
     }
 
     @Override


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that doesn't accord with this template
    may be closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly about why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->


### <Feature description>
- [x] Update the documentation to include this new feature.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

Kafka provides "MirrorMaker 2.0(MM2)" which leverages the Connect framework to replicate topics between Kafka clusters. This is realy helpful when handling large-scaled services/Multiple Data Centers/Edge Computing. 
When skywalking cluster deployed in a Data Center("DC1" for example) and the topics mirrored from other Data Centers will be renamed based on the aliases("DC2.skywalking-metrics etc."):
https://github.com/apache/kafka/tree/trunk/connect/mirror#remote-topics

Adding support to oap kafka module for the renamed topics, set the aliases via application.yml or environment variables. This feature need to set up an oap server for each mirrored Kafka cluster.