### PR TITLE
[ISSUE 5541] Fix H2 in-memory database table missing issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Release Notes.
 * Fix potential gRPC connection leak(not closed) for the channels among OAP instances.
 * Filter OAP instances(unassigned in booting stage) of the empty IP in KubernetesCoordinator.
 * Add component ID for Python aiohttp plugin requester and server.
+* Fix H2 in-memory database table missing issues
 
 #### UI
 * Fix un-removed tags in trace query.

--- a/oap-server/server-bootstrap/src/main/resources/application.yml
+++ b/oap-server/server-bootstrap/src/main/resources/application.yml
@@ -154,7 +154,7 @@ storage:
     advanced: ${SW_STORAGE_ES_ADVANCED:""}
   h2:
     driver: ${SW_STORAGE_H2_DRIVER:org.h2.jdbcx.JdbcDataSource}
-    url: ${SW_STORAGE_H2_URL:jdbc:h2:mem:skywalking-oap-db}
+    url: ${SW_STORAGE_H2_URL:jdbc:h2:mem:skywalking-oap-db;DB_CLOSE_DELAY=-1}
     user: ${SW_STORAGE_H2_USER:sa}
     metadataQueryMaxSize: ${SW_STORAGE_H2_QUERY_MAX_SIZE:5000}
     maxSizeOfArrayColumn: ${SW_STORAGE_MAX_SIZE_OF_ARRAY_COLUMN:20}

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/H2StorageConfig.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/H2StorageConfig.java
@@ -26,7 +26,7 @@ import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 @Getter
 public class H2StorageConfig extends ModuleConfig {
     private String driver = "org.h2.jdbcx.JdbcDataSource";
-    private String url = "jdbc:h2:mem:skywalking-oap-db";
+    private String url = "jdbc:h2:mem:skywalking-oap-db;DB_CLOSE_DELAY=-1";
     private String user = "";
     private String password = "";
     private int metadataQueryMaxSize = 5000;


### PR DESCRIPTION
### Fix H2 in-memory database table missing issues
- [x] Explain briefly about why the bug exists and how to fix it.

   Just add ;DB_CLOSE_DELAY=-1 to the database URL for H2StorageConfig
   
   See the [In-Memory Databases](http://h2database.com/html/features.html#in_memory_databases) section of the Features page. To quote:
   > By default, closing the last connection to a database closes the database. For an in-memory database, this means the content is lost. To keep the database open, add ;DB_CLOSE_DELAY=-1 to the database URL. To keep the content of an in-memory database as long as the virtual machine is alive, use jdbc:h2:mem:test;DB_CLOSE_DELAY=-1.
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #5541 
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
