### PR TITLE
Support config `agent.span_limit_per_segment` can be changed in the runtime.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Release Notes.
 * Fix apm-dubbo-2.7.x-plugin memory leak due to some Dubbo RpcExceptions.
 * Fix lettuce-5.x-plugin get null host in redis sentinel mode.
 * Fix ClassCastException by making CallbackAdapterInterceptor to implement EnhancedInstance interface in the spring-kafka plugin.
+* Support config `agent.span_limit_per_segment` can be changed in the runtime.
 
 #### OAP-Backend
 * Allow user-defined `JAVA_OPTS` in the startup script.

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/dynamic/watcher/SamplingRateWatcher.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/dynamic/watcher/SamplingRateWatcher.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.agent.core.conf.dynamic.watcher;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.skywalking.apm.agent.core.conf.Config;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+import org.apache.skywalking.apm.agent.core.sampling.SamplingService;
+
+public class SamplingRateWatcher extends AgentConfigChangeWatcher {
+    private static final ILog LOGGER = LogManager.getLogger(SamplingRateWatcher.class);
+
+    private final AtomicInteger samplingRate;
+    private final SamplingService samplingService;
+
+    public SamplingRateWatcher(final String propertyKey, SamplingService samplingService) {
+        super(propertyKey);
+        this.samplingRate = new AtomicInteger(getDefaultValue());
+        this.samplingService = samplingService;
+    }
+
+    private void activeSetting(String config) {
+        if (LOGGER.isDebugEnable()) {
+            LOGGER.debug("Updating using new static config: {}", config);
+        }
+        try {
+            this.samplingRate.set(Integer.parseInt(config));
+
+            /*
+             * We need to notify samplingService the samplingRate changed.
+             */
+            samplingService.handleSamplingRateChanged();
+        } catch (NumberFormatException ex) {
+            LOGGER.error(ex, "Cannot load {} from: {}", getPropertyKey(), config);
+        }
+    }
+
+    @Override
+    public void notify(final ConfigChangeEvent value) {
+        if (EventType.DELETE.equals(value.getEventType())) {
+            activeSetting(String.valueOf(getDefaultValue()));
+        } else {
+            activeSetting(value.getNewValue());
+        }
+    }
+
+    @Override
+    public String value() {
+        return String.valueOf(samplingRate.get());
+    }
+
+    private int getDefaultValue() {
+        return Config.Agent.SAMPLE_N_PER_3_SECS;
+    }
+
+    public int getSamplingRate() {
+        return samplingRate.get();
+    }
+}

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManagerExtendService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManagerExtendService.java
@@ -53,11 +53,12 @@ public class ContextManagerExtendService implements BootService, GRPCChannelList
         ignoreSuffixArray = Config.Agent.IGNORE_SUFFIX.split(",");
         ignoreSuffixPatternsWatcher = new IgnoreSuffixPatternsWatcher("agent.ignore_suffix", this);
         spanLimitWatcher = new SpanLimitWatcher("agent.span_limit_per_segment");
-        ServiceManager.INSTANCE.findService(ConfigurationDiscoveryService.class)
-                               .registerAgentConfigChangeWatcher(spanLimitWatcher);
 
-        ServiceManager.INSTANCE.findService(ConfigurationDiscoveryService.class)
-                               .registerAgentConfigChangeWatcher(ignoreSuffixPatternsWatcher);
+        ConfigurationDiscoveryService configurationDiscoveryService = ServiceManager.INSTANCE.findService(
+            ConfigurationDiscoveryService.class);
+        configurationDiscoveryService.registerAgentConfigChangeWatcher(spanLimitWatcher);
+        configurationDiscoveryService.registerAgentConfigChangeWatcher(ignoreSuffixPatternsWatcher);
+
         handleIgnoreSuffixPatternsChanged();
     }
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManagerExtendService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManagerExtendService.java
@@ -25,6 +25,7 @@ import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.Config;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.ConfigurationDiscoveryService;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.IgnoreSuffixPatternsWatcher;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.SpanLimitWatcher;
 import org.apache.skywalking.apm.agent.core.remote.GRPCChannelListener;
 import org.apache.skywalking.apm.agent.core.remote.GRPCChannelManager;
 import org.apache.skywalking.apm.agent.core.remote.GRPCChannelStatus;
