### PR TITLE
Clean up some warnings in maven build

### DIFF
--- a/apm-dist-es7/pom.xml
+++ b/apm-dist-es7/pom.xml
@@ -106,9 +106,9 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <copy file="${project.build.directory}/apache-skywalking-apm-bin-es7.tar.gz" tofile="${project.basedir}/../dist/apache-skywalking-apm-bin-es7.tar.gz" overwrite="true" />
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/apm-dist-es7/src/main/assembly/binary-es7.xml
+++ b/apm-dist-es7/src/main/assembly/binary-es7.xml
@@ -27,7 +27,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/../dist-material/bin</directory>
-            <outputDirectory>/bin</outputDirectory>
+            <outputDirectory>bin</outputDirectory>
             <includes>
                 <include>*.sh</include>
                 <include>*.bat</include>
@@ -36,7 +36,7 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../dist-material</directory>
-            <outputDirectory>/config</outputDirectory>
+            <outputDirectory>config</outputDirectory>
             <includes>
                 <include>log4j2.xml</include>
                 <include>alarm-settings.yml</include>
@@ -44,7 +44,7 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../dist-material</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <includes>
                 <include>config-examples/*</include>
             </includes>
@@ -68,49 +68,39 @@
                 <include>lal/*</include>
                 <include>log-mal-rules/*</include>
             </includes>
-            <outputDirectory>/config</outputDirectory>
+            <outputDirectory>config</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../oap-server/server-starter-es7/target/skywalking-oap-assembly/skywalking-oap/libs</directory>
-            <outputDirectory>/oap-libs</outputDirectory>
+            <outputDirectory>oap-libs</outputDirectory>
         </fileSet>
 
         <!-- Agent repackage into the dist -->
         <fileSet>
             <directory>${project.basedir}/../skywalking-agent</directory>
-            <outputDirectory>/agent</outputDirectory>
+            <outputDirectory>agent</outputDirectory>
         </fileSet>
 
         <!-- Profile exporter tools -->
         <fileSet>
             <directory>${project.basedir}/../tools/profile-exporter</directory>
-            <outputDirectory>/tools/profile-exporter</outputDirectory>
-        </fileSet>
-
-        <!-- Release docs and licenses -->
-        <fileSet>
-            <directory>${project.basedir}/../</directory>
-            <outputDirectory>/</outputDirectory>
-            <includes>
-                <include>DISCLAIMER</include>
-                <include>CHANGES</include>
-            </includes>
+            <outputDirectory>tools/profile-exporter</outputDirectory>
         </fileSet>
 
         <fileSet>
             <directory>${project.basedir}/../dist-material/release-docs</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
         </fileSet>
     </fileSets>
     <files>
         <file>
             <source>${project.basedir}/../apm-webapp/target/skywalking-webapp.jar</source>
-            <outputDirectory>/webapp</outputDirectory>
+            <outputDirectory>webapp</outputDirectory>
             <fileMode>0644</fileMode>
         </file>
         <file>
             <source>${project.basedir}/../apm-webapp/src/main/assembly/webapp.yml</source>
-            <outputDirectory>/webapp</outputDirectory>
+            <outputDirectory>webapp</outputDirectory>
             <fileMode>0644</fileMode>
         </file>
     </files>

--- a/apm-dist/pom.xml
+++ b/apm-dist/pom.xml
@@ -106,9 +106,9 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <copy file="${project.build.directory}/apache-skywalking-apm-bin.tar.gz" tofile="${project.basedir}/../dist/apache-skywalking-apm-bin.tar.gz" overwrite="true" />
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/apm-dist/src/main/assembly/binary.xml
+++ b/apm-dist/src/main/assembly/binary.xml
@@ -27,7 +27,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/../dist-material/bin</directory>
-            <outputDirectory>/bin</outputDirectory>
+            <outputDirectory>bin</outputDirectory>
             <includes>
                 <include>*.sh</include>
                 <include>*.bat</include>
@@ -36,7 +36,7 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../dist-material</directory>
-            <outputDirectory>/config</outputDirectory>
+            <outputDirectory>config</outputDirectory>
             <includes>
                 <include>log4j2.xml</include>
                 <include>alarm-settings.yml</include>
@@ -44,7 +44,7 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../dist-material</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <includes>
                 <include>config-examples/*</include>
             </includes>
@@ -68,49 +68,39 @@
                 <include>lal/*</include>
                 <include>log-mal-rules/*</include>
             </includes>
-            <outputDirectory>/config</outputDirectory>
+            <outputDirectory>config</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../oap-server/server-starter/target/skywalking-oap-assembly/skywalking-oap/libs</directory>
-            <outputDirectory>/oap-libs</outputDirectory>
+            <outputDirectory>oap-libs</outputDirectory>
         </fileSet>
 
         <!-- Agent repackage into the dist -->
         <fileSet>
             <directory>${project.basedir}/../skywalking-agent</directory>
-            <outputDirectory>/agent</outputDirectory>
+            <outputDirectory>agent</outputDirectory>
         </fileSet>
 
         <!-- Profile exporter tools -->
         <fileSet>
             <directory>${project.basedir}/../tools/profile-exporter</directory>
-            <outputDirectory>/tools/profile-exporter</outputDirectory>
-        </fileSet>
-
-        <!-- Release docs and licenses -->
-        <fileSet>
-            <directory>${project.basedir}/../</directory>
-            <outputDirectory>/</outputDirectory>
-            <includes>
-                <include>DISCLAIMER</include>
-                <include>CHANGES</include>
-            </includes>
+            <outputDirectory>tools/profile-exporter</outputDirectory>
         </fileSet>
 
         <fileSet>
             <directory>${project.basedir}/../dist-material/release-docs</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
         </fileSet>
     </fileSets>
     <files>
         <file>
             <source>${project.basedir}/../apm-webapp/target/skywalking-webapp.jar</source>
-            <outputDirectory>/webapp</outputDirectory>
+            <outputDirectory>webapp</outputDirectory>
             <fileMode>0644</fileMode>
         </file>
         <file>
             <source>${project.basedir}/../apm-webapp/src/main/assembly/webapp.yml</source>
-            <outputDirectory>/webapp</outputDirectory>
+            <outputDirectory>webapp</outputDirectory>
             <fileMode>0644</fileMode>
         </file>
     </files>

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -239,9 +239,9 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <delete dir="${project.basedir}/../../packages" />
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                     <execution>

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -116,9 +116,9 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <delete dir="${project.basedir}/../../skywalking-agent" />
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                     <execution>
@@ -128,13 +128,13 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <mkdir dir="${project.basedir}/../../skywalking-agent" />
                                 <copy file="${project.build.directory}/skywalking-agent.jar" tofile="${project.basedir}/../../skywalking-agent/skywalking-agent.jar" overwrite="true" />
                                 <mkdir dir="${project.basedir}/../../skywalking-agent/config" />
                                 <mkdir dir="${project.basedir}/../../skywalking-agent/logs" />
                                 <copydir src="${project.basedir}/../config" dest="${project.basedir}/../../skywalking-agent/config" forceoverwrite="true" />
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/apm-sniffer/apm-sdk-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pom.xml
@@ -189,7 +189,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.runtime.classpath" />
                                 <if>
                                     <equals arg1="${project.packaging}" arg2="jar" />
@@ -199,7 +199,7 @@
                                     </then>
                                 </if>
 
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/apm-sniffer/apm-toolkit-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/pom.xml
@@ -115,7 +115,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.runtime.classpath" />
                                 <if>
                                     <equals arg1="${project.packaging}" arg2="jar" />
@@ -125,7 +125,7 @@
                                     </then>
                                 </if>
 
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/apm-sniffer/bootstrap-plugins/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/pom.xml
@@ -101,7 +101,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.runtime.classpath" />
                                 <if>
                                     <equals arg1="${project.packaging}" arg2="jar" />
@@ -110,7 +110,7 @@
                                         <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar" tofile="${bootstrap.plugin.dest.dir}/${project.artifactId}-${project.version}.jar" overwrite="true" />
                                     </then>
                                 </if>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/apm-sniffer/optional-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/pom.xml
@@ -106,7 +106,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.runtime.classpath" />
                                 <if>
                                     <equals arg1="${project.packaging}" arg2="jar" />
@@ -115,7 +115,7 @@
                                         <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar" tofile="${optional.plugin.dest.dir}/${project.artifactId}-${project.version}.jar" overwrite="true" />
                                     </then>
                                 </if>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/pom.xml
+++ b/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/pom.xml
@@ -118,7 +118,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.runtime.classpath" />
                                 <if>
                                     <equals arg1="${project.packaging}" arg2="jar" />
@@ -127,7 +127,7 @@
                                         <copy file="${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar" tofile="${optional.reporter.plugins.dest.dir}/${project.artifactId}-${project.version}.jar" overwrite="true" />
                                     </then>
                                 </if>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/oap-server/server-library/library-util/pom.xml
+++ b/oap-server/server-library/library-util/pom.xml
@@ -38,11 +38,6 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
             <version>${ststem-rules.version}</version>

--- a/oap-server/server-receiver-plugin/receiver-proto/src/main/proto/envoy/service/metrics/v2/metrics_service.proto
+++ b/oap-server/server-receiver-plugin/receiver-proto/src/main/proto/envoy/service/metrics/v2/metrics_service.proto
@@ -10,12 +10,6 @@ option java_generic_services = true;
 
 import "envoy/service/metrics/v3/metrics_service.proto";
 
-// This line is different from the definition in https://github.com/envoyproxy/data-plane-api to let
-// the dependency structure clearer.
-import "prometheus/client_model/metrics.proto";
-
-import "validate/validate.proto";
-
 // Service for streaming metrics to server that consumes the metrics data. It uses Prometheus metric
 // data model as a standard to represent metrics information.
 service MetricsService {


### PR DESCRIPTION
1. Replace deprecated `tasks` with `target` in ant-run plugin
2. Remove leading `/` in assembly file, which is not cross platform compatible
3. Remove outdated `DISCLAIMER` file and `CHANGES` file in assembly file
4. Remove unused imports in Envoy metrics service proto files