### PR TITLE
Enhance gRPC log appender to allow layout pattern

### DIFF
--- a/.github/actions/e2e-test/action.yml
+++ b/.github/actions/e2e-test/action.yml
@@ -59,7 +59,8 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Run E2E Test ${{ inputs.test_class }}"
-        ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false verify -Dit.test=${{ inputs.test_class }}
+        SW_VERSION=$(./mvnw -q -DforceStdout -N org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version)
+        ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false -Dsw.version=${SW_VERSION} verify -Dit.test=${{ inputs.test_class }}
         echo "::endgroup::"
     - name: Report Coverage
       shell: bash

--- a/.github/actions/e2e-test/action.yml
+++ b/.github/actions/e2e-test/action.yml
@@ -32,7 +32,7 @@ runs:
         sudo apt install -y -q xmlstarlet
         SW_VERSION=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 -t -v "/pom:project/pom:properties/pom:sw.version" test/e2e/pom.xml)
         if [[ "$(echo $(echo $SW_VERSION))" != "" ]]; then
-          echo "Please don't submitt the change of sw.version in test/e2e/pom.xml"
+          echo "Please don't submit the change of sw.version in test/e2e/pom.xml"
           exit 1
         fi
         echo "::endgroup::"

--- a/.github/actions/e2e-test/action.yml
+++ b/.github/actions/e2e-test/action.yml
@@ -25,6 +25,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check Unintended Changes
+      shell: bash
+      run: |
+        echo "::group::Check sw.version"
+        sudo apt install -y -q xmlstarlet
+        SW_VERSION=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 -t -v "/pom:project/pom:properties/pom:sw.version" test/e2e/pom.xml)
+        if [[ "$(echo $(echo $SW_VERSION))" != "" ]]; then
+          echo "Please don't submitt the change of sw.version in test/e2e/pom.xml"
+          exit 1
+        fi
+        echo "::endgroup::"
     - name: Check License
       shell: bash
       run: |

--- a/.github/actions/e2e-test/action.yml
+++ b/.github/actions/e2e-test/action.yml
@@ -53,6 +53,11 @@ runs:
     - name: Run E2E Test
       shell: bash
       run: |
+        echo "::group::Install SNAPSHOT apm-application-toolkit"
+        ./mvnw -DskipTests -N install
+        ./mvnw -f apm-application-toolkit -DskipTests -am install
+        echo "::endgroup::"
+
         echo "::group::Run E2E Test ${{ inputs.test_class }}"
         ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false verify -Dit.test=${{ inputs.test_class }}
         echo "::endgroup::"

--- a/.github/actions/plugins-test/action.yml
+++ b/.github/actions/plugins-test/action.yml
@@ -36,7 +36,7 @@ runs:
         sudo apt install -y -q xmlstarlet
         SW_VERSION=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 -t -v "/pom:project/pom:properties/pom:sw.version" test/e2e/pom.xml)
         if [[ "$(echo $(echo $SW_VERSION))" != "" ]]; then
-          echo "Please don't submitt the change of sw.version in test/e2e/pom.xml"
+          echo "Please don't submit the change of sw.version in test/e2e/pom.xml"
           exit 1
         fi
         echo "::endgroup::"

--- a/.github/actions/plugins-test/action.yml
+++ b/.github/actions/plugins-test/action.yml
@@ -29,6 +29,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check Unintended Changes
+      shell: bash
+      run: |
+        echo "::group::Check sw.version"
+        sudo apt install -y -q xmlstarlet
+        SW_VERSION=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 -t -v "/pom:project/pom:properties/pom:sw.version" test/e2e/pom.xml)
+        if [[ "$(echo $(echo $SW_VERSION))" != "" ]]; then
+          echo "Please don't submitt the change of sw.version in test/e2e/pom.xml"
+          exit 1
+        fi
+        echo "::endgroup::"
     - name: Check License
       shell: bash
       run: |

--- a/.github/workflows/e2e.istio.yaml
+++ b/.github/workflows/e2e.istio.yaml
@@ -132,6 +132,9 @@ jobs:
           export WEBAPP_HOST=127.0.0.1
           export WEBAPP_PORT=8080
 
+          ./mvnw -DskipTests -N install
+          ./mvnw -f apm-application-toolkit -DskipTests -am install
+
           ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false verify -Dit.test=org.apache.skywalking.e2e.mesh.ALSE2E
 
       - name: Logs
@@ -245,6 +248,9 @@ jobs:
           export GATEWAY_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
           export WEBAPP_HOST=127.0.0.1
           export WEBAPP_PORT=8080
