### PR TITLE
Remove filename suffix in the meter active file config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Release Notes.
 * Enhance `MeterSystem` to allow creating metrics with same `metricName` / `function` / `scope`.
 * Storage plugin supports postgresql.
 * Fix kubernetes.client.opeanapi.ApiException.
+* Remove filename suffix in the meter active file config.
 
 #### UI
 * Update selector scroller to show in all pages.

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/AnalyzerModuleConfig.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/AnalyzerModuleConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.analyzer.provider;
 
+import com.google.common.base.Splitter;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -145,10 +146,10 @@ public class AnalyzerModuleConfig extends ModuleConfig {
     /**
      * Get all files could be meter analyzed, files split by ","
      */
-    public String[] meterAnalyzerActiveFileNames() {
+    public List<String> meterAnalyzerActiveFileNames() {
         if (StringUtils.isEmpty(this.meterAnalyzerActiveFiles)) {
             return null;
         }
-        return this.meterAnalyzerActiveFiles.split(",");
+        return Splitter.on(",").splitToList(this.meterAnalyzerActiveFiles);
     }
 }

--- a/oap-server/server-bootstrap/src/main/resources/application.yml
+++ b/oap-server/server-bootstrap/src/main/resources/application.yml
@@ -225,7 +225,7 @@ agent-analyzer:
     # Exit spans with the component in the list would not generate the client-side instance relation metrics.
     noUpstreamRealAddressAgents: ${SW_NO_UPSTREAM_REAL_ADDRESS:6000,9000}
     slowTraceSegmentThreshold: ${SW_SLOW_TRACE_SEGMENT_THRESHOLD:-1} # Setting this threshold about the latency would make the slow trace segments sampled if they cost more time, even the sampling mechanism activated. The default value is `-1`, which means would not sample slow traces. Unit, millisecond.
-    meterAnalyzerActiveFiles: ${SW_METER_ANALYZER_ACTIVE_FILES:spring-sleuth.yaml} # Which files could be meter analyzed, files split by ","
+    meterAnalyzerActiveFiles: ${SW_METER_ANALYZER_ACTIVE_FILES:spring-sleuth} # Which files could be meter analyzed, files split by ","
 
 log-analyzer:
   selector: ${SW_LOG_ANALYZER:default}

--- a/test/e2e/e2e-test/docker/kafka/docker-compose.meter.yml
+++ b/test/e2e/e2e-test/docker/kafka/docker-compose.meter.yml
@@ -26,7 +26,7 @@ services:
       SW_KAFKA_FETCHER_PARTITIONS: 2
       SW_KAFKA_FETCHER_PARTITIONS_FACTOR: 1
       SW_KAFKA_FETCHER_ENABLE_METER_SYSTEM: "true"
-      SW_METER_ANALYZER_ACTIVE_FILES: spring-sleuth.yaml
+      SW_METER_ANALYZER_ACTIVE_FILES: spring-sleuth
     depends_on:
       broker-a:
         condition: service_healthy

--- a/test/e2e/e2e-test/docker/meter/docker-compose.yml
+++ b/test/e2e/e2e-test/docker/meter/docker-compose.yml
@@ -18,7 +18,7 @@ version: '2.1'
 services:
   oap:
     environment:
-      SW_METER_ANALYZER_ACTIVE_FILES: spring-sleuth.yaml
+      SW_METER_ANALYZER_ACTIVE_FILES: spring-sleuth
     extends:
       file: ../base-compose.yml
       service: oap


### PR DESCRIPTION

- [x] Follow [LAL discuss file name suffix config](https://github.com/apache/skywalking/pull/6388#discussion_r578955988), should remove the filename suffix in the meter active file config.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
