### PR TITLE
Fix apm-dubbo-2.7.x-plugin memory leak due to some Dubbo RpcExceptions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Release Notes.
 * Fix ClassCastException of log4j gRPC reporter.
 * Fix NPE when Kafka reporter activated.
 * Enhance gRPC log appender to allow layout pattern.
+* Fix apm-dubbo-2.7.x-plugin memory leak due to some Dubbo RpcExceptions.
 
 #### OAP-Backend
 * Allow user-defined `JAVA_OPTS` in the startup script.

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/asf/dubbo/DubboInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/asf/dubbo/DubboInterceptor.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.RpcException;
 import org.apache.skywalking.apm.agent.core.context.CarrierItem;
 import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
@@ -109,8 +110,12 @@ public class DubboInterceptor implements InstanceMethodsAroundInterceptor {
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
                               Object ret) throws Throwable {
         Result result = (Result) ret;
-        if (result != null && result.getException() != null) {
-            dealException(result.getException());
+        try {
+            if (result != null && result.getException() != null) {
+                dealException(result.getException());
+            }
+        } catch (RpcException e) {
+            dealException(e);
         }
 
         ContextManager.stopSpan();


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix apm-dubbo-2.7.x-plugin memory leak due to some Dubbo RpcExceptions
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
Dubbo Version: 2.7.5
Skywalking Version: 8.3.0

My Java app ran into an endless FullGC state some days before. After some analysis, I found this.
When Dubbo RPC Chain acts like: A-->dubbo://B-->dubbo://C, and in some situation server C slow down or suddenly crush, Dubbo-thread(Provider) on Server B may triggers an 'Consumer is shutting down' Exception, org.apache.dubbo.rpc.AsyncRpcResult.getAppResponse won't get any result(dubbo code notes: '// This should not happen in normal request process;').
Then result.getException in afterMethod throws exception in Skywalking java agent as below(won't log into span.log):

> ERROR 2021-01-27 15:06:19:290 Dubbo-thread-388 InstMethodsInter : class[class org.apache.dubbo.monitor.support.MonitorFilter] after method[invoke] intercept failure
> org.apache.dubbo.rpc.RpcException: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: Consumer is shutting down and this call is going to be stopped without receiving any result, usually this is called by a slow provider instance or bad service implementation.
  >    at org.apache.dubbo.rpc.AsyncRpcResult.getAppResponse(AsyncRpcResult.java:148)
  >    at org.apache.dubbo.rpc.AsyncRpcResult.getException(AsyncRpcResult.java:107)
  >    at org.apache.skywalking.apm.plugin.asf.dubbo.DubboInterceptor.afterMethod(DubboInterceptor.java:110)
  >    at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:97)
  >    at org.apache.dubbo.monitor.support.MonitorFilter.invoke(MonitorFilter.java)
  >    at org.apache.dubbo.rpc.protocol.ProtocolFilterWrapper$1.invoke(ProtocolFilterWrapper.java:81)
  >    at org.apache.dubbo.rpc.protocol.dubbo.filter.FutureFilter.invoke(FutureFilter.java:49)
  >    at org.apache.dubbo.rpc.protocol.ProtocolFilterWrapper$1.invoke(ProtocolFilterWrapper.java:81)

StopSpan() won't work, TraceSegment will be kept by ThreadLocal when dubbo runs in threadpool mode.
While this thread creating new entryspans later, the old TraceSegment will be added into refs.(memory leak)

This is a JVM heapdump after the memory leak happened for several days(the thread is holding 768332 spans):
![mat](https://user-images.githubusercontent.com/8132268/108948485-8a781280-769d-11eb-97ea-5121996ec2fa.png)

I thinks maybe there are some 'unnormal' RpcExceptions which can't be obtained by result.getException(). Perhaps we could catch them when calling it from afterMethod.
Built an new dubbo-2.7.x-plugin on my machine and it looks good now.

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
