### PR TITLE
Remove unnecessary check for getSkyWalkingDynamicField invocation

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/CallbackConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/main/java/org/apache/skywalking/apm/plugin/kafka/CallbackConstructorInterceptor.java
@@ -30,12 +30,7 @@ public class CallbackConstructorInterceptor implements InstanceConstructorInterc
     @Override
     public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
         Callback callback = (Callback) allArguments[0];
-        CallbackCache cache;
-        if (null != objInst.getSkyWalkingDynamicField()) {
-            cache = (CallbackCache) objInst.getSkyWalkingDynamicField();
-        } else {
-            cache = new CallbackCache();
-        }
+        CallbackCache cache = new CallbackCache();
         cache.setCallback(callback);
         objInst.setSkyWalkingDynamicField(cache);
     }


### PR DESCRIPTION
For the details on how this PR works, refer to #6456.

My test env setup:

- kafka_2.13-2.7.0 server
- spring-kafka-2.2.6.RELEASE
- patched apm-kafka-plugin-8.5.0-SNAPSHOT.jar with skywalking 8.4.0

I have checked the following Kafka usages:

- `KafkaProducer.send(record)`
- `KafkaProducer.send(record, callback)`
- `KafkaTemplate.send(topic, data)`
- `KafkaTemplate.execute(callback)` such as
```java
kafkaTemplate.execute(
    (Producer<String, String> producer) -> {
      producer.send(
          new ProducerRecord<>(topic, data),
          (RecordMetadata metadata, Exception e) -> {
            // ...
          });
      return 0;
    });
```

In all the above usages, `objInst.getSkyWalkingDynamicField()` is `null`.

@zifeihan 