+
+          ./mvnw -DskipTests -N install
+          ./mvnw -f apm-application-toolkit -DskipTests -am install
 
           ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false verify -Dit.test=org.apache.skywalking.e2e.mesh.MetricsServiceE2E
 

--- a/.github/workflows/e2e.istio.yaml
+++ b/.github/workflows/e2e.istio.yaml
@@ -54,7 +54,7 @@ jobs:
           sudo apt install -y -q xmlstarlet
           SW_VERSION=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 -t -v "/pom:project/pom:properties/pom:sw.version" test/e2e/pom.xml)
           if [[ "$(echo $(echo $SW_VERSION))" != "" ]]; then
-            echo "::error Please don't submitt the change of sw.version in test/e2e/pom.xml"
+            echo "::error Please don't submit the change of sw.version in test/e2e/pom.xml"
             exit 1
           fi
           echo "::endgroup::"
@@ -184,7 +184,7 @@ jobs:
           sudo apt install -y -q xmlstarlet
           SW_VERSION=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 -t -v "/pom:project/pom:properties/pom:sw.version" test/e2e/pom.xml)
           if [[ "$(echo $(echo $SW_VERSION))" != "" ]]; then
-            echo "Please don't submitt the change of sw.version in test/e2e/pom.xml"
+            echo "Please don't submit the change of sw.version in test/e2e/pom.xml"
             exit 1
           fi
           echo "::endgroup::"

--- a/.github/workflows/e2e.istio.yaml
+++ b/.github/workflows/e2e.istio.yaml
@@ -48,6 +48,17 @@ jobs:
         with:
           submodules: true
 
+      - name: Check Unintended Changes
+        run: |
+          echo "::group::Check sw.version"
+          sudo apt install -y -q xmlstarlet
+          SW_VERSION=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 -t -v "/pom:project/pom:properties/pom:sw.version" test/e2e/pom.xml)
+          if [[ "$(echo $(echo $SW_VERSION))" != "" ]]; then
+            echo "::error Please don't submitt the change of sw.version in test/e2e/pom.xml"
+            exit 1
+          fi
+          echo "::endgroup::"
+
       - name: Set Skip Env Var
         uses: ./.github/actions/skip
 
@@ -166,6 +177,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: Check Unintended Changes
+        run: |
+          echo "::group::Check sw.version"
+          sudo apt install -y -q xmlstarlet
+          SW_VERSION=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 -t -v "/pom:project/pom:properties/pom:sw.version" test/e2e/pom.xml)
+          if [[ "$(echo $(echo $SW_VERSION))" != "" ]]; then
+            echo "Please don't submitt the change of sw.version in test/e2e/pom.xml"
+            exit 1
+          fi
+          echo "::endgroup::"
 
       - name: Set Skip Env Var
         uses: ./.github/actions/skip

--- a/.github/workflows/e2e.istio.yaml
+++ b/.github/workflows/e2e.istio.yaml
@@ -132,10 +132,12 @@ jobs:
           export WEBAPP_HOST=127.0.0.1
           export WEBAPP_PORT=8080
 
+          export SW_VERSION=$(./mvnw -q -DforceStdout -N org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version)
+
           ./mvnw -DskipTests -N install
           ./mvnw -f apm-application-toolkit -DskipTests -am install
 
-          ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false verify -Dit.test=org.apache.skywalking.e2e.mesh.ALSE2E
+          ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false -Dsw.version=${SW_VERSION} verify -Dit.test=org.apache.skywalking.e2e.mesh.ALSE2E
 
       - name: Logs
         if: ${{ failure() }}
@@ -249,10 +251,12 @@ jobs:
           export WEBAPP_HOST=127.0.0.1
           export WEBAPP_PORT=8080
 
+          export SW_VERSION=$(./mvnw -q -DforceStdout -N org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version)
+
           ./mvnw -DskipTests -N install
           ./mvnw -f apm-application-toolkit -DskipTests -am install
 
