### PR TITLE
Enhance the LAL to allow easily skipping logs with malformed formats

### DIFF
--- a/docs/en/concepts-and-designs/lal.md
+++ b/docs/en/concepts-and-designs/lal.md
@@ -64,6 +64,7 @@ See examples below.
 ```groovy
 filter {
     json {
+        abortOnFailure true // this is optional because it's default behaviour
     }
 }
 ```
@@ -73,6 +74,7 @@ filter {
 ```groovy
 filter {
     yaml {
+        abortOnFailure true // this is optional because it's default behaviour
     }
 }
 ```
@@ -90,6 +92,7 @@ all the captured groups can be used later in the extractors or sinks.
 ```groovy
 filter {
     text {
+        abortOnFailure true // this is optional because it's default behaviour
         // this is just a demo pattern
         regexp "(?<timestamp>\\d{8}) (?<thread>\\w+) (?<level>\\w+) (?<traceId>\\w+) (?<msg>.+)"
     }

--- a/docs/en/concepts-and-designs/lal.md
+++ b/docs/en/concepts-and-designs/lal.md
@@ -35,10 +35,9 @@ filter {
         abort {} // all remaining components won't be executed at all
     }
     text {
-        if (!regexp("(?<timestamp>\\d{8}) (?<thread>\\w+) (?<level>\\w+) (?<traceId>\\w+) (?<msg>.+)")) {
-            // if the logs don't match this regexp, skip it
-            abort {}
-        }
+        // if the logs don't match this regexp, skip it
+        abortOnFailure true
+        regexp "(?<timestamp>\\d{8}) (?<thread>\\w+) (?<level>\\w+) (?<traceId>\\w+) (?<msg>.+)"
     }
     // ... extractors, sinks
 }
@@ -55,15 +54,35 @@ types of parsers at the moment, namely `json`, `yaml`, and `text`.
 When a piece of log is parsed, there is a corresponding property available, called `parsed`, injected by LAL.
 Property `parsed` is typically a map, containing all the fields parsed from the raw logs, for example, if the parser
 is `json` / `yaml`, `parsed` is a map containing all the key-values in the `json` / `yaml`, if the parser is `text`
-, `parsed` is a map containing all the captured groups and their values (for `regexp` and `grok`). See examples below.
+, `parsed` is a map containing all the captured groups and their values (for `regexp` and `grok`).
+
+All parsers share the following options:
+
+| Option | Type | Description | Default Value |
+| ------ | ---- | ----------- | ------------- |
+| `abortOnFailure` | `boolean` | Whether the filter chain should abort if the parser failed to parse / match the logs | `false` |
+
+See examples below.
 
 #### `json`
 
-<!-- TODO: is structured in the reported (gRPC) `LogData`, not much to do -->
+```groovy
+filter {
+    json {
+        abortOnFailure true
+    }
+}
+```
 
 #### `yaml`
 
-<!-- TODO: is structured in the reported (gRPC) `LogData`, not much to do -->
+```groovy
+filter {
+    yaml {
+        abortOnFailure true
+    }
+}
+```
 
 #### `text`
 
@@ -78,6 +97,7 @@ all the captured groups can be used later in the extractors or sinks.
 ```groovy
 filter {
     text {
+        abortOnFailure true  // if the logs don't match the pattern below, abort the filter chain
         regexp "(?<timestamp>\\d{8}) (?<thread>\\w+) (?<level>\\w+) (?<traceId>\\w+) (?<msg>.+)"
         // this is just a demo pattern
     }
@@ -91,9 +111,10 @@ filter {
 }
 ```
 
-- `grok`
+- `grok` (TODO)
 
-<!-- TODO: grok Java library has poor performance, need to benchmark it, the idea is basically the same with `regexp` above -->
+Because grok Java library has performance issue, we need some investigations and benchmark on it. Contributions are
+welcome.
 
 ### Extractor
 

--- a/docs/en/concepts-and-designs/lal.md
+++ b/docs/en/concepts-and-designs/lal.md
@@ -34,12 +34,7 @@ filter {
     if (log.service == "TestingService") { // Don't waste resources on TestingServices
         abort {} // all remaining components won't be executed at all
     }
-    text {
-        // if the logs don't match this regexp, skip it
-        abortOnFailure true
-        regexp "(?<timestamp>\\d{8}) (?<thread>\\w+) (?<level>\\w+) (?<traceId>\\w+) (?<msg>.+)"
-    }
-    // ... extractors, sinks
+    // ... parsers, extractors, sinks
 }
 ```
 
@@ -60,7 +55,7 @@ All parsers share the following options:
 
 | Option | Type | Description | Default Value |
 | ------ | ---- | ----------- | ------------- |
-| `abortOnFailure` | `boolean` | Whether the filter chain should abort if the parser failed to parse / match the logs | `false` |
+| `abortOnFailure` | `boolean` | Whether the filter chain should abort if the parser failed to parse / match the logs | `true` |
 
 See examples below.
 
@@ -69,7 +64,6 @@ See examples below.
 ```groovy
 filter {
     json {
-        abortOnFailure true
     }
 }
 ```
@@ -79,7 +73,6 @@ filter {
 ```groovy
 filter {
     yaml {
-        abortOnFailure true
     }
 }
 ```
@@ -97,9 +90,8 @@ all the captured groups can be used later in the extractors or sinks.
 ```groovy
 filter {
     text {
-        abortOnFailure true  // if the logs don't match the pattern below, abort the filter chain
-        regexp "(?<timestamp>\\d{8}) (?<thread>\\w+) (?<level>\\w+) (?<traceId>\\w+) (?<msg>.+)"
         // this is just a demo pattern
+        regexp "(?<timestamp>\\d{8}) (?<thread>\\w+) (?<level>\\w+) (?<traceId>\\w+) (?<msg>.+)"
     }
     extractor {
         tag level: parsed.level

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/filter/FilterSpec.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/filter/FilterSpec.java
@@ -98,11 +98,17 @@ public class FilterSpec extends AbstractSpec {
         cl.call();
 
         final LogData.Builder logData = BINDING.get().log();
-        final Map<String, Object> parsed = jsonParser.create().fromJson(
-            logData.getBody().getJson().getJson(), parsedType
-        );
+        try {
+            final Map<String, Object> parsed = jsonParser.create().fromJson(
+                logData.getBody().getJson().getJson(), parsedType
+            );
 
-        BINDING.get().parsed(parsed);
+            BINDING.get().parsed(parsed);
+        } catch (final Exception e) {
+            if (jsonParser.abortOnFailure()) {
+                BINDING.get().abort();
+            }
+        }
     }
 
     @SuppressWarnings({"unused", "unchecked"})
@@ -114,11 +120,17 @@ public class FilterSpec extends AbstractSpec {
         cl.call();
 
         final LogData.Builder logData = BINDING.get().log();
-        final Map<String, Object> parsed = (Map<String, Object>) yamlParser.create().load(
-            logData.getBody().getYaml().getYaml()
-        );
+        try {
+            final Map<String, Object> parsed = (Map<String, Object>) yamlParser.create().load(
+                logData.getBody().getYaml().getYaml()
+            );
 
-        BINDING.get().parsed(parsed);
+            BINDING.get().parsed(parsed);
+        } catch (final Exception e) {
+            if (yamlParser.abortOnFailure()) {
+                BINDING.get().abort();
+            }
+        }
     }
 
     @SuppressWarnings("unused")

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/parser/AbstractParserSpec.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/parser/AbstractParserSpec.java
@@ -34,7 +34,7 @@ public class AbstractParserSpec extends AbstractSpec {
      */
     @Getter
     @Setter
-    private boolean abortOnFailure;
+    private boolean abortOnFailure = true;
 
     public AbstractParserSpec(final ModuleManager moduleManager,
                               final LogAnalyzerModuleConfig moduleConfig) {

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/parser/AbstractParserSpec.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/parser/AbstractParserSpec.java
@@ -18,28 +18,26 @@
 
 package org.apache.skywalking.oap.log.analyzer.dsl.spec.parser;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.apache.skywalking.oap.log.analyzer.dsl.spec.AbstractSpec;
 import org.apache.skywalking.oap.log.analyzer.provider.LogAnalyzerModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 
-public class JsonParserSpec extends AbstractParserSpec {
-    private final GsonBuilder gsonBuilder;
+@Accessors(fluent = true)
+public class AbstractParserSpec extends AbstractSpec {
+    /**
+     * Whether the filter chain should abort when parsing the logs failed.
+     *
+     * Failing to parse the logs means either parsing throws exceptions or the logs not matching the desired patterns.
+     */
+    @Getter
+    @Setter
+    private boolean abortOnFailure;
 
-    private final Gson gson;
-
-    public JsonParserSpec(final ModuleManager moduleManager,
-                          final LogAnalyzerModuleConfig moduleConfig) {
+    public AbstractParserSpec(final ModuleManager moduleManager,
+                              final LogAnalyzerModuleConfig moduleConfig) {
         super(moduleManager, moduleConfig);
-
-        gsonBuilder = new GsonBuilder();
-
-        // We just create a gson instance in advance for now (for the sake of performance),
-        // when we want to provide some extra options, we'll move this into method "create" then.
-        gson = gsonBuilder.create();
-    }
-
-    public Gson create() {
-        return gson;
     }
 }

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/parser/TextParserSpec.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/parser/TextParserSpec.java
@@ -21,11 +21,10 @@ package org.apache.skywalking.oap.log.analyzer.dsl.spec.parser;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.skywalking.apm.network.logging.v3.LogData;
-import org.apache.skywalking.oap.log.analyzer.dsl.spec.AbstractSpec;
 import org.apache.skywalking.oap.log.analyzer.provider.LogAnalyzerModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 
-public class TextParserSpec extends AbstractSpec {
+public class TextParserSpec extends AbstractParserSpec {
     public TextParserSpec(final ModuleManager moduleManager,
                           final LogAnalyzerModuleConfig moduleConfig) {
         super(moduleManager, moduleConfig);
@@ -45,6 +44,8 @@ public class TextParserSpec extends AbstractSpec {
         final boolean matched = matcher.find();
         if (matched) {
             BINDING.get().parsed(matcher);
+        } else if (abortOnFailure()) {
+            BINDING.get().abort();
         }
         return matched;
     }

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/parser/YamlParserSpec.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/dsl/spec/parser/YamlParserSpec.java
@@ -18,7 +18,6 @@
 
 package org.apache.skywalking.oap.log.analyzer.dsl.spec.parser;
 
-import org.apache.skywalking.oap.log.analyzer.dsl.spec.AbstractSpec;
 import org.apache.skywalking.oap.log.analyzer.provider.LogAnalyzerModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.yaml.snakeyaml.DumperOptions;
@@ -27,7 +26,7 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.representer.Representer;
 
-public class YamlParserSpec extends AbstractSpec {
+public class YamlParserSpec extends AbstractParserSpec {
     private final LoaderOptions loaderOptions;
 
     public YamlParserSpec(final ModuleManager moduleManager,

--- a/oap-server/server-bootstrap/src/main/resources/lal/envoy-als.yaml
+++ b/oap-server/server-bootstrap/src/main/resources/lal/envoy-als.yaml
@@ -18,7 +18,6 @@ rules:
     dsl: |
       filter {
         json {
-          abortOnFailure true
         }
         // only collect abnormal logs (http status code >= 300, or commonProperties?.responseFlags is not empty)
         if (parsed?.response?.responseCode < 400 && !parsed?.commonProperties?.responseFlags) {

--- a/oap-server/server-bootstrap/src/main/resources/lal/envoy-als.yaml
+++ b/oap-server/server-bootstrap/src/main/resources/lal/envoy-als.yaml
@@ -18,6 +18,7 @@ rules:
     dsl: |
       filter {
         json {
+          abortOnFailure true
         }
         // only collect abnormal logs (http status code >= 300, or commonProperties?.responseFlags is not empty)
         if (parsed?.response?.responseCode < 400 && !parsed?.commonProperties?.responseFlags) {

--- a/test/e2e/e2e-test/docker/log/lal.yaml
+++ b/test/e2e/e2e-test/docker/log/lal.yaml
@@ -18,6 +18,7 @@ rules:
     dsl: |
       filter {
         text {
+          abortOnFailure false // for test purpose, we want to persist all logs
           regexp $/(?s)(?<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}) \[TID:(?<tid>.+?)] \[(?<thread>.+?)] (?<level>\w{4,}) (?<logger>.{1,36}) (?<msg>.+)/$
         }
         extractor {


### PR DESCRIPTION
The `json` / `yaml` parsers will benefit from option `abortOnFailure` in usage:

```groovy
json {
  abortOnFailure true
  // ... we will have other options here
}
```

instead of (imaginary, not implemented actually)

```groovy
if (!json({
  // ... we will have other options here
})) {
  abort {}
}
```

> P.S. 8.5.0 is the first version introducing LAL so I didn't update the change log file about this enhancement.