### PR TITLE
Fix KafkaContextManagerExtendService boot error of kafka plugin.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 * Remove invalid mysql configuration in agent.config.
 * Add net.bytebuddy.agent.builder.AgentBuilder.RedefinitionStrategy.Listener to show detail message when redefine errors occur.
 * Fix ClassCastException of log4j gRPC reporter.
+* Fix KafkaContextManagerExtendService boot error of kafka plugin.
 
 #### OAP-Backend
 * Allow user-defined `JAVA_OPTS` in the startup script.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Release Notes.
 * Remove invalid mysql configuration in agent.config.
 * Add net.bytebuddy.agent.builder.AgentBuilder.RedefinitionStrategy.Listener to show detail message when redefine errors occur.
 * Fix ClassCastException of log4j gRPC reporter.
-* Fix KafkaContextManagerExtendService boot error of kafka plugin.
+* Fix NPE when Kafka reporter activated.
 
 #### OAP-Backend
 * Allow user-defined `JAVA_OPTS` in the startup script.

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/sampling/SamplingService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/sampling/SamplingService.java
@@ -53,11 +53,11 @@ public class SamplingService implements BootService {
 
     @Override
     public void prepare() {
-        samplingRateWatcher = new SamplingRateWatcher("agent.sample_n_per_3_secs", this);
     }
 
     @Override
     public void boot() {
+        samplingRateWatcher = new SamplingRateWatcher("agent.sample_n_per_3_secs", this);
         ServiceManager.INSTANCE.findService(ConfigurationDiscoveryService.class)
                                .registerAgentConfigChangeWatcher(samplingRateWatcher);
 

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/IgnoreSuffixPatternsWatcherTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/IgnoreSuffixPatternsWatcherTest.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.agent.core.context;
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
 import org.apache.skywalking.apm.agent.core.test.tools.AgentServiceRule;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,6 +38,11 @@ public class IgnoreSuffixPatternsWatcherTest {
     @Before
     public void setUp() {
         contextManagerExtendService = ServiceManager.INSTANCE.findService(ContextManagerExtendService.class);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        ServiceManager.INSTANCE.shutdown();
     }
 
     @Test

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/IgnoreSuffixPatternsWatcherTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/IgnoreSuffixPatternsWatcherTest.java
@@ -19,32 +19,31 @@
 package org.apache.skywalking.apm.agent.core.context;
 
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
-import org.apache.skywalking.apm.agent.core.test.tools.AgentServiceRule;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 public class IgnoreSuffixPatternsWatcherTest {
 
-    @Rule
-    public AgentServiceRule agentServiceRule = new AgentServiceRule();
-
     private ContextManagerExtendService contextManagerExtendService = new ContextManagerExtendService();
 
     @Before
     public void setUp() {
-        contextManagerExtendService.prepare();
+        Whitebox.setInternalState(
+            contextManagerExtendService
+            , "ignoreSuffixPatternsWatcher",
+            new IgnoreSuffixPatternsWatcher("agent.ignore_suffix", contextManagerExtendService)
+        );
     }
 
     @Test
     public void testConfigModifyEvent() {
         IgnoreSuffixPatternsWatcher ignoreSuffixPatternsWatcher = Whitebox.getInternalState(contextManagerExtendService
-                , "ignoreSuffixPatternsWatcher");
+            , "ignoreSuffixPatternsWatcher");
         ignoreSuffixPatternsWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
-                ".txt,.log",
-                AgentConfigChangeWatcher.EventType.MODIFY
+            ".txt,.log",
+            AgentConfigChangeWatcher.EventType.MODIFY
         ));
         Assert.assertEquals(".txt,.log", ignoreSuffixPatternsWatcher.getIgnoreSuffixPatterns());
         Assert.assertEquals("agent.ignore_suffix", ignoreSuffixPatternsWatcher.getPropertyKey());
@@ -53,10 +52,10 @@ public class IgnoreSuffixPatternsWatcherTest {
     @Test
     public void testConfigDeleteEvent() {
         IgnoreSuffixPatternsWatcher ignoreSuffixPatternsWatcher = Whitebox.getInternalState(contextManagerExtendService
-                , "ignoreSuffixPatternsWatcher");
+            , "ignoreSuffixPatternsWatcher");
         ignoreSuffixPatternsWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
-                null,
-                AgentConfigChangeWatcher.EventType.DELETE
+            null,
+            AgentConfigChangeWatcher.EventType.DELETE
         ));
         Assert.assertEquals("agent.ignore_suffix", ignoreSuffixPatternsWatcher.getPropertyKey());
     }

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/IgnoreSuffixPatternsWatcherTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/IgnoreSuffixPatternsWatcherTest.java
@@ -18,23 +18,25 @@
 
 package org.apache.skywalking.apm.agent.core.context;
 
