### PR TITLE
chore: fix occasional build failure on Mac

### DIFF
--- a/oap-server/server-bootstrap/pom.xml
+++ b/oap-server/server-bootstrap/pom.xml
@@ -255,9 +255,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
                     <excludes>
                         <exclude>application.yml</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,9 @@
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin.version}</version>
+                    <configuration>
+                        <forceCreation>true</forceCreation>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
This patch tries to fix the build error on GHA, which recently occurs in a higher possibility.


```text
Error:  Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.1.1:shade (default) on project apm-agent-core: Error creating shaded jar: duplicate entry: META-INF/services/org.apache.skywalking.apm.dependencies.io.grpc.NameResolverProvider -> [Help 1]
```

Example https://github.com/apache/skywalking/runs/1801039068