### PR TITLE
Fix the uuid field in GRPCConfigWatcherRegister is not updated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Release Notes.
 * Add JavaScript component ID.
 * Fix CVE of UninstrumentedGateways in Dynamic Configuration activation.
 * Improve query performance in storage-influxdb-plugin.
+* Fix the uuid field in GRPCConfigWatcherRegister is not updated.
 
 #### UI
 * Fix un-removed tags in trace query.

--- a/oap-server/server-configuration/grpc-configuration-sync/src/main/java/org/apache/skywalking/oap/server/configuration/grpc/GRPCConfigWatcherRegister.java
+++ b/oap-server/server-configuration/grpc-configuration-sync/src/main/java/org/apache/skywalking/oap/server/configuration/grpc/GRPCConfigWatcherRegister.java
@@ -67,6 +67,7 @@ public class GRPCConfigWatcherRegister extends ConfigWatcherRegister {
                     table.add(new ConfigTable.ConfigItem(name, config.getValue()));
                 }
             });
+            this.uuid = responseUuid;
         } catch (Exception e) {
             LOGGER.error("Remote config center [" + settings + "] is not available.", e);
         }


### PR DESCRIPTION

### Fix the uuid field in GRPCConfigWatcherRegister is not updated.
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

The uuid field is not set, and is the same value every time request, modified to update uuid after each request is completed.