@@ -40,6 +41,8 @@ public class ContextManagerExtendService implements BootService, GRPCChannelList
 
     private IgnoreSuffixPatternsWatcher ignoreSuffixPatternsWatcher;
 
+    private SpanLimitWatcher spanLimitWatcher;
+
     @Override
     public void prepare() {
         ServiceManager.INSTANCE.findService(GRPCChannelManager.class).addChannelListener(this);
@@ -49,6 +52,10 @@ public class ContextManagerExtendService implements BootService, GRPCChannelList
     public void boot() {
         ignoreSuffixArray = Config.Agent.IGNORE_SUFFIX.split(",");
         ignoreSuffixPatternsWatcher = new IgnoreSuffixPatternsWatcher("agent.ignore_suffix", this);
+        spanLimitWatcher = new SpanLimitWatcher("agent.span_limit_per_segment");
+        ServiceManager.INSTANCE.findService(ConfigurationDiscoveryService.class)
+                               .registerAgentConfigChangeWatcher(spanLimitWatcher);
+
         ServiceManager.INSTANCE.findService(ConfigurationDiscoveryService.class)
                                .registerAgentConfigChangeWatcher(ignoreSuffixPatternsWatcher);
         handleIgnoreSuffixPatternsChanged();
@@ -80,7 +87,7 @@ public class ContextManagerExtendService implements BootService, GRPCChannelList
         } else {
             SamplingService samplingService = ServiceManager.INSTANCE.findService(SamplingService.class);
             if (forceSampling || samplingService.trySampling(operationName)) {
-                context = new TracingContext(operationName);
+                context = new TracingContext(operationName, spanLimitWatcher);
             } else {
                 context = new IgnoredTracerContext();
             }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManagerExtendService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/ContextManagerExtendService.java
@@ -24,6 +24,7 @@ import org.apache.skywalking.apm.agent.core.boot.DefaultImplementor;
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.Config;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.ConfigurationDiscoveryService;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.IgnoreSuffixPatternsWatcher;
 import org.apache.skywalking.apm.agent.core.remote.GRPCChannelListener;
 import org.apache.skywalking.apm.agent.core.remote.GRPCChannelManager;
 import org.apache.skywalking.apm.agent.core.remote.GRPCChannelStatus;
@@ -93,7 +94,7 @@ public class ContextManagerExtendService implements BootService, GRPCChannelList
         this.status = status;
     }
 
-    void handleIgnoreSuffixPatternsChanged() {
+    public void handleIgnoreSuffixPatternsChanged() {
         if (StringUtil.isNotBlank(ignoreSuffixPatternsWatcher.getIgnoreSuffixPatterns())) {
             ignoreSuffixArray = ignoreSuffixPatternsWatcher.getIgnoreSuffixPatterns().split(",");
         }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -26,6 +26,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.Config;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.ConfigurationDiscoveryService;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.SpanLimitWatcher;
 import org.apache.skywalking.apm.agent.core.context.ids.DistributedTraceId;
 import org.apache.skywalking.apm.agent.core.context.ids.PropagatedTraceId;
@@ -134,6 +135,8 @@ public class TracingContext implements AbstractTracerContext {
         this.correlationContext = new CorrelationContext();
         this.extensionContext = new ExtensionContext();
         this.spanLimitWatcher = new SpanLimitWatcher("agent.span_limit_per_segment");
+        ServiceManager.INSTANCE.findService(ConfigurationDiscoveryService.class)
+                               .registerAgentConfigChangeWatcher(spanLimitWatcher);
     }
 
     /**

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -26,7 +26,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.Config;
-import org.apache.skywalking.apm.agent.core.conf.dynamic.ConfigurationDiscoveryService;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.SpanLimitWatcher;
 import org.apache.skywalking.apm.agent.core.context.ids.DistributedTraceId;
 import org.apache.skywalking.apm.agent.core.context.ids.PropagatedTraceId;
@@ -118,7 +117,7 @@ public class TracingContext implements AbstractTracerContext {
     /**
      * Initialize all fields with default value.
      */
-    TracingContext(String firstOPName) {
+    TracingContext(String firstOPName, SpanLimitWatcher spanLimitWatcher) {
         this.segment = new TraceSegment();
         this.spanIdGenerator = 0;
         isRunningInAsyncMode = false;
@@ -134,9 +133,7 @@ public class TracingContext implements AbstractTracerContext {
 
         this.correlationContext = new CorrelationContext();
         this.extensionContext = new ExtensionContext();
-        this.spanLimitWatcher = new SpanLimitWatcher("agent.span_limit_per_segment");
-        ServiceManager.INSTANCE.findService(ConfigurationDiscoveryService.class)
-                               .registerAgentConfigChangeWatcher(spanLimitWatcher);
+        this.spanLimitWatcher = spanLimitWatcher;
     }
 
     /**

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/sampling/SamplingService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/sampling/SamplingService.java
@@ -29,6 +29,7 @@ import org.apache.skywalking.apm.agent.core.boot.DefaultNamedThreadFactory;
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.Config;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.ConfigurationDiscoveryService;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.SamplingRateWatcher;
 import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
 import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
@@ -109,7 +110,7 @@ public class SamplingService implements BootService {
     /**
      * Handle the samplingRate changed.
      */
-    void handleSamplingRateChanged() {
+    public void handleSamplingRateChanged() {
         if (samplingRateWatcher.getSamplingRate() > 0) {
             if (!on) {
                 on = true;

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/conf/watcher/IgnoreSuffixPatternsWatcherTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/conf/watcher/IgnoreSuffixPatternsWatcherTest.java
@@ -16,10 +16,12 @@
  *
  */
 
-package org.apache.skywalking.apm.agent.core.sampling;
+package org.apache.skywalking.apm.agent.core.conf.watcher;
 
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.IgnoreSuffixPatternsWatcher;
+import org.apache.skywalking.apm.agent.core.context.ContextManagerExtendService;
 import org.apache.skywalking.apm.agent.core.test.tools.AgentServiceRule;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -28,16 +30,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
-public class SamplingRateWatcherTest {
+public class IgnoreSuffixPatternsWatcherTest {
 
     @Rule
     public AgentServiceRule agentServiceRule = new AgentServiceRule();
 
-    private SamplingService samplingService;
+    private ContextManagerExtendService contextManagerExtendService;
 
     @Before
     public void setUp() {
-        samplingService = ServiceManager.INSTANCE.findService(SamplingService.class);
+        contextManagerExtendService = ServiceManager.INSTANCE.findService(ContextManagerExtendService.class);
     }
 
     @AfterClass
@@ -47,24 +49,24 @@ public class SamplingRateWatcherTest {
 
     @Test
     public void testConfigModifyEvent() {
-        SamplingRateWatcher samplingRateWatcher = Whitebox.getInternalState(
-            samplingService, "samplingRateWatcher");
-        samplingRateWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
-            "10",
+        IgnoreSuffixPatternsWatcher ignoreSuffixPatternsWatcher = Whitebox.getInternalState(contextManagerExtendService
+            , "ignoreSuffixPatternsWatcher");
+        ignoreSuffixPatternsWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
+            ".txt,.log",
             AgentConfigChangeWatcher.EventType.MODIFY
         ));
-        Assert.assertEquals(10, samplingRateWatcher.getSamplingRate());
-        Assert.assertEquals("agent.sample_n_per_3_secs", samplingRateWatcher.getPropertyKey());
+        Assert.assertEquals(".txt,.log", ignoreSuffixPatternsWatcher.getIgnoreSuffixPatterns());
+        Assert.assertEquals("agent.ignore_suffix", ignoreSuffixPatternsWatcher.getPropertyKey());
     }
 
     @Test
     public void testConfigDeleteEvent() {
-        SamplingRateWatcher samplingRateWatcher = Whitebox.getInternalState(
-            samplingService, "samplingRateWatcher");
-        samplingRateWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
+        IgnoreSuffixPatternsWatcher ignoreSuffixPatternsWatcher = Whitebox.getInternalState(contextManagerExtendService
+            , "ignoreSuffixPatternsWatcher");
+        ignoreSuffixPatternsWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
             null,
             AgentConfigChangeWatcher.EventType.DELETE
         ));
-        Assert.assertEquals("agent.sample_n_per_3_secs", samplingRateWatcher.getPropertyKey());
+        Assert.assertEquals("agent.ignore_suffix", ignoreSuffixPatternsWatcher.getPropertyKey());
     }
 }

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/conf/watcher/SamplingRateWatcherTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/conf/watcher/SamplingRateWatcherTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.agent.core.conf.watcher;
+
+import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.SamplingRateWatcher;
+import org.apache.skywalking.apm.agent.core.sampling.SamplingService;
+import org.apache.skywalking.apm.agent.core.test.tools.AgentServiceRule;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+public class SamplingRateWatcherTest {
+
+    @Rule
+    public AgentServiceRule agentServiceRule = new AgentServiceRule();
+
+    private SamplingService samplingService;
+
+    @Before
+    public void setUp() {
+        samplingService = ServiceManager.INSTANCE.findService(SamplingService.class);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        ServiceManager.INSTANCE.shutdown();
+    }
+
+    @Test
+    public void testConfigModifyEvent() {
+        SamplingRateWatcher samplingRateWatcher = Whitebox.getInternalState(
+            samplingService, "samplingRateWatcher");
+        samplingRateWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
+            "10",
+            AgentConfigChangeWatcher.EventType.MODIFY
+        ));
+        Assert.assertEquals(10, samplingRateWatcher.getSamplingRate());
+        Assert.assertEquals("agent.sample_n_per_3_secs", samplingRateWatcher.getPropertyKey());
+    }
+
+    @Test
+    public void testConfigDeleteEvent() {
+        SamplingRateWatcher samplingRateWatcher = Whitebox.getInternalState(
+            samplingService, "samplingRateWatcher");
+        samplingRateWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
+            null,
+            AgentConfigChangeWatcher.EventType.DELETE
+        ));
+        Assert.assertEquals("agent.sample_n_per_3_secs", samplingRateWatcher.getPropertyKey());
+    }
+}

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/conf/watcher/SpanLimitWatcherTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/conf/watcher/SpanLimitWatcherTest.java
@@ -16,28 +16,27 @@
  *
  */
 
-package org.apache.skywalking.apm.agent.core.context;
+package org.apache.skywalking.apm.agent.core.conf.watcher;
 
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.dynamic.AgentConfigChangeWatcher;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.SpanLimitWatcher;
 import org.apache.skywalking.apm.agent.core.test.tools.AgentServiceRule;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.powermock.reflect.Whitebox;
 
-public class IgnoreSuffixPatternsWatcherTest {
+public class SpanLimitWatcherTest {
 
     @Rule
     public AgentServiceRule agentServiceRule = new AgentServiceRule();
 
-    private ContextManagerExtendService contextManagerExtendService;
+    private final SpanLimitWatcher spanLimitWatcher = new SpanLimitWatcher("agent.span_limit_per_segment");
 
     @Before
     public void setUp() {
-        contextManagerExtendService = ServiceManager.INSTANCE.findService(ContextManagerExtendService.class);
     }
 
     @AfterClass
@@ -47,24 +46,20 @@ public class IgnoreSuffixPatternsWatcherTest {
 
     @Test
     public void testConfigModifyEvent() {
-        IgnoreSuffixPatternsWatcher ignoreSuffixPatternsWatcher = Whitebox.getInternalState(contextManagerExtendService
-            , "ignoreSuffixPatternsWatcher");
-        ignoreSuffixPatternsWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
-            ".txt,.log",
+        spanLimitWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
+            "400",
             AgentConfigChangeWatcher.EventType.MODIFY
         ));
-        Assert.assertEquals(".txt,.log", ignoreSuffixPatternsWatcher.getIgnoreSuffixPatterns());
-        Assert.assertEquals("agent.ignore_suffix", ignoreSuffixPatternsWatcher.getPropertyKey());
+        Assert.assertEquals(400, spanLimitWatcher.getSpanLimit());
+        Assert.assertEquals("agent.span_limit_per_segment", spanLimitWatcher.getPropertyKey());
     }
 
     @Test
     public void testConfigDeleteEvent() {
-        IgnoreSuffixPatternsWatcher ignoreSuffixPatternsWatcher = Whitebox.getInternalState(contextManagerExtendService
-            , "ignoreSuffixPatternsWatcher");
-        ignoreSuffixPatternsWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
+        spanLimitWatcher.notify(new AgentConfigChangeWatcher.ConfigChangeEvent(
             null,
             AgentConfigChangeWatcher.EventType.DELETE
         ));
-        Assert.assertEquals("agent.ignore_suffix", ignoreSuffixPatternsWatcher.getPropertyKey());
+        Assert.assertEquals("agent.span_limit_per_segment", spanLimitWatcher.getPropertyKey());
     }
 }

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/TracingContextTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/context/TracingContextTest.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.apm.agent.core.context;
 
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.Config;
+import org.apache.skywalking.apm.agent.core.conf.dynamic.watcher.SpanLimitWatcher;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
 import org.apache.skywalking.apm.agent.core.test.tools.AgentServiceRule;
@@ -32,6 +33,8 @@ import org.junit.Test;
 public class TracingContextTest {
     @Rule
     public AgentServiceRule serviceRule = new AgentServiceRule();
+
+    private final SpanLimitWatcher spanLimitWatcher = new SpanLimitWatcher("agent.span_limit_per_segment");
 
     @BeforeClass
     public static void beforeClass() {
@@ -55,7 +58,7 @@ public class TracingContextTest {
         };
         TracingContext.ListenerManager.add(listener);
         try {
-            TracingContext tracingContext = new TracingContext("/url");
+            TracingContext tracingContext = new TracingContext("/url", spanLimitWatcher);
             AbstractSpan span = tracingContext.createEntrySpan("/url");
 
             for (int i = 0; i < 10; i++) {

--- a/docs/en/setup/service-agent/java-agent/configuration-discovery.md
+++ b/docs/en/setup/service-agent/java-agent/configuration-discovery.md
@@ -27,6 +27,6 @@ Java agent supports the following dynamic configurations.
 | agent.sample_n_per_3_secs |          The number of sampled traces per 3 seconds          |          -1           | - |
 | agent.ignore_suffix       |          If the operation name of the first span is included in this set, this segment should be ignored. Multiple values should be separated by `,`        |          `.txt,.log`         | - |
 | agent.trace.ignore_path   |          The value is the path that you need to ignore, multiple paths should be separated by `,` [more details](./agent-optional-plugins/trace-ignore-plugin.md)         |          `/your/path/1/**,/your/path/2/**`         | `apm-trace-ignore-plugin` |
-| agent.span_limit_per_segment   |           The max number of span per segment.        |         `300`        | - |
+| agent.span_limit_per_segment   |           The max number of spans per segment.        |         `300`        | - |
 
 * `Required plugin(s)`, the configuration affects only when the required plugins activated.

--- a/docs/en/setup/service-agent/java-agent/configuration-discovery.md
+++ b/docs/en/setup/service-agent/java-agent/configuration-discovery.md
@@ -27,5 +27,6 @@ Java agent supports the following dynamic configurations.
 | agent.sample_n_per_3_secs |          The number of sampled traces per 3 seconds          |          -1           | - |
 | agent.ignore_suffix       |          If the operation name of the first span is included in this set, this segment should be ignored. Multiple values should be separated by `,`        |          `.txt,.log`         | - |
 | agent.trace.ignore_path   |          The value is the path that you need to ignore, multiple paths should be separated by `,` [more details](./agent-optional-plugins/trace-ignore-plugin.md)         |          `/your/path/1/**,/your/path/2/**`         | `apm-trace-ignore-plugin` |
+| agent.span_limit_per_segment   |           The max number of span per segment.        |         `300`        | - |
 
 * `Required plugin(s)`, the configuration affects only when the required plugins activated.


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

### Support config `agent.span_limit_per_segment` can be changed in the runtime.
- [x] Tests(including UT, IT, E2E) are added to verify the new feature.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
