### PR TITLE
Add  arg `namespace` to func `retagByK8sMeta`, rebuild the relationship between pod and service by labels

### DIFF
--- a/docs/en/concepts-and-designs/mal.md
+++ b/docs/en/concepts-and-designs/mal.md
@@ -65,22 +65,22 @@ MAL supports using the metadata of k8s to manipulate the tags and their values.
 This feature requires OAP Server to have the authority to access the K8s's `API Server`.
 
 ##### retagByK8sMeta
-`retagByK8sMeta(newLabelName, K8sRetagType, existingLabelName)`. Add a new tag to the sample family based on an existing label's value. Provide several internal converting types, including
+`retagByK8sMeta(newLabelName, K8sRetagType, existingLabelName, namespaceLabelName)`. Add a new tag to the sample family based on an existing label's value. Provide several internal converting types, including
 - K8sRetagType.Pod2Service  
 
 Add a tag to the sample by using `service` as the key, `$serviceName.$namespace` as the value, by the given value of the tag key, which represents the name of a pod.
 
 For example:
 ```
-container_cpu_usage_seconds_total{container=my-nginx, cpu=total, pod=my-nginx-5dc4865748-mbczh} 2
+container_cpu_usage_seconds_total{namespace=default, container=my-nginx, cpu=total, pod=my-nginx-5dc4865748-mbczh} 2
 ```
 Expression:
 ```
-container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod')
+container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod' , 'namespace')
 ```
 Output:
 ```
-container_cpu_usage_seconds_total{container=my-nginx, cpu=total, pod=my-nginx-5dc4865748-mbczh, service='nginx-service.default'} 2
+container_cpu_usage_seconds_total{namespace=default, container=my-nginx, cpu=total, pod=my-nginx-5dc4865748-mbczh, service='nginx-service.default'} 2
 ```
 
 ### Binary operators

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
@@ -312,7 +312,7 @@ public class SampleFamily {
     }
 
     /* k8s retags*/
-    public SampleFamily retagByK8sMeta(String newLabelName, K8sRetagType type, String existingLabelName) {
+    public SampleFamily retagByK8sMeta(String newLabelName, K8sRetagType type, String existingLabelName, String namespaceLabelName) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(newLabelName));
         Preconditions.checkArgument(!Strings.isNullOrEmpty(existingLabelName));
         ExpressionParsingContext.get().ifPresent(ctx -> ctx.isRetagByK8sMeta = true);
@@ -320,7 +320,7 @@ public class SampleFamily {
             return EMPTY;
         }
 
