### PR TITLE
Remove fields of parent entity in the relation sources.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Release Notes.
 * Upgrade the Zipkin Elasticsearch storage from 6 to 7.
 * Require Zipkin receiver must work with `zipkin-elasticsearch7` storage option.
 * Fix `DatabaseSlowStatementBuilder` statement maybe null.
+* Remove fields of parent entity in the relation sources. 
 
 #### UI
 * Update selector scroller to show in all pages.

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/EndpointRelation.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/EndpointRelation.java
@@ -44,6 +44,7 @@ public class EndpointRelation extends Source {
 
     @Getter
     @Setter
+    @ScopeDefaultColumn.DefinedByField(columnName = "source_endpoint_name", requireDynamicActive = true)
     private String endpoint;
     @Getter
     private String serviceId;
@@ -58,6 +59,7 @@ public class EndpointRelation extends Source {
     private String serviceInstanceName;
     @Getter
     @Setter
+    @ScopeDefaultColumn.DefinedByField(columnName = "child_endpoint_name", requireDynamicActive = true)
     private String childEndpoint;
     @Getter
     private String childServiceId;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/EndpointRelation.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/EndpointRelation.java
@@ -44,11 +44,8 @@ public class EndpointRelation extends Source {
 
     @Getter
     @Setter
-    @ScopeDefaultColumn.DefinedByField(columnName = "source_endpoint_name")
     private String endpoint;
-
     @Getter
-    @ScopeDefaultColumn.DefinedByField(columnName = "service_id")
     private String serviceId;
     @Getter
     @Setter
@@ -61,10 +58,8 @@ public class EndpointRelation extends Source {
     private String serviceInstanceName;
     @Getter
     @Setter
-    @ScopeDefaultColumn.DefinedByField(columnName = "child_endpoint_name")
     private String childEndpoint;
     @Getter
-    @ScopeDefaultColumn.DefinedByField(columnName = "child_service_id")
     private String childServiceId;
     @Setter
     @Getter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceRelation.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceRelation.java
@@ -51,10 +51,8 @@ public class ServiceInstanceRelation extends Source {
     }
 
     @Getter
-    @ScopeDefaultColumn.DefinedByField(columnName = "source_service_instance_id")
     private String sourceServiceInstanceId;
     @Getter
-    @ScopeDefaultColumn.DefinedByField(columnName = "source_service_id")
     private String sourceServiceId;
     @Getter
     @Setter
@@ -67,10 +65,8 @@ public class ServiceInstanceRelation extends Source {
     @ScopeDefaultColumn.DefinedByField(columnName = "source_service_instance_name", requireDynamicActive = true)
     private String sourceServiceInstanceName;
     @Getter
-    @ScopeDefaultColumn.DefinedByField(columnName = "dest_service_instance_id")
     private String destServiceInstanceId;
     @Getter
-    @ScopeDefaultColumn.DefinedByField(columnName = "dest_service_id")
     private String destServiceId;
     @Setter
     private NodeType destServiceNodeType;


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

I noticed these unnecessary fields when I discussed with @EvanLjp about #6411, we don't need these parent fields now, or upgrade the frontend to use metrics v2 APIs to query topology metrics. So I removed all these.