### PR TITLE
fix: Non-atomic operation on volatile field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ Release Notes.
 * Fix jdk-http and okhttp-3.x plugin did not overwrite the old trace header.
 * Support collecting logs of log4j, log4j2, and logback in the tracing context with a new `logger-plugin`.
 * Fix the unexpected RunningContext recreation in the Tomcat plugin.
-* Fix Non-atomic operation on volatile field in `SimpleRollingPartitioner` and `MultipleChannelsConsumer`
+* Fix Non-atomic operation on volatile field in `SimpleRollingPartitioner`
 
 #### OAP-Backend
 * Make meter receiver support MAL.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
 * Fix jdk-http and okhttp-3.x plugin did not overwrite the old trace header.
 * Support collecting logs of log4j, log4j2, and logback in the tracing context with a new `logger-plugin`.
 * Fix the unexpected RunningContext recreation in the Tomcat plugin.
+* Fix Non-atomic operation on volatile field in `SimpleRollingPartitioner` and `MultipleChannelsConsumer`
 
 #### OAP-Backend
 * Make meter receiver support MAL.

--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/MultipleChannelsConsumer.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/MultipleChannelsConsumer.java
@@ -20,6 +20,8 @@ package org.apache.skywalking.apm.commons.datacarrier.consumer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.skywalking.apm.commons.datacarrier.buffer.Channels;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.QueueBuffer;
 
