### PR TITLE
Fix bug that the same sample name in one MAL expression caused `IllegalArgumentException` in `Analyzer.analyse`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,7 @@ Release Notes.
 * Fix bug in `parseInternalErrorCode` where some error codes are never reached.
 * OAL supports multiple values when as numeric
 * Add node information from the Openensus proto to the labels of the samples, to support the identification of the source of the Metric data.
+* Fix bug that the same sample name in one MAL expression caused `IllegalArgumentException` in `Analyzer.analyse`.
 
 #### UI
 * Fix un-removed tags in trace query.

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/Expression.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/Expression.java
@@ -95,7 +95,11 @@ public class Expression {
         expression.setDelegate(new GroovyObjectSupport() {
 
             public SampleFamily propertyMissing(String metricName) {
-                ExpressionParsingContext.get().ifPresent(ctx -> ctx.samples.add(metricName));
+                ExpressionParsingContext.get().ifPresent(ctx -> {
+                    if (!ctx.samples.contains(metricName)) {
+                        ctx.samples.add(metricName);
+                    }
+                });
                 ImmutableMap<String, SampleFamily> sampleFamilies = propertyRepository.get();
                 if (sampleFamilies == null) {
                     return SampleFamily.EMPTY;

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ArithmeticTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ArithmeticTest.java
@@ -239,6 +239,20 @@ public class ArithmeticTest {
                 false,
             },
             {
+                "sameSampleFamily-minus-sameSampleFamily",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1" , "service", "service1")).value(100).build(),
+                    Sample.builder().labels(of("idc", "t2" , "service", "service1")).value(30).build(),
+                    Sample.builder().labels(of("idc", "t3" , "service", "service1")).value(40).build(),
+                    Sample.builder().labels(of("region", "us" , "service", "service1")).value(80).build()
+                ).build()),
+                "http_success_request.sum(['service']) - http_success_request.sum(['service'])",
+                Result.success(SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("service", "service1")).value(0).build()
+                ).build()),
+                false,
+                },
+            {
                 "empty-multiple-empty",
                 of("http_success_request", SampleFamily.EMPTY,
                     "http_error_request", SampleFamily.EMPTY),

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ExpressionParsingTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ExpressionParsingTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.meter.analyzer.dsl;
 
+import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.core.analysis.meter.ScopeType;
 import org.junit.Test;
@@ -74,6 +75,18 @@ public class ExpressionParsingTest {
                                         .percentiles(new int[]{50, 99}).build(),
                 false,
             },
+            {
+                "sameSamples",
+                "(node_cpu_seconds_total.sum(['node_identifier_host_name']) - node_cpu_seconds_total.tagEqual('mode', 'idle').sum(['node_identifier_host_name'])).service(['node_identifier_host_name']) ",
+                ExpressionParsingContext.builder()
+                                        .samples(Collections.singletonList("node_cpu_seconds_total"))
+                                        .scopeType(ScopeType.SERVICE)
+                                        .scopeLabels(Collections.singletonList("node_identifier_host_name"))
+                                        .aggregationLabels(Lists.newArrayList("node_identifier_host_name" , "node_identifier_host_name"))
+                                        .downsampling(DownsamplingType.AVG)
+                                        .isHistogram(false).build(),
+                false,
+                },
         });
     }
 


### PR DESCRIPTION


<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->


### Fix <Fix bug that the same sample name in one MAL expression caused `IllegalArgumentException` in `Analyzer.analyse`>
- [X] Add a unit test to verify that the fix works.
- [X] Explain briefly why the bug exists and how to fix it.


<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

### Bug scene:
When I used MAL expression in `yaml` like:
<pre>
exp: node_cpu_seconds_total.sum(['node_identifier_host_name']) - node_cpu_seconds_total.tagEqual('mode', 'idle').sum(['node_identifier_host_name'])
</pre>
Then caused `IllegalArgumentException` in `Analyzer.analyse`.
 Because there 2 same sample name in the list of `ExpressionParsingContext.samples`:
<pre>
[0]'node_cpu_seconds_total' 
[1]'node_cpu_seconds_total'
</pre>
When in `Analyzer.analyse` try to buid `ImmutableMap` caused `IllegalArgumentException`:
<pre>ImmutableMap<String, SampleFamily> input = samples.stream().map(s -> Tuple.of(s, sampleFamilies.get(s)))
            .filter(t -> t._2 != null).collect(ImmutableMap.toImmutableMap(t -> t._1, t -> t._2));</pre>
### How to fix:
Add codes in `Expression.empower`, add the metricName to `ExpressionParsingContext.samples` only if it doesn't contained.