### PR TITLE
added an optional plugin which control sampling by specifying a "percentage" instead of "agent.sample_n_per_3_secs"

### DIFF
--- a/apm-sniffer/optional-plugins/percentage-sampling-plugin/README.md
+++ b/apm-sniffer/optional-plugins/percentage-sampling-plugin/README.md
@@ -1,0 +1,12 @@
+# Overview
+
+This plugin adds another sampling mechanism which determines if it should "sample"
+according to a specified rate parameter instead of the original `agent.sample_n_per_3_secs`.
+
+# Usage
+
+1. To enable this plugin, drop the apm-percentage-sampling-plugin-<version>.jar into plugins folder
+2. Add a config to agentArgs using key `plugin.sampling.sample_rate` to sample n out of 10000.
+For example `plugin.sampling.sample_rate = 100` means 1% (100 out of 10000). Do note that:
+    - because PRNG is involved, the actual result will not be precisely the specified amount.
+    - just like other plugins, config can be given using system properties and environment variables.

--- a/apm-sniffer/optional-plugins/percentage-sampling-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/percentage-sampling-plugin/pom.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>optional-plugins</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>8.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-percentage-sampling-plugin</artifactId>
+    <name>percentage-sampling-plugin</name>
+    <packaging>jar</packaging>
+</project>

--- a/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/main/java/org/apache/skywalking/apm/plugin/sampling/percentage/PercentageSamplingPluginConfig.java
+++ b/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/main/java/org/apache/skywalking/apm/plugin/sampling/percentage/PercentageSamplingPluginConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.sampling.percentage;
+
+import org.apache.skywalking.apm.agent.core.boot.PluginConfig;
+
+public class PercentageSamplingPluginConfig {
+    public static class Plugin {
+        @PluginConfig(root = PercentageSamplingPluginConfig.class)
+        public static class Sampling {
+            public static int SAMPLE_RATE = -1;
+        }
+    }
+
+}

--- a/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/main/java/org/apache/skywalking/apm/plugin/sampling/percentage/PercentageSamplingService.java
+++ b/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/main/java/org/apache/skywalking/apm/plugin/sampling/percentage/PercentageSamplingService.java
@@ -64,6 +64,7 @@ public class PercentageSamplingService extends SamplingService {
      * @param operationName The first operation name of the new tracing context.
      * @return true, if sampling mechanism is on
      */
+    @Override
     public boolean trySampling(String operationName) {
         if (on) {
             return ThreadLocalRandom.current().nextInt(0, MAX_N) < DFT_SAMPLING_RATE;
@@ -75,6 +76,7 @@ public class PercentageSamplingService extends SamplingService {
      * Increase the sampling factor by force, to avoid sampling too many traces. If many distributed traces require
      * sampled, the trace beginning at local, has less chance to be sampled.
      */
+    @Override
     public void forceSampled() {
     }
 }

--- a/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/main/java/org/apache/skywalking/apm/plugin/sampling/percentage/PercentageSamplingService.java
+++ b/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/main/java/org/apache/skywalking/apm/plugin/sampling/percentage/PercentageSamplingService.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.sampling.percentage;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.skywalking.apm.agent.core.boot.OverrideImplementor;
+import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+import org.apache.skywalking.apm.agent.core.sampling.SamplingService;
+
+/**
+ * The <code>PercentageSamplingService</code> take charge of how to sample the {@link TraceSegment}. This has the same
+ * functionality as core SamplingService but in a percentage way.
+ * <p>
+ */
+@OverrideImplementor(SamplingService.class)
+public class PercentageSamplingService extends SamplingService {
+    private static final ILog LOGGER = LogManager.getLogger(PercentageSamplingService.class);
+    private static final int MAX_N = 10000;
+    private volatile boolean on = false;
+    public static int DFT_SAMPLING_RATE = 0;
+
+    @Override
+    public void prepare() {
+    }
+
+    @Override
+    public void boot() {
+        LOGGER.info("percentage sampling service booted");
+        if (PercentageSamplingPluginConfig.Plugin.Sampling.SAMPLE_RATE >= 0) {
+            DFT_SAMPLING_RATE = PercentageSamplingPluginConfig.Plugin.Sampling.SAMPLE_RATE;
+            LOGGER.info("enabling percentage sampling with default sampling rate " + DFT_SAMPLING_RATE);
+            on = true;
+        }
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    /**
+     * @param operationName The first operation name of the new tracing context.
+     * @return true, if sampling mechanism is on
+     */
+    public boolean trySampling(String operationName) {
+        if (on) {
+            return ThreadLocalRandom.current().nextInt(0, MAX_N) < DFT_SAMPLING_RATE;
+        }
+        return true;
+    }
+
+    /**
+     * Increase the sampling factor by force, to avoid sampling too many traces. If many distributed traces require
+     * sampled, the trace beginning at local, has less chance to be sampled.
+     */
+    public void forceSampled() {
+    }
+}
+

--- a/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/main/resources/META-INF/services/org.apache.skywalking.apm.agent.core.boot.BootService
+++ b/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/main/resources/META-INF/services/org.apache.skywalking.apm.agent.core.boot.BootService
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+org.apache.skywalking.apm.plugin.sampling.percentage.PercentageSamplingService

--- a/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/test/java/org/apache/skywalking/apm/plugin/sampling/percentage/PercentageSamplingTest.java
+++ b/apm-sniffer/optional-plugins/percentage-sampling-plugin/src/test/java/org/apache/skywalking/apm/plugin/sampling/percentage/PercentageSamplingTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.sampling.percentage;
+
+import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
+import org.apache.skywalking.apm.agent.core.sampling.SamplingService;
+import org.apache.skywalking.apm.agent.test.tools.AgentServiceRule;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PercentageSamplingTest {
+
+    @Rule
+    public AgentServiceRule serviceRule = new AgentServiceRule();
+
+    @Test
+    public void testServiceOverrideFromPlugin() {
+        SamplingService service = ServiceManager.INSTANCE.findService(SamplingService.class);
+        Assert.assertEquals(PercentageSamplingService.class, service.getClass());
+    }
+
+    @Test
+    public void testDefaultSamplingRate() {
+        // kick start PercentageSamplingService
+        PercentageSamplingPluginConfig.Plugin.Sampling.SAMPLE_RATE = 0;
+
+        SamplingService service = ServiceManager.INSTANCE.findService(SamplingService.class);
+        service.boot();
+
+        PercentageSamplingService.DFT_SAMPLING_RATE = 0;
+        int sampleCnt = 0;
+        for (int i = 0; i < 10; i++) {
+            if (service.trySampling("whatever")) {
+                sampleCnt++;
+            }
+        }
+        Assert.assertEquals(0, sampleCnt);
+        PercentageSamplingService.DFT_SAMPLING_RATE = 10000;
+        for (int i = 0; i < 10; i++) {
+            if (service.trySampling("whatever")) {
+                sampleCnt++;
+            }
+        }
+        Assert.assertEquals(10, sampleCnt);
+    }
+}

--- a/apm-sniffer/optional-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/pom.xml
@@ -50,6 +50,7 @@
         <module>kotlin-coroutine-plugin</module>
         <module>quartz-scheduler-2.x-plugin</module>
         <module>logger-plugin</module>
+        <module>percentage-sampling-plugin</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
This trivial plugin provides a `plugin.sampling.sample_rate` config to control sampling rate (n out of 10000). It overrides default `SamplingService`. Our team is using it to work around what had been discussed in #5997 and thought this might be useful to some others.

### Add an agent plugin to support <framework name>
- [x] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->



- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #5997.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
