### PR TITLE
ArrayBlockingQueueBuffer del IF_POSSIBLE strategy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Release Notes.
 * Fix thrift plugin trace link broken when intermediate service does not mount agent
 * Fix thrift plugin collects wrong args when the method without parameter.
 * Fix DataCarrier's `org.apache.skywalking.apm.commons.datacarrier.buffer.Buffer` implementation isn't activated in `IF_POSSIBLE` mode.
+* Fix ArrayBlockingQueueBuffer's useless `IF_POSSIBLE` mode list
 
 #### OAP-Backend
 * Make meter receiver support MAL.

--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/buffer/ArrayBlockingQueueBuffer.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/buffer/ArrayBlockingQueueBuffer.java
@@ -40,16 +40,12 @@ public class ArrayBlockingQueueBuffer<T> implements QueueBuffer<T> {
 
     @Override
     public boolean save(T data) {
-        switch (strategy) {
-            case IF_POSSIBLE:
-                return queue.offer(data);
-            default:
-                try {
-                    queue.put(data);
-                } catch (InterruptedException e) {
-                    // Ignore the error
-                    return false;
-                }
+        //only BufferStrategy.BLOCKING
+        try {
+            queue.put(data);
+        } catch (InterruptedException e) {
+            // Ignore the error
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
Dear skywalking team and @wu-sheng 
This pull request has relation with the issue. #6045.
And what the pull request I do is:
1. Remove the useless `IF_POSSIBLE` clause in ArrayBlockingQueueBuffer, as the strategy won't show up.
2. Update the [CHANGES log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
