### PR TITLE
Add functions in MAL to filter metrics according to the metric value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,7 +53,7 @@ Release Notes.
 * Fix receiver don't need to get itself when healthCheck
 * Remove group concept from AvgHistogramFunction. Heatmap(function result) doesn't support labels.
 * Support metrics grouped by scope labelValue in MAL, no need global same labelValue as before.
-
+* Add functions in MAL to filter metrics according to the metric value.
 #### UI
 * Update selector scroller to show in all pages.
 * Implement searching logs with date.

--- a/docs/en/concepts-and-designs/mal.md
+++ b/docs/en/concepts-and-designs/mal.md
@@ -41,6 +41,22 @@ For example, this filters all instance_trace_count samples for us-west and asia-
 ```
 instance_trace_count.tagMatch("region", "us-west|asia-north").tagEqual("az", "az-1")
 ```
+### Value filter
+
+MAL support six type operations to filter samples in a sample family by value:
+
+- valueEqual: Filter values that are exactly equal to the provided value.
+- valueNotEqual: Filter values that are not equal to the provided value.
+- valueGreater: Filter values that greater than the provided value.
+- valueGreaterEqual: Filter values that greater or equal the provided value.
+- valueLess: Filter values that less than the provided value.
+- valueLessEqual: Filter values that less or equal the provided value.
+
+For example, this filters all instance_trace_count samples for values >= 33:
+
+```
+instance_trace_count.valueGreaterEqual(33)
+```
 
 ### Binary operators
 

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AtomicDouble;
 import groovy.lang.Closure;
 import io.vavr.Function2;