+import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
+import org.apache.skywalking.apm.agent.core.test.tools.AgentServiceRule;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 public class IgnoreSuffixPatternsWatcherTest {
 
-    private ContextManagerExtendService contextManagerExtendService = new ContextManagerExtendService();
+    @Rule
+    public AgentServiceRule agentServiceRule = new AgentServiceRule();
+
+    private ContextManagerExtendService contextManagerExtendService;
 
     @Before
     public void setUp() {
-        Whitebox.setInternalState(
-            contextManagerExtendService
-            , "ignoreSuffixPatternsWatcher",
-            new IgnoreSuffixPatternsWatcher("agent.ignore_suffix", contextManagerExtendService)
-        );
+        contextManagerExtendService = ServiceManager.INSTANCE.findService(ContextManagerExtendService.class);
     }
 
     @Test

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/sampling/SamplingRateWatcherTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/sampling/SamplingRateWatcherTest.java
@@ -25,11 +25,15 @@ import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 public class SamplingRateWatcherTest {
+
     private SamplingService samplingService = new SamplingService();
 
     @Before
     public void setUp() {
-        samplingService.prepare();
+        Whitebox.setInternalState(
+            samplingService, "samplingRateWatcher",
+            new SamplingRateWatcher("agent.sample_n_per_3_secs", samplingService)
+        );
     }
 
     @Test

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/sampling/SamplingRateWatcherTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/sampling/SamplingRateWatcherTest.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.agent.core.sampling;
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
 import org.apache.skywalking.apm.agent.core.test.tools.AgentServiceRule;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,6 +38,11 @@ public class SamplingRateWatcherTest {
     @Before
     public void setUp() {
         samplingService = ServiceManager.INSTANCE.findService(SamplingService.class);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        ServiceManager.INSTANCE.shutdown();
     }
 
     @Test

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/sampling/SamplingRateWatcherTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/sampling/SamplingRateWatcherTest.java
@@ -18,22 +18,25 @@
 
 package org.apache.skywalking.apm.agent.core.sampling;
 
+import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
+import org.apache.skywalking.apm.agent.core.test.tools.AgentServiceRule;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 public class SamplingRateWatcherTest {
 
-    private SamplingService samplingService = new SamplingService();
+    @Rule
+    public AgentServiceRule agentServiceRule = new AgentServiceRule();
+
+    private SamplingService samplingService;
 
     @Before
     public void setUp() {
-        Whitebox.setInternalState(
-            samplingService, "samplingRateWatcher",
-            new SamplingRateWatcher("agent.sample_n_per_3_secs", samplingService)
-        );
+        samplingService = ServiceManager.INSTANCE.findService(SamplingService.class);
     }
 
     @Test

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/src/main/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnoreExtendService.java
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/src/main/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnoreExtendService.java
@@ -41,7 +41,6 @@ public class TraceIgnoreExtendService extends SamplingService {
     @Override
     public void prepare() {
         super.prepare();
-        traceIgnorePatternWatcher = new TraceIgnorePatternWatcher("agent.trace.ignore_path", this);
     }
 
     @Override
@@ -53,6 +52,7 @@ public class TraceIgnoreExtendService extends SamplingService {
             patterns = IgnoreConfig.Trace.IGNORE_PATH.split(PATTERN_SEPARATOR);
         }
 
+        traceIgnorePatternWatcher = new TraceIgnorePatternWatcher("agent.trace.ignore_path", this);
         ServiceManager.INSTANCE.findService(ConfigurationDiscoveryService.class)
                                .registerAgentConfigChangeWatcher(traceIgnorePatternWatcher);
 

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnorePatternWatcherTest.java
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnorePatternWatcherTest.java
@@ -22,7 +22,6 @@ import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
 import org.apache.skywalking.apm.agent.core.sampling.SamplingService;
 import org.apache.skywalking.apm.agent.test.tools.AgentServiceRule;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -40,11 +39,6 @@ public class TraceIgnorePatternWatcherTest {
     public void setUp() {
         traceIgnoreExtendService =
             (TraceIgnoreExtendService) ServiceManager.INSTANCE.findService(SamplingService.class);
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        ServiceManager.INSTANCE.shutdown();
     }
 
     @Test

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnorePatternWatcherTest.java
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnorePatternWatcherTest.java
@@ -22,6 +22,7 @@ import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
 import org.apache.skywalking.apm.agent.core.sampling.SamplingService;
 import org.apache.skywalking.apm.agent.test.tools.AgentServiceRule;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,6 +40,11 @@ public class TraceIgnorePatternWatcherTest {
     public void setUp() {
         traceIgnoreExtendService =
             (TraceIgnoreExtendService) ServiceManager.INSTANCE.findService(SamplingService.class);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        ServiceManager.INSTANCE.shutdown();
     }
 
     @Test

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnorePatternWatcherTest.java
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnorePatternWatcherTest.java
@@ -25,11 +25,16 @@ import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 public class TraceIgnorePatternWatcherTest {
+
     private TraceIgnoreExtendService traceIgnoreExtendService = new TraceIgnoreExtendService();
 
     @Before
     public void setUp() {
-        traceIgnoreExtendService.prepare();
+        Whitebox.setInternalState(
+            traceIgnoreExtendService
+            , "traceIgnorePatternWatcher",
+            new TraceIgnorePatternWatcher("agent.trace.ignore_path", traceIgnoreExtendService)
+        );
     }
 
     @Test

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnorePatternWatcherTest.java
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TraceIgnorePatternWatcherTest.java
@@ -18,23 +18,27 @@
 
 package org.apache.skywalking.apm.plugin.trace.ignore;
 
+import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
+import org.apache.skywalking.apm.agent.core.sampling.SamplingService;
+import org.apache.skywalking.apm.agent.test.tools.AgentServiceRule;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 public class TraceIgnorePatternWatcherTest {
 
-    private TraceIgnoreExtendService traceIgnoreExtendService = new TraceIgnoreExtendService();
+    @Rule
+    public AgentServiceRule agentServiceRule = new AgentServiceRule();
+
+    private TraceIgnoreExtendService traceIgnoreExtendService;
 
     @Before
     public void setUp() {
-        Whitebox.setInternalState(
-            traceIgnoreExtendService
-            , "traceIgnorePatternWatcher",
-            new TraceIgnorePatternWatcher("agent.trace.ignore_path", traceIgnoreExtendService)
-        );
+        traceIgnoreExtendService =
+            (TraceIgnoreExtendService) ServiceManager.INSTANCE.findService(SamplingService.class);
     }
 
     @Test


### PR DESCRIPTION

### Fix KafkaContextManagerExtendService boot error of kafka plugin.
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

Fix https://github.com/apache/skywalking/issues/6406, 
Because when KafkaContextManagerExtendService is used, the ignoreSuffixPatternsWatcher is not initialized by calling prepare of ContextManagerExtendService, which results in a NullPointerException. Don't worry too much, this exception will only affect ignoreSuffixArray not being dynamically updated, and will not affect the trace and other functions.