### PR TITLE
Fix `docs/menu.yml` for  website-docs/8.2.0

### DIFF
--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -73,7 +73,7 @@ catalog:
               - name: "Plugin development guide"
                 path: "/en/setup/service-agent/java-agent/readme#plugin-development-guide"
               - name: "Agent plugin tests and performance tests"
-                path: "/en/setup/service-agent/java-agent/readme#plugin-development-guide"
+                path: "/en/setup/service-agent/java-agent/readme#test"
 
           - name: "Other language agents"
             path: "/en/setup/readme#language-agents-in-service"


### PR DESCRIPTION
Fix `docs/menu.yml` 