### PR TITLE
Add test cases for kafka-plugin

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/test/java/org/apache/skywalking/apm/plugin/kafka/CallbackInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/src/test/java/org/apache/skywalking/apm/plugin/kafka/CallbackInterceptorTest.java
@@ -152,6 +152,15 @@ public class CallbackInterceptorTest {
         cache.setCallback(callbackAdapterInterceptor);
         EnhancedInstance instance = new CallbackInstance(cache);
         callbackInterceptor.beforeMethod(instance, null, arguments, argumentTypes, null);
+        callbackInterceptor.afterMethod(instance, null, arguments, argumentTypes, null);
+    }
+
+    @Test
+    public void testCallbackWithNullCallbackCache() throws Throwable {
+        EnhancedInstance instance = new CallbackInstance(null);
+        callbackInterceptor.beforeMethod(instance, null, arguments, argumentTypes, null);
+        callbackInterceptor.afterMethod(instance, null, arguments, argumentTypes, null);
+        callbackInterceptor.handleMethodException(instance, null, arguments, argumentTypes, null);
     }
 
     private void assertCallbackSpanWithException(AbstractTracingSpan span) {

--- a/test/plugin/scenarios/kafka-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/kafka-scenario/config/expectedData.yaml
@@ -89,6 +89,21 @@ segmentItems:
         - {key: mq.broker, value: 'kafka-server:9092'}
         - {key: mq.topic, value: test2}
       skipAnalysis: 'false'
+    - operationName: Kafka/test2/Producer
+      operationId: 0
+      parentSpanId: 0
+      spanId: 3
+      spanLayer: MQ
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 40
+      isError: false
+      spanType: Exit
+      peer: kafka-server:9092
+      tags:
+        - {key: mq.broker, value: 'kafka-server:9092'}
+        - {key: mq.topic, value: test2}
+      skipAnalysis: 'false'
     - operationName: /case/kafka-case
       operationId: 0
       parentSpanId: -1
@@ -158,9 +173,13 @@ segmentItems:
           - {key: mq.broker, value: 'kafka-server:9092'}
           - {key: mq.topic, value: test.}
           - {key: transmission.latency, value: not null}
+          - {key: transmission.latency, value: not null}
         refs:
           - {parentEndpoint: /case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
              parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
+                                                                null, parentService: 'kafka-scenario', traceId: not null}
+          - {parentEndpoint: /case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
+             parentSpanId: 3, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                 null, parentService: 'kafka-scenario', traceId: not null}
         skipAnalysis: 'false'
   - segmentId: not null


### PR DESCRIPTION
1. Add plugin test for KafkaProducer.send(record).

Since an exception in CallbackInterceptor can't be checked by a plugin test. The new test does not check exceptions thrown by  CallbackInterceptor. But the test does cover more KafkaProducer usages.

2. Add exception checking test cases for CallbackInterceptor.

These unit test cases check exceptions thrown by CallbackInterceptor.

See #6481.

@zifeihan 