@@ -30,13 +32,12 @@ import org.apache.skywalking.apm.commons.datacarrier.buffer.QueueBuffer;
 public class MultipleChannelsConsumer extends Thread {
     private volatile boolean running;
     private volatile ArrayList<Group> consumeTargets;
-    @SuppressWarnings("NonAtomicVolatileUpdate")
-    private volatile long size;
+    private final AtomicLong size = new AtomicLong();
     private final long consumeCycle;
 
     public MultipleChannelsConsumer(String threadName, long consumeCycle) {
         super(threadName);
-        this.consumeTargets = new ArrayList<Group>();
+        this.consumeTargets = new ArrayList<>();
         this.consumeCycle = consumeCycle;
     }
 
@@ -94,17 +95,14 @@ public class MultipleChannelsConsumer extends Thread {
     public void addNewTarget(Channels channels, IConsumer consumer) {
         Group group = new Group(channels, consumer);
         // Recreate the new list to avoid change list while the list is used in consuming.
-        ArrayList<Group> newList = new ArrayList<Group>();
-        for (Group target : consumeTargets) {
-            newList.add(target);
-        }
+        ArrayList<Group> newList = new ArrayList<>(consumeTargets);
         newList.add(group);
         consumeTargets = newList;
-        size += channels.size();
+        size.addAndGet(channels.size());
     }
 
     public long size() {
-        return size;
+        return size.get();
     }
 
     void shutdown() {

--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/MultipleChannelsConsumer.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/MultipleChannelsConsumer.java
@@ -20,8 +20,6 @@ package org.apache.skywalking.apm.commons.datacarrier.consumer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.skywalking.apm.commons.datacarrier.buffer.Channels;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.QueueBuffer;
 
@@ -32,12 +30,13 @@ import org.apache.skywalking.apm.commons.datacarrier.buffer.QueueBuffer;
 public class MultipleChannelsConsumer extends Thread {
     private volatile boolean running;
     private volatile ArrayList<Group> consumeTargets;
-    private final AtomicLong size = new AtomicLong();
+    @SuppressWarnings("NonAtomicVolatileUpdate")
+    private volatile long size;
     private final long consumeCycle;
 
     public MultipleChannelsConsumer(String threadName, long consumeCycle) {
         super(threadName);
-        this.consumeTargets = new ArrayList<>();
+        this.consumeTargets = new ArrayList<Group>();
         this.consumeCycle = consumeCycle;
     }
 
@@ -95,14 +94,17 @@ public class MultipleChannelsConsumer extends Thread {
     public void addNewTarget(Channels channels, IConsumer consumer) {
         Group group = new Group(channels, consumer);
         // Recreate the new list to avoid change list while the list is used in consuming.
-        ArrayList<Group> newList = new ArrayList<>(consumeTargets);
+        ArrayList<Group> newList = new ArrayList<Group>();
+        for (Group target : consumeTargets) {
+            newList.add(target);
+        }
         newList.add(group);
         consumeTargets = newList;
-        size.addAndGet(channels.size());
+        size += channels.size();
     }
 
     public long size() {
-        return size.get();
+        return size;
     }
 
     void shutdown() {

--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/partition/SimpleRollingPartitioner.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/partition/SimpleRollingPartitioner.java
@@ -18,16 +18,18 @@
 
 package org.apache.skywalking.apm.commons.datacarrier.partition;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * use normal int to rolling.
  */
 public class SimpleRollingPartitioner<T> implements IDataPartitioner<T> {
-    @SuppressWarnings("NonAtomicVolatileUpdate")
-    private volatile int i = 0;
+
+    private final AtomicInteger i = new AtomicInteger();
 
     @Override
     public int partition(int total, T data) {
-        return Math.abs(i++ % total);
+        return Math.abs(i.getAndIncrement() % total);
     }
 
     @Override

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/partition/SimpleRollingPartitionerTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/partition/SimpleRollingPartitionerTest.java
@@ -22,6 +22,12 @@ import org.apache.skywalking.apm.commons.datacarrier.SampleData;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class SimpleRollingPartitionerTest {
     @Test
     public void testPartition() {
@@ -29,5 +35,35 @@ public class SimpleRollingPartitionerTest {
         Assert.assertEquals(partitioner.partition(10, new SampleData()), 0);
         Assert.assertEquals(partitioner.partition(10, new SampleData()), 1);
         Assert.assertEquals(partitioner.partition(10, new SampleData()), 2);
+    }
+
+    @Test
+    public void testPartitionWithMultiThreads() throws InterruptedException {
+        final SimpleRollingPartitioner<SampleData> partitioner = new SimpleRollingPartitioner<>();
+        final SampleData sampleData = new SampleData();
+        final int nPartition = 5;
+        final int nTimesPerPartition = 2000;
+        final int nThread = 10;
+        final ConcurrentMap<Integer, AtomicInteger> result = new ConcurrentHashMap<>();
+        for (int i = 0; i < nPartition; i++) {
+            result.put(i, new AtomicInteger());
+        }
+
+        final CountDownLatch countDownLatch = new CountDownLatch(nThread);
+        for (int i = 0; i < nThread; i++) {
+            new Thread(() -> {
+                for (int j = 0; j < nTimesPerPartition; j++) {
+                    int partition = partitioner.partition(nPartition, sampleData);
+                    result.get(partition).incrementAndGet();
+                }
+                countDownLatch.countDown();
+            }).start();
+        }
+        countDownLatch.await();
+
+        final int exceptedCountPerPartition = nThread * nTimesPerPartition / nPartition;
+        for (Map.Entry<Integer, AtomicInteger> entry : result.entrySet()) {
+            Assert.assertEquals(exceptedCountPerPartition, entry.getValue().get());
+        }
     }
 }


### PR DESCRIPTION
### Fix Non-atomic operation on volatile field
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [x] Fix #5606, this PR didn't fix the bug.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

Recently I dive into SkyWalking sources code, and I find some bugs in the `DataCarrier` module.
It runs with something wrong although they won't affect the main feature. 

IntelliJ IDEA shows the warning as follow:
> Inspection info: Reports any non-atomic operations on volatile fields. Non-atomic operations on volatile fields are operations where the field is read and the value is used to update the field. It is possible for the value of the field to change between the read and the write, possibly invalidating the operation. The non-atomic operation can be avoided by surrounding it with a synchronized block or by making use of one of the classes from the java.util.concurrent.atomic package.