### PR TITLE
Change the Apdex metric combine calculator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Release Notes.
 * Add some defensive codes for NPE and bump up Kubernetes client version to expose exception stack trace.
 * Update the `timestamp` field type for `LogQuery`.
 * Support Zabbix protocol to receive agent metrics.
+* Update the Apdex metric combine calculator.
 
 #### UI
 * Update selector scroller to show in all pages.

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetrics.java
@@ -68,10 +68,10 @@ public abstract class ApdexMetrics extends Metrics implements IntValueHolder {
         int t = DICT.lookup(name).intValue();
         int t4 = t * 4;
         totalNum++;
-        if (!status || value >= t4) {
+        if (!status || value > t4) {
             return;
         }
-        if (value >= t) {
+        if (value > t) {
             tNum++;
         } else {
             sNum++;

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetricsTest.java
@@ -47,7 +47,7 @@ public class ApdexMetricsTest {
         apdex = new ApdexMetricsImpl();
         apdex.combine(2000, "foo", true);
         apdex.calculate();
-        assertThat(apdex.getValue(), is(0));
+        assertThat(apdex.getValue(), is(5000));
 
         apdex = new ApdexMetricsImpl();
         apdex.combine(200, "foo", true);


### PR DESCRIPTION
### Update the Apdex metric combine calculator
- Follow the [Apdex document in The New Relic](https://docs.newrelic.com/docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction), I think we need to change the range between Apdex levels.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
