### PR TITLE
Bugfix/lettucev5 plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Release Notes.
 * Fix NPE when Kafka reporter activated.
 * Enhance gRPC log appender to allow layout pattern.
 * Fix apm-dubbo-2.7.x-plugin memory leak due to some Dubbo RpcExceptions.
+* Fix lettuce-5.x-plugin get null host in redis sentinel mode.
 
 #### OAP-Backend
 * Allow user-defined `JAVA_OPTS` in the startup script.

--- a/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisClientConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisClientConstructorInterceptor.java
@@ -22,6 +22,9 @@ import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor;
+import org.apache.skywalking.apm.util.StringUtil;
+
+import java.util.stream.Collectors;
 
 public class RedisClientConstructorInterceptor implements InstanceConstructorInterceptor {
 
@@ -30,6 +33,13 @@ public class RedisClientConstructorInterceptor implements InstanceConstructorInt
         RedisURI redisURI = (RedisURI) allArguments[1];
         RedisClient redisClient = (RedisClient) objInst;
         EnhancedInstance optionsInst = (EnhancedInstance) redisClient.getOptions();
-        optionsInst.setSkyWalkingDynamicField(redisURI.getHost() + ":" + redisURI.getPort());
+        StringBuilder redisInfoSb = new StringBuilder();
+        if (StringUtil.isNotBlank(redisURI.getSentinelMasterId())) {
+            redisInfoSb.append(redisURI.getSentinelMasterId()).append(
+                    redisURI.getSentinels().stream().map(r -> r.getHost() + ":" + r.getPort()).collect(Collectors.joining(",")));
+        } else {
+            redisInfoSb.append(redisURI.getHost()).append(":").append(redisURI.getPort());
+        }
+        optionsInst.setSkyWalkingDynamicField(redisInfoSb.toString());
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisClientConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisClientConstructorInterceptor.java
@@ -33,14 +33,14 @@ public class RedisClientConstructorInterceptor implements InstanceConstructorInt
         RedisURI redisURI = (RedisURI) allArguments[1];
         RedisClient redisClient = (RedisClient) objInst;
         EnhancedInstance optionsInst = (EnhancedInstance) redisClient.getOptions();
-        StringBuilder redisInfoSb = new StringBuilder();
+        StringBuilder redisPeer = new StringBuilder();
         if (StringUtil.isNotBlank(redisURI.getSentinelMasterId())) {
-            redisInfoSb.append(redisURI.getSentinelMasterId()).append("[").append(
+            redisPeer.append(redisURI.getSentinelMasterId()).append("[").append(
                     redisURI.getSentinels().stream().map(r -> r.getHost() + ":" + r.getPort())
                             .collect(Collectors.joining(","))).append("]");
         } else {
-            redisInfoSb.append(redisURI.getHost()).append(":").append(redisURI.getPort());
+            redisPeer.append(redisURI.getHost()).append(":").append(redisURI.getPort());
         }
-        optionsInst.setSkyWalkingDynamicField(redisInfoSb.toString());
+        optionsInst.setSkyWalkingDynamicField(redisPeer.toString());
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisClientConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisClientConstructorInterceptor.java
@@ -35,8 +35,9 @@ public class RedisClientConstructorInterceptor implements InstanceConstructorInt
         EnhancedInstance optionsInst = (EnhancedInstance) redisClient.getOptions();
         StringBuilder redisInfoSb = new StringBuilder();
         if (StringUtil.isNotBlank(redisURI.getSentinelMasterId())) {
-            redisInfoSb.append(redisURI.getSentinelMasterId()).append(
-                    redisURI.getSentinels().stream().map(r -> r.getHost() + ":" + r.getPort()).collect(Collectors.joining(",")));
+            redisInfoSb.append(redisURI.getSentinelMasterId()).append("[").append(
+                    redisURI.getSentinels().stream().map(r -> r.getHost() + ":" + r.getPort())
+                            .collect(Collectors.joining(","))).append("]");
         } else {
             redisInfoSb.append(redisURI.getHost()).append(":").append(redisURI.getPort());
         }


### PR DESCRIPTION
### Fix lettuce-5.x-plugin bug  <https://github.com/apache/skywalking/issues/6443>
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
noraml we could get redis node info from redisURI.host and redisURI.port ,but when redis cluster mode is sentinel ,we need to get info from redisURI.sentinels. so  i add a condition  when sentinelMasterId is not blank,splicing sentinels node info,  finally nodeInfoString would be like masterId[ip:port,ip1:port], otherwise same with before.


- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