+import io.vavr.Function3;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -99,6 +100,31 @@ public class SampleFamily {
 
     public SampleFamily tagNotMatch(String[] labels) {
         return match(labels, (sv, lv) -> !sv.matches(lv));
+    }
+
+    /* value filter operations*/
+    public SampleFamily valueEqual(double compValue) {
+        return valueMatch(CompType.EQUAL, compValue, InternalOps::valueComp);
+    }
+
+    public SampleFamily valueNotEqual(double compValue) {
+        return valueMatch(CompType.NOT_EQUAL, compValue, InternalOps::valueComp);
+    }
+
+    public SampleFamily valueGreater(double compValue) {
+        return valueMatch(CompType.GREATER, compValue, InternalOps::valueComp);
+    }
+
+    public SampleFamily valueGreaterEqual(double compValue) {
+        return valueMatch(CompType.GREATER_EQUAL, compValue, InternalOps::valueComp);
+    }
+
+    public SampleFamily valueLess(double compValue) {
+        return valueMatch(CompType.LESS, compValue, InternalOps::valueComp);
+    }
+
+    public SampleFamily valueLessEqual(double compValue) {
+        return valueMatch(CompType.LESS_EQUAL, compValue, InternalOps::valueComp);
     }
 
     /* Binary operator overloading*/
@@ -401,6 +427,14 @@ public class SampleFamily {
         return ss.length > 0 ? SampleFamily.build(this.context, ss) : EMPTY;
     }
 
+    private SampleFamily valueMatch(CompType compType,
+                                    double compValue,
+                                    Function3<CompType, Double, Double, Boolean> op) {
+        Sample[] ss = Arrays.stream(samples)
+                            .filter(sample -> op.apply(compType, sample.value, compValue)).toArray(Sample[]::new);
+        return ss.length > 0 ? SampleFamily.build(this.context, ss) : EMPTY;
+    }
+
     SampleFamily newValue(Function<Double, Double> transform) {
         if (this == EMPTY) {
             return EMPTY;
@@ -509,6 +543,26 @@ public class SampleFamily {
             return a.equals(b);
         }
 
+        private static boolean valueComp(CompType compType, double a, double b) {
+            int result = Double.compare(a, b);
+            switch (compType) {
+                case EQUAL:
+                    return result == 0 ? true : false;
+                case NOT_EQUAL:
+                    return result != 0 ? true : false;
+                case GREATER:
+                    return result == 1 ? true : false;
+                case GREATER_EQUAL:
+                    return (result == 0 || result == 1) ? true : false;
+                case LESS:
+                    return result == -1 ? true : false;
+                case LESS_EQUAL:
+                    return (result == 0 || result == -1) ? true : false;
+            }
+
+            return false;
+        }
+
         private static ImmutableMap<String, String> getLabels(final List<String> labelKeys, final Sample sample) {
             return labelKeys.stream()
                             .collect(toImmutableMap(
@@ -516,5 +570,9 @@ public class SampleFamily {
                                 labelKey -> sample.labels.getOrDefault(labelKey, "")
                             ));
         }
+    }
+
+    private enum CompType {
+        EQUAL, NOT_EQUAL, LESS, LESS_EQUAL, GREATER, GREATER_EQUAL
     }
 }

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
@@ -104,27 +104,27 @@ public class SampleFamily {
 
     /* value filter operations*/
     public SampleFamily valueEqual(double compValue) {
-        return valueMatch(CompType.EQUAL, compValue, InternalOps::valueComp);
+        return valueMatch(CompType.EQUAL, compValue, InternalOps::doubleComp);
     }
 
     public SampleFamily valueNotEqual(double compValue) {
-        return valueMatch(CompType.NOT_EQUAL, compValue, InternalOps::valueComp);
+        return valueMatch(CompType.NOT_EQUAL, compValue, InternalOps::doubleComp);
     }
 
     public SampleFamily valueGreater(double compValue) {
-        return valueMatch(CompType.GREATER, compValue, InternalOps::valueComp);
+        return valueMatch(CompType.GREATER, compValue, InternalOps::doubleComp);
     }
 
     public SampleFamily valueGreaterEqual(double compValue) {
-        return valueMatch(CompType.GREATER_EQUAL, compValue, InternalOps::valueComp);
+        return valueMatch(CompType.GREATER_EQUAL, compValue, InternalOps::doubleComp);
     }
 
     public SampleFamily valueLess(double compValue) {
-        return valueMatch(CompType.LESS, compValue, InternalOps::valueComp);
+        return valueMatch(CompType.LESS, compValue, InternalOps::doubleComp);
     }
 
     public SampleFamily valueLessEqual(double compValue) {
-        return valueMatch(CompType.LESS_EQUAL, compValue, InternalOps::valueComp);
+        return valueMatch(CompType.LESS_EQUAL, compValue, InternalOps::doubleComp);
     }
 
     /* Binary operator overloading*/
@@ -543,21 +543,21 @@ public class SampleFamily {
             return a.equals(b);
         }
 
-        private static boolean valueComp(CompType compType, double a, double b) {
+        private static boolean doubleComp(CompType compType, double a, double b) {
             int result = Double.compare(a, b);
             switch (compType) {
                 case EQUAL:
-                    return result == 0 ? true : false;
+                    return result == 0;
                 case NOT_EQUAL:
-                    return result != 0 ? true : false;
+                    return result != 0;
                 case GREATER:
-                    return result == 1 ? true : false;
+                    return result == 1;
                 case GREATER_EQUAL:
-                    return (result == 0 || result == 1) ? true : false;
+                    return result == 0 || result == 1;
                 case LESS:
-                    return result == -1 ? true : false;
+                    return result == -1;
                 case LESS_EQUAL:
-                    return (result == 0 || result == -1) ? true : false;
+                    return result == 0 || result == -1;
             }
 
             return false;

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ValueFilterTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ValueFilterTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.meter.analyzer.dsl;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collection;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+@Slf4j
+@RunWith(Parameterized.class)
+public class ValueFilterTest {
+
+    @Parameterized.Parameter
+    public String name;
+
+    @Parameterized.Parameter(1)
+    public ImmutableMap<String, SampleFamily> input;
+
+    @Parameterized.Parameter(2)
+    public String expression;
+
+    @Parameterized.Parameter(3)
+    public Result want;
+
+    @Parameterized.Parameter(4)
+    public boolean isThrow;
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {
+                "valueEqual",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                "http_success_request.valueEqual(1)",
+                Result.success(SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                false,
+                },
+            {
+                "valueNotEqual",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                "http_success_request.valueNotEqual(1)",
+                Result.success(SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build()
+                ).build()),
+                false,
+                },
+            {
+                "valueGreater",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                "http_success_request.valueGreater(1)",
+                Result.success(SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build()
+                ).build()),
+                false,
+                },
+            {
+                "valueGreaterEqual",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                "http_success_request.valueGreaterEqual(1)",
+                Result.success(SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                false,
+                },
+            {
+                "valueLessEqual",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                "http_success_request.valueLess(2)",
+                Result.success(SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                false,
+                },
+            {
+                "valueLessEqual",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                "http_success_request.valueLessEqual(2)",
+                Result.success(SampleFamilyBuilder.newBuilder(
+                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                ).build()),
+                false,
+                },
+            });
+    }
+
+    @Test
+    public void test() {
+        Expression e = DSL.parse(expression);
+        Result r = null;
+        try {
+            r = e.run(input);
+        } catch (Throwable t) {
+            if (isThrow) {
+                return;
+            }
+            log.error("Test failed", t);
+            fail("Should not throw anything");
+        }
+        if (isThrow) {
+            fail("Should throw something");
+        }
+        assertThat(r, is(want));
+    }
+}

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ValueFilterTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ValueFilterTest.java
@@ -110,7 +110,7 @@ public class ValueFilterTest {
                 false,
                 },
             {
-                "valueLessEqual",
+                "valueLess",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
                     Sample.builder().labels(of("idc", "t1")).value(2).build(),
                     Sample.builder().labels(of("idc", "t2")).value(2).build(),


### PR DESCRIPTION
### Add functions in MAL to filter metrics according to the metric value
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [X] Update the documentation to include this new feature.
- [X] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.

- [X] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #6583.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

Added functions:
- valueEqual: Filter values that are exactly equal to the provided value.
- valueNotEqual: Filter values that are not equal to the provided value.
- valueGreater: Filter values that greater than the provided value.
- valueGreaterEqual: Filter values that greater or equal the provided value.
- valueLess: Filter values that less than the provided value.
- valueLessEqual: Filter values that less or equal the provided value.
