### PR TITLE
Fix ALS K8SServiceRegistry didn't remove the correct entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ Release Notes.
 * Optimize the self monitoring grafana dashboard.
 * Enhance the export service.
 * Add function `retagByK8sMeta` and opt type `K8sRetagType.Pod2Service` in MAL for k8s to relate pods and services.
+* Fix ALS K8SServiceRegistry didn't remove the correct entry.
 
 #### UI
 * Update selector scroller to show in all pages.

--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/als/k8s/K8SServiceRegistry.java
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/als/k8s/K8SServiceRegistry.java
@@ -209,7 +209,7 @@ public class K8SServiceRegistry {
 
     protected void removeService(final V1Service service) {
         ofNullable(service.getMetadata()).ifPresent(
-            metadata -> idServiceMap.remove(metadata.getUid())
+            metadata -> idServiceMap.remove(metadata.getNamespace() + ":" + metadata.getName())
         );
     }
 


### PR DESCRIPTION
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [X] Explain briefly why the bug exists and how to fix it.

The function `removeService` used an incorrect key to remove the entry.
![image](https://user-images.githubusercontent.com/16773043/113082133-7bd8ca00-920c-11eb-96ae-9c47c30af239.png)

How to fix it:
Use `namesapce:name` as the key.
```java
    protected void removeService(final V1Service service) {
        ofNullable(service.getMetadata()).ifPresent(
            metadata -> idServiceMap.remove(metadata.getNamespace() + ":" + metadata.getName())
        );
    }
```

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
