### PR TITLE
Update GRPCLogAppenderActivation.java

### DIFF
--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/log/log4j/v1/x/log/GRPCLogAppenderActivation.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/log/log4j/v1/x/log/GRPCLogAppenderActivation.java
@@ -36,7 +36,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class GRPCLogAppenderActivation extends ClassInstanceMethodsEnhancePluginDefine {
 
     public static final String INTERCEPT_CLASS =
-            "org.apache.skywalking.apm.toolkit.activation.log.logback.v1.x.log.GRPCLogAppenderInterceptor";
+            "org.apache.skywalking.apm.toolkit.activation.log.log4j.v1.x.log.GRPCLogAppenderInterceptor";
     public static final String ENHANCE_CLASS =
             "org.apache.skywalking.apm.toolkit.log.log4j.v1.x.log.GRPCLogClientAppender";
     public static final String ENHANCE_METHOD = "append";


### PR DESCRIPTION
### Fix

Logback is mentioned in the log4j 1.x activation file. Renamed to log4j.

- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
