### PR TITLE
Fix the segment tag is not synchronized when updating the correlation value.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
 * Add net.bytebuddy.agent.builder.AgentBuilder.RedefinitionStrategy.Listener to show detail message when redefine errors occur.
 * Fix ClassCastException of log4j gRPC reporter.
 * Fix NPE when Kafka reporter activated.
+* Fix the segment tag is not synchronized when updating the correlation value.
 
 #### OAP-Backend
 * Allow user-defined `JAVA_OPTS` in the startup script.

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/CorrelationContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/CorrelationContext.java
@@ -78,6 +78,11 @@ public class CorrelationContext {
         // already contain key
         if (data.containsKey(key)) {
             final String previousValue = data.put(key, value);
+
+            // update tag if need
+            if (AUTO_TAG_KEYS.contains(key) && ContextManager.isActive()) {
+                ContextManager.activeSpan().tag(new StringTag(-1, key, true), value);
+            }
             return Optional.of(previousValue);
         }
 
@@ -86,7 +91,7 @@ public class CorrelationContext {
             return Optional.empty();
         }
         if (AUTO_TAG_KEYS.contains(key) && ContextManager.isActive()) {
-            ContextManager.activeSpan().tag(new StringTag(key), value);
+            ContextManager.activeSpan().tag(new StringTag(-1, key, true), value);
         }
         // setting
         data.put(key, value);


### PR DESCRIPTION
- [x] When put the same correlation key, the value will update. In the auto tag case, the segment tag value not override. 
- [x] Add a unit test to verify that the fix works.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
