### PR TITLE
Change the Zabbix receiver is disabled by default

### DIFF
--- a/oap-server/server-bootstrap/src/main/resources/application.yml
+++ b/oap-server/server-bootstrap/src/main/resources/application.yml
@@ -267,7 +267,7 @@ receiver-profile:
   default:
 
 receiver-zabbix:
-  selector: ${SW_RECEIVER_ZABBIX:default}
+  selector: ${SW_RECEIVER_ZABBIX:-}
   default:
     port: ${SW_RECEIVER_ZABBIX_PORT:10051}
     host: ${SW_RECEIVER_ZABBIX_HOST:0.0.0.0}

--- a/test/e2e/e2e-test/docker/zabbix/docker-compose.yml
+++ b/test/e2e/e2e-test/docker/zabbix/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     extends:
       file: ../base-compose.yml
       service: oap
+    environment:
+      SW_RECEIVER_ZABBIX: default
     volumes:
       - ./agent.yaml:/skywalking/config/zabbix-rules/agent.yaml
 


### PR DESCRIPTION
### Change the Zabbix receiver is disabled by default
- [x] Fix conflict with OTEL plugin when creating the metrics