### PR TITLE
Fix dead link and wrong link

### DIFF
--- a/docs/en/setup/service-agent/java-agent/Supported-list.md
+++ b/docs/en/setup/service-agent/java-agent/Supported-list.md
@@ -78,8 +78,8 @@ metrics based on the tracing data.
     * [transport-client](https://github.com/elastic/elasticsearch/tree/v6.7.1/client/transport) 6.7.1-6.8.4
     * [rest-high-level-client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/6.7/index.html) 6.7.1-6.8.4
     * [rest-high-level-client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.0/java-rest-high.html) 7.0.0-7.5.2
-  * [Solr](https://github.com/apache/lucene-solr/)
-    * [SolrJ](https://github.com/apache/lucene-solr/tree/master/solr/solrj) 7.x
+  * [Solr](https://github.com/apache/solr/)
+    * [SolrJ](https://github.com/apache/solr/tree/main/solr/solrj) 7.x
   * [Cassandra](https://github.com/apache/cassandra) 3.x
     * [cassandra-java-driver](https://github.com/datastax/java-driver) 3.7.0-3.7.2
   * HBase


### PR DESCRIPTION
Solr has now been a TLP of Apache and has its own repo, https://github.com/apache/lucene-solr/tree/master/solr/solrj is unavailable now