### PR TITLE
Fix MAL concurrent execution issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
 #### OAP-Backend
 * Make meter receiver support MAL.
 * Support Kafka MirrorMaker 2.0 to replicate topics between Kafka clusters.
+* Fix MAL concurrent execution issues
 
 #### UI
 * Fix un-removed tags in trace query.

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/ExpressionParsingContext.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/ExpressionParsingContext.java
@@ -42,6 +42,7 @@ public class ExpressionParsingContext implements Closeable {
     static ExpressionParsingContext create() {
         if (CACHE.get() == null) {
             CACHE.set(ExpressionParsingContext.builder()
+                                              .samples(Lists.newArrayList())
                                               .downsampling(DownsamplingType.AVG)
                                               .scopeLabels(Lists.newArrayList())
                                               .aggregationLabels(Lists.newArrayList()).build());
@@ -54,6 +55,8 @@ public class ExpressionParsingContext implements Closeable {
     }
 
     private final static ThreadLocal<ExpressionParsingContext> CACHE = new ThreadLocal<>();
+
+    List<String> samples;
 
     boolean isHistogram;
 

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/Result.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/Result.java
@@ -23,12 +23,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Result indicates the parsing result of expression.
  */
-@Slf4j
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 @ToString
@@ -42,7 +40,6 @@ public class Result {
      * @return failed result.
      */
     public static Result fail(final Throwable throwable) {
-        log.info("Expression fails: {}", throwable.getMessage());
         return new Result(false, true, throwable.getMessage(), SampleFamily.EMPTY);
     }
 
@@ -53,7 +50,6 @@ public class Result {
      * @return failed result.
      */
     public static Result fail(String message) {
-        log.info("Expression fails: {}", message);
         return new Result(false, false, message, SampleFamily.EMPTY);
     }
 
@@ -63,7 +59,6 @@ public class Result {
      * @return failed result.
      */
     public static Result fail() {
-        log.info("Expression fails");
         return new Result(false, false, null, SampleFamily.EMPTY);
     }
 
@@ -74,9 +69,6 @@ public class Result {
      * @return successful result.
      */
     public static Result success(SampleFamily sf) {
-        if (log.isDebugEnabled()) {
-            log.debug("Result is successful, sample family is {}", sf);
-        }
         return new Result(true, false, null, sf);
     }
 

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ExpressionParsingTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ExpressionParsingTest.java
@@ -65,6 +65,7 @@ public class ExpressionParsingTest {
                 "all",
                 "latest (foo - 1).tagEqual('bar', '1').sum(['tt']).irate().histogram().histogram_percentile([50,99]).service(['rr'])",
                 ExpressionParsingContext.builder()
+                                        .samples(Collections.singletonList("foo"))
                                         .scopeType(ScopeType.SERVICE)
                                         .scopeLabels(Collections.singletonList("rr"))
                                         .aggregationLabels(Collections.singletonList("tt"))


### PR DESCRIPTION

### Fix <bug description or the bug issue number or bug issue link>
- [x] Explain briefly why the bug exists and how to fix it.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

### Description

Expression objects are share in a single rule, being executed by otel receiver threads concurrently. `SampleFamility` map might be overridden unexpectedly. 

### How to fix

Introduce a ThreadLocal repository to avoid to share this map, ensuring all of SampleFamilies could be accessed in the runtime of this expression.