-          ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false verify -Dit.test=org.apache.skywalking.e2e.mesh.MetricsServiceE2E
+          ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false -Dsw.version=${SW_VERSION} verify -Dit.test=org.apache.skywalking.e2e.mesh.MetricsServiceE2E
 
       - name: Logs
         if: ${{ failure() }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
 * Add net.bytebuddy.agent.builder.AgentBuilder.RedefinitionStrategy.Listener to show detail message when redefine errors occur.
 * Fix ClassCastException of log4j gRPC reporter.
 * Fix NPE when Kafka reporter activated.
+* Enhance gRPC log appender to allow layout pattern.
 
 #### OAP-Backend
 * Allow user-defined `JAVA_OPTS` in the startup script.

--- a/apm-application-toolkit/apm-toolkit-log4j-1.x/src/main/java/org/apache/skywalking/apm/toolkit/log/log4j/v1/x/log/GRPCLogClientAppender.java
+++ b/apm-application-toolkit/apm-toolkit-log4j-1.x/src/main/java/org/apache/skywalking/apm/toolkit/log/log4j/v1/x/log/GRPCLogClientAppender.java
@@ -19,9 +19,18 @@
 package org.apache.skywalking.apm.toolkit.log.log4j.v1.x.log;
 
 import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Layout;
 import org.apache.log4j.spi.LoggingEvent;
 
 public class GRPCLogClientAppender extends AppenderSkeleton {
+
+    public GRPCLogClientAppender() {
+    }
+
+    public GRPCLogClientAppender(Layout layout) {
+        this.setLayout(layout);
+    }
+
     @Override
     protected void append(LoggingEvent loggingEvent) {
 
@@ -34,6 +43,6 @@ public class GRPCLogClientAppender extends AppenderSkeleton {
 
     @Override
     public boolean requiresLayout() {
-        return false;
+        return true;
     }
 }

--- a/apm-application-toolkit/apm-toolkit-logback-1.x/src/main/java/org/apache/skywalking/apm/toolkit/log/logback/v1/x/log/GRPCLogClientAppender.java
+++ b/apm-application-toolkit/apm-toolkit-logback-1.x/src/main/java/org/apache/skywalking/apm/toolkit/log/logback/v1/x/log/GRPCLogClientAppender.java
@@ -18,12 +18,21 @@
 
 package org.apache.skywalking.apm.toolkit.log.logback.v1.x.log;
 
-import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.OutputStreamAppender;
+import java.io.IOException;
+import java.io.OutputStream;
 
-public class GRPCLogClientAppender<E> extends AppenderBase<E> {
-
-    @Override
-    protected void append(E eventObject) {
+public class GRPCLogClientAppender<E> extends OutputStreamAppender<E> {
+    public GRPCLogClientAppender() {
+        setOutputStream(new OutputStream() {
+            @Override
+            public void write(final int b) throws IOException {
+                // discarded
+            }
+        });
     }
 
+    @Override
+    protected void subAppend(final E event) {
+    }
 }

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/log/logback/v1/x/log/GRPCLogAppenderActivation.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/log/logback/v1/x/log/GRPCLogAppenderActivation.java
@@ -39,7 +39,7 @@ public class GRPCLogAppenderActivation extends ClassInstanceMethodsEnhancePlugin
             "org.apache.skywalking.apm.toolkit.activation.log.logback.v1.x.log.GRPCLogAppenderInterceptor";
     public static final String ENHANCE_CLASS =
             "org.apache.skywalking.apm.toolkit.log.logback.v1.x.log.GRPCLogClientAppender";
-    public static final String ENHANCE_METHOD = "append";
+    public static final String ENHANCE_METHOD = "subAppend";
 
     @Override
     protected ClassMatch enhanceClass() {

--- a/test/e2e/e2e-service-provider/pom.xml
+++ b/test/e2e/e2e-service-provider/pom.xml
@@ -34,7 +34,7 @@
     <artifactId>e2e-service-provider</artifactId>
 
     <properties>
-        <sw.version>8.4.0</sw.version>
+        <sw.version>8.5.0-SNAPSHOT</sw.version>
         <log4j.version>1.2.17</log4j.version>
         <log4j2.version>2.7</log4j2.version>
         <logback.version>1.2.3</logback.version>

--- a/test/e2e/e2e-service-provider/pom.xml
+++ b/test/e2e/e2e-service-provider/pom.xml
@@ -34,7 +34,6 @@
     <artifactId>e2e-service-provider</artifactId>
 
     <properties>
-        <sw.version>8.5.0-SNAPSHOT</sw.version>
         <log4j.version>1.2.17</log4j.version>
         <log4j2.version>2.7</log4j2.version>
         <logback.version>1.2.3</logback.version>

--- a/test/e2e/e2e-service-provider/src/main/resources/log4j.properties
+++ b/test/e2e/e2e-service-provider/src/main/resources/log4j.properties
@@ -14,3 +14,5 @@
 # limitations under the License.
 log4j.rootLogger=info,CustomAppender
 log4j.appender.CustomAppender=org.apache.skywalking.apm.toolkit.log.log4j.v1.x.log.GRPCLogClientAppender
+log4j.appender.CustomAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.CustomAppender.layout.ConversionPattern=[%t] %-5p %c %x - %m%n

--- a/test/e2e/e2e-service-provider/src/main/resources/log4j2.xml
+++ b/test/e2e/e2e-service-provider/src/main/resources/log4j2.xml
@@ -20,7 +20,9 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
-        <GRPCLogClientAppender name="grpc-log"/>
+        <GRPCLogClientAppender name="grpc-log">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </GRPCLogClientAppender>
     </Appenders>
 
 

--- a/test/e2e/e2e-service-provider/src/main/resources/logback.xml
+++ b/test/e2e/e2e-service-provider/src/main/resources/logback.xml
@@ -25,7 +25,13 @@
         </encoder>
     </appender>
 
-    <appender name="grpc-log" class="org.apache.skywalking.apm.toolkit.log.logback.v1.x.log.GRPCLogClientAppender"/>
+    <appender name="grpc-log" class="org.apache.skywalking.apm.toolkit.log.logback.v1.x.log.GRPCLogClientAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.apache.skywalking.apm.toolkit.log.logback.v1.x.mdc.TraceIdMDCPatternLogbackLayout">
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{tid}] [%thread] %-5level %logger{36} -%msg%n</Pattern>
+            </layout>
+        </encoder>
+    </appender>
 
     <root level="INFO">
         <appender-ref ref="grpc-log"/>

--- a/test/e2e/pom.xml
+++ b/test/e2e/pom.xml
@@ -44,7 +44,14 @@
     </modules>
 
     <properties>
-        <sw.version></sw.version> <!-- Please manually set the SkyWalking version here to build in the IDE (if you build from command line, just use ./mvnw -Dsw.version=xxx), but make sure not to check it into the code base / git -->
+        <sw.version>
+            <!--
+            Please manually set the SkyWalking version here to build in the IDE
+            (if you build from command line, just use ./mvnw -Dsw.version=x.y.z),
+            but make sure not to check it into the code base / git
+            -->
+            8.5.0-SNAPSHOT
+        </sw.version>
 
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/test/e2e/pom.xml
+++ b/test/e2e/pom.xml
@@ -44,7 +44,7 @@
     </modules>
 
     <properties>
-        <sw.version></sw.version> <!-- Please manually set the SkyWalking version here to build in the IDE, but make sure not to check it into the code base / git -->
+        <sw.version></sw.version> <!-- Please manually set the SkyWalking version here to build in the IDE (if you build from command line, just use ./mvnw -Dsw.version=xxx), but make sure not to check it into the code base / git -->
 
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/test/e2e/pom.xml
+++ b/test/e2e/pom.xml
@@ -50,7 +50,6 @@
             (if you build from command line, just use ./mvnw -Dsw.version=x.y.z),
             but make sure not to check it into the code base / git
             -->
-            8.5.0-SNAPSHOT
         </sw.version>
 
         <java.version>1.8</java.version>

--- a/test/e2e/pom.xml
+++ b/test/e2e/pom.xml
@@ -44,7 +44,7 @@
     </modules>
 
     <properties>
-        <sw.version>8.5.0-SNAPSHOT</sw.version>
+        <sw.version></sw.version> <!-- Please manually set the SkyWalking version here to build in the IDE, but make sure not to check it into the code base / git -->
 
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/test/e2e/pom.xml
+++ b/test/e2e/pom.xml
@@ -44,6 +44,8 @@
     </modules>
 
     <properties>
+        <sw.version>8.5.0-SNAPSHOT</sw.version>
+
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>. NO
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

The gRPC log appender only grasps the users' log message without supporting layout / encoder, which makes no sense in real use cases, this patch enhances the appender to support layout / encoder, the appenders now behave similar to the ConsolerAppender in the corresponding logging frameworks.

- logback

```xml
    <appender name="grpc-log" class="org.apache.skywalking.apm.toolkit.log.logback.v1.x.log.GRPCLogClientAppender">
        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
            <layout class="org.apache.skywalking.apm.toolkit.log.logback.v1.x.mdc.TraceIdMDCPatternLogbackLayout">
                <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{tid}] [%thread] %-5level %logger{36} -%msg%n</Pattern>
            </layout>
        </encoder>
    </appender>
```

- log4j2

```xml
        <GRPCLogClientAppender name="grpc-log">
            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
        </GRPCLogClientAppender>
```

- log4j

```properties
log4j.appender.CustomAppender=org.apache.skywalking.apm.toolkit.log.log4j.v1.x.log.GRPCLogClientAppender
log4j.appender.CustomAppender.layout=org.apache.log4j.PatternLayout
log4j.appender.CustomAppender.layout.ConversionPattern=[%t] %-5p %c %x - %m%n
```