### PR TITLE
Fix jdk-http and okhttp-3.x plugin did not overwrite the old trace header.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Release Notes.
 * Chore: adapt `create_source_release.sh` to make it runnable on Linux.
 
 #### Java Agent
-
+* Fix jdk-http and okhttp-3.x plugin did not overwrite the old trace header.
 
 #### OAP-Backend
 * Make meter receiver support MAL.

--- a/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/okhttp/v3/RealCallInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/okhttp/v3/RealCallInterceptor.java
@@ -74,7 +74,7 @@ public class RealCallInterceptor implements InstanceMethodsAroundInterceptor, In
         CarrierItem next = contextCarrier.items();
         while (next.hasNext()) {
             next = next.next();
-            headerBuilder.add(next.getHeadKey(), next.getHeadValue());
+            headerBuilder.set(next.getHeadKey(), next.getHeadValue());
         }
         headersField.set(request, headerBuilder.build());
     }

--- a/apm-sniffer/bootstrap-plugins/jdk-http-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdk/http/HttpClientWriteRequestInterceptor.java
+++ b/apm-sniffer/bootstrap-plugins/jdk-http-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdk/http/HttpClientWriteRequestInterceptor.java
@@ -52,7 +52,7 @@ public class HttpClientWriteRequestInterceptor implements InstanceMethodsAroundI
         CarrierItem next = contextCarrier.items();
         while (next.hasNext()) {
             next = next.next();
-            headers.add(next.getHeadKey(), next.getHeadValue());
+            headers.set(next.getHeadKey(), next.getHeadValue());
         }
     }
 

--- a/test/plugin/scenarios/jdk-http-scenario/src/main/java/org/apache/skywalking/apm/testcase/jdkhttp/controller/CaseController.java
+++ b/test/plugin/scenarios/jdk-http-scenario/src/main/java/org/apache/skywalking/apm/testcase/jdkhttp/controller/CaseController.java
@@ -38,9 +38,11 @@ public class CaseController {
     @RequestMapping("/jdk-http-scenario")
     @ResponseBody
     public String testcase() throws IOException {
+        // Like gateway forward trace header.
         URL url = new URL("http://localhost:8080/jdk-http-scenario/case/receiveContext-0");
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.addRequestProperty("key", "value");
+        connection.addRequestProperty("sw8", "123456");
         int responseCode = connection.getResponseCode();
         return "Success:" + responseCode;
     }

--- a/test/plugin/scenarios/okhttp-scenario/src/main/java/test/apache/skywalking/testcase/okhttp/controller/CaseController.java
+++ b/test/plugin/scenarios/okhttp-scenario/src/main/java/test/apache/skywalking/testcase/okhttp/controller/CaseController.java
@@ -47,7 +47,9 @@ public class CaseController {
     @RequestMapping("/okhttp-case")
     @ResponseBody
     public String okHttpScenario() {
-        Request request = new Request.Builder().url("http://127.0.0.1:8080/okhttp-case/case/receiveContext-0").build();
+        // Like gateway forward trace header.
+        Request request = new Request.Builder().url("http://127.0.0.1:8080/okhttp-case/case/receiveContext-0")
+                                               .header("sw8", "123456").build();
 
         new OkHttpClient().newCall(request).enqueue(new Callback() {
             @Override
@@ -58,6 +60,7 @@ public class CaseController {
             @Override
             public void onResponse(Call call, Response response) throws IOException {
                 Request request = new Request.Builder().url("http://127.0.0.1:8080/okhttp-case/case/receiveContext-1")
+                                                       .header("sw8", "123456")
                                                        .build();
                 new OkHttpClient().newCall(request).execute();
             }


### PR DESCRIPTION
### Fix jdk-http and okhttp-3.x plugin did not overwrite the old trace header.
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly about why the bug exists and how to fix it.

Fix jdk-http and okhttp-3.x plugin did not overwrite the old trace header.