-        return SampleFamily.build(this.context, type.execute(samples, newLabelName, existingLabelName));
+        return SampleFamily.build(this.context, type.execute(samples, newLabelName, existingLabelName, namespaceLabelName));
     }
 
     public SampleFamily histogram() {

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
@@ -315,6 +315,7 @@ public class SampleFamily {
     public SampleFamily retagByK8sMeta(String newLabelName, K8sRetagType type, String existingLabelName, String namespaceLabelName) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(newLabelName));
         Preconditions.checkArgument(!Strings.isNullOrEmpty(existingLabelName));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(namespaceLabelName));
         ExpressionParsingContext.get().ifPresent(ctx -> ctx.isRetagByK8sMeta = true);
         if (this == EMPTY) {
             return EMPTY;

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/tagOpt/K8sRetagType.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/tagOpt/K8sRetagType.java
@@ -30,12 +30,15 @@ public enum K8sRetagType implements Retag {
 
     Pod2Service {
         @Override
-        public Sample[] execute(final Sample[] ss, final String newLabelName, final String existingLabelName) {
+        public Sample[] execute(final Sample[] ss,
+                                final String newLabelName,
+                                final String existingLabelName,
+                                final String namespaceLabelName) {
             Sample[] samples = Arrays.stream(ss).map(sample -> {
                 String podName = sample.getLabels().get(existingLabelName);
-
-                if (!Strings.isNullOrEmpty(podName)) {
-                    String serviceName = K8sInfoRegistry.getInstance().findServiceName(podName);
+                String namespace = sample.getLabels().get(namespaceLabelName);
+                if (!Strings.isNullOrEmpty(podName) && !Strings.isNullOrEmpty(namespace)) {
+                    String serviceName = K8sInfoRegistry.getInstance().findServiceName(namespace, podName);
                     if (!Strings.isNullOrEmpty(serviceName)) {
                         Map<String, String> labels = Maps.newHashMap(sample.getLabels());
                         labels.put(newLabelName, serviceName);

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/tagOpt/Retag.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/tagOpt/Retag.java
@@ -21,5 +21,5 @@ package org.apache.skywalking.oap.meter.analyzer.dsl.tagOpt;
 import org.apache.skywalking.oap.meter.analyzer.dsl.Sample;
 
 public interface Retag {
-    Sample[] execute(Sample[] ss, String newLabelName, String existingLabelName);
+    Sample[] execute(Sample[] ss, String newLabelName, String existingLabelName, String namespaceLabelName);
 }

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/K8sTagTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/K8sTagTest.java
@@ -19,8 +19,14 @@
 package org.apache.skywalking.oap.meter.analyzer.dsl;
 
 import com.google.common.collect.ImmutableMap;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1Service;
+import io.kubernetes.client.openapi.models.V1ServiceSpec;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.meter.analyzer.k8s.K8sInfoRegistry;
 import org.junit.Before;
@@ -28,13 +34,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.reflect.Whitebox;
 
 import static com.google.common.collect.ImmutableMap.of;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.when;
 
 @Slf4j
 @RunWith(Parameterized.class)
@@ -63,24 +69,28 @@ public class K8sTagTest {
                 of("container_cpu_usage_seconds_total", SampleFamilyBuilder.newBuilder(
                     Sample.builder()
                           .labels(
-                              of("container", "my-nginx", "cpu", "total", "pod", "my-nginx-5dc4865748-mbczh"))
+                              of(
+                                  "namespace", "default", "container", "my-nginx", "cpu", "total", "pod",
+                                  "my-nginx-5dc4865748-mbczh"
+                              ))
                           .value(2)
                           .build(),
                     Sample.builder()
                           .labels(
                               of(
-                                  "container", "kube-state-metrics", "cpu", "total", "pod",
+                                  "namespace", "kube-system", "container", "kube-state-metrics", "cpu", "total", "pod",
                                   "kube-state-metrics-6f979fd498-z7xwx"
                               ))
                           .value(1)
                           .build()
                 ).build()),
-                "container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod')",
+                "container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod' , 'namespace')",
                 Result.success(SampleFamilyBuilder.newBuilder(
                     Sample.builder()
                           .labels(
                               of(
-                                  "container", "my-nginx", "cpu", "total", "pod", "my-nginx-5dc4865748-mbczh",
+                                  "namespace", "default", "container", "my-nginx", "cpu", "total", "pod",
+                                  "my-nginx-5dc4865748-mbczh",
                                   "service", "nginx-service.default"
                               ))
                           .value(2)
@@ -88,7 +98,7 @@ public class K8sTagTest {
                     Sample.builder()
                           .labels(
                               of(
-                                  "container", "kube-state-metrics", "cpu", "total", "pod",
+                                  "namespace", "kube-system", "container", "kube-state-metrics", "cpu", "total", "pod",
                                   "kube-state-metrics-6f979fd498-z7xwx",
                                   "service", "kube-state-metrics.kube-system"
                               ))
@@ -102,31 +112,35 @@ public class K8sTagTest {
                 of("container_cpu_usage_seconds_total", SampleFamilyBuilder.newBuilder(
                     Sample.builder()
                           .labels(
-                              of("container", "my-nginx", "cpu", "total", "pod", "my-nginx-5dc4865748-no-pod"))
+                              of(
+                                  "namespace", "default", "container", "my-nginx", "cpu", "total", "pod",
+                                  "my-nginx-5dc4865748-no-pod"
+                              ))
                           .value(2)
                           .build(),
                     Sample.builder()
                           .labels(
                               of(
-                                  "container", "kube-state-metrics", "cpu", "total", "pod",
+                                  "namespace", "kube-system", "container", "kube-state-metrics", "cpu", "total", "pod",
                                   "kube-state-metrics-6f979fd498-z7xwx"
                               ))
                           .value(1)
                           .build()
                 ).build()),
-                "container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod')",
+                "container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod' , 'namespace')",
                 Result.success(SampleFamilyBuilder.newBuilder(
                     Sample.builder()
                           .labels(
                               of(
-                                  "container", "my-nginx", "cpu", "total", "pod", "my-nginx-5dc4865748-no-pod"
+                                  "namespace", "default", "container", "my-nginx", "cpu", "total", "pod",
+                                  "my-nginx-5dc4865748-no-pod"
                               ))
                           .value(2)
                           .build(),
                     Sample.builder()
                           .labels(
                               of(
-                                  "container", "kube-state-metrics", "cpu", "total", "pod",
+                                  "namespace", "kube-system", "container", "kube-state-metrics", "cpu", "total", "pod",
                                   "kube-state-metrics-6f979fd498-z7xwx",
                                   "service", "kube-state-metrics.kube-system"
                               ))
@@ -140,31 +154,35 @@ public class K8sTagTest {
                 of("container_cpu_usage_seconds_total", SampleFamilyBuilder.newBuilder(
                     Sample.builder()
                           .labels(
-                              of("container", "my-nginx", "cpu", "total", "pod", "my-nginx-5dc4865748-no-service"))
+                              of(
+                                  "namespace", "default", "container", "my-nginx", "cpu", "total", "pod",
+                                  "my-nginx-5dc4865748-no-service"
+                              ))
                           .value(2)
                           .build(),
                     Sample.builder()
                           .labels(
                               of(
-                                  "container", "kube-state-metrics", "cpu", "total", "pod",
+                                  "namespace", "kube-system", "container", "kube-state-metrics", "cpu", "total", "pod",
                                   "kube-state-metrics-6f979fd498-z7xwx"
                               ))
                           .value(1)
                           .build()
                 ).build()),
-                "container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod')",
+                "container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod' , 'namespace')",
                 Result.success(SampleFamilyBuilder.newBuilder(
                     Sample.builder()
                           .labels(
                               of(
-                                  "container", "my-nginx", "cpu", "total", "pod", "my-nginx-5dc4865748-no-service"
+                                  "namespace", "default", "container", "my-nginx", "cpu", "total", "pod",
+                                  "my-nginx-5dc4865748-no-service"
                               ))
                           .value(2)
                           .build(),
                     Sample.builder()
                           .labels(
                               of(
-                                  "container", "kube-state-metrics", "cpu", "total", "pod",
+                                  "namespace", "kube-system", "container", "kube-state-metrics", "cpu", "total", "pod",
                                   "kube-state-metrics-6f979fd498-z7xwx",
                                   "service", "kube-state-metrics.kube-system"
                               ))
@@ -176,19 +194,44 @@ public class K8sTagTest {
             });
     }
 
+    @SneakyThrows
     @Before
     public void setup() {
         Whitebox.setInternalState(K8sInfoRegistry.class, "INSTANCE",
                                   Mockito.spy(K8sInfoRegistry.getInstance())
         );
-        when(K8sInfoRegistry.getInstance().findServiceName("my-nginx-5dc4865748-mbczh")).thenReturn(
-            "nginx-service.default");
-        when(K8sInfoRegistry.getInstance().findServiceName("kube-state-metrics-6f979fd498-z7xwx")).thenReturn(
-            "kube-state-metrics.kube-system");
-        when(K8sInfoRegistry.getInstance().findServiceName("my-nginx-5dc4865748-no-pod")).thenReturn(
-            null);
-        when(K8sInfoRegistry.getInstance().findServiceName("my-nginx-5dc4865748-no-service")).thenReturn(
-            null);
+
+        PowerMockito.when(
+            K8sInfoRegistry.getInstance(), "addService", mockService("nginx-service", "default", of("run", "nginx")))
+                    .thenCallRealMethod();
+        PowerMockito.when(
+            K8sInfoRegistry.getInstance(), "addService",
+            mockService("kube-state-metrics", "kube-system", of("run", "kube-state-metrics"))
+        ).thenCallRealMethod();
+        PowerMockito.when(
+            K8sInfoRegistry.getInstance(), "addPod",
+            mockPod("my-nginx-5dc4865748-mbczh", "default", of("run", "nginx"))
+        ).thenCallRealMethod();
+        PowerMockito.when(
+            K8sInfoRegistry.getInstance(), "addPod",
+            mockPod("kube-state-metrics-6f979fd498-z7xwx", "kube-system", of("run", "kube-state-metrics"))
+        ).thenCallRealMethod();
+
+        PowerMockito.when(
+            K8sInfoRegistry.getInstance(), "removeService", mockService("nginx-service", "default", of("run", "nginx")))
+                    .thenCallRealMethod();
+        PowerMockito.when(
+            K8sInfoRegistry.getInstance(), "removePod",
+            mockPod("my-nginx-5dc4865748-mbczh", "default", of("run", "nginx"))
+        ).thenCallRealMethod();
+        PowerMockito.when(
+            K8sInfoRegistry.getInstance(), "addService", mockService("nginx-service", "default", of("run", "nginx")))
+                    .thenCallRealMethod();
+        PowerMockito.when(
+            K8sInfoRegistry.getInstance(), "addPod",
+            mockPod("my-nginx-5dc4865748-mbczh", "default", of("run", "nginx"))
+        ).thenCallRealMethod();
+
     }
 
     @Test
@@ -208,5 +251,30 @@ public class K8sTagTest {
             fail("Should throw something");
         }
         assertThat(r, is(want));
+    }
+
+    private V1Service mockService(String name, String namespace, Map<String, String> selector) {
+        V1Service service = new V1Service();
+        V1ObjectMeta serviceMeta = new V1ObjectMeta();
+        V1ServiceSpec v1ServiceSpec = new V1ServiceSpec();
+
+        serviceMeta.setName(name);
+        serviceMeta.setNamespace(namespace);
+        service.setMetadata(serviceMeta);
+        v1ServiceSpec.setSelector(selector);
+        service.setSpec(v1ServiceSpec);
+
+        return service;
+    }
+
+    private V1Pod mockPod(String name, String namespace, Map<String, String> labels) {
+        V1Pod v1Pod = new V1Pod();
+        V1ObjectMeta podMeta = new V1ObjectMeta();
+        podMeta.setName(name);
+        podMeta.setNamespace(namespace);
+        podMeta.setLabels(labels);
+        v1Pod.setMetadata(podMeta);
+
+        return v1Pod;
     }
 }


### PR DESCRIPTION
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [X] Update the documentation to include this new feature.
- [X] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

Related to PR #6608
Add argument `namespace`, to avoid the duplicated label value.
Rebuild the relationship between pod and service by labels(selector), since if the pod is not running, we can't get the endpoint IP.
