### PR TITLE
Append the root slash(/) to getIndex and getTemplate requests in ES client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,7 @@ Release Notes.
 * Add function `retagByK8sMeta` and opt type `K8sRetagType.Pod2Service` in MAL for k8s to relate pods and services.
 * Fix ALS K8SServiceRegistry didn't remove the correct entry.
 * Using "service.istio.io/canonical-name" to replace "app" label to resolve Envoy ALS service name
+* Append the root slash(/) to getIndex and getTemplate requests in ES client
 
 #### UI
 * Update selector scroller to show in all pages.

--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
@@ -234,7 +234,7 @@ public class ElasticSearchClient implements Client, HealthCheckable {
         indexName = formatIndexName(indexName);
         try {
             Response response = client.getLowLevelClient()
-                                      .performRequest(HttpGet.METHOD_NAME, indexName);
+                                      .performRequest(HttpGet.METHOD_NAME, "/" + indexName);
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode != HttpStatus.SC_OK) {
                 healthChecker.health();
@@ -341,7 +341,7 @@ public class ElasticSearchClient implements Client, HealthCheckable {
         name = formatIndexName(name);
         try {
             Response response = client.getLowLevelClient()
-                                      .performRequest(HttpGet.METHOD_NAME, "_template/" + name);
+                                      .performRequest(HttpGet.METHOD_NAME, "/_template/" + name);
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode != HttpStatus.SC_OK) {
                 healthChecker.health();


### PR DESCRIPTION
OAP server get below errors when deploying an Envoy proxy in front of ES.

```
org.elasticsearch.client.ResponseException: method [GET], host [http://localhost:9200], URI [_template/skywalking_metrics-histogram], status line [HTTP/1.1 400 Bad Request]
2021-03-31T14:58:32.297233834Z stdout F Bad Request
2021-03-31T14:58:32.297240199Z stdout F 	at org.elasticsearch.client.RestClient$SyncResponseListener.get(RestClient.java:705) ~[elasticsearch-rest-client-6.3.2.jar:6.3.2]
2021-03-31T14:58:32.297245735Z stdout F 	at org.elasticsearch.client.RestClient.performRequest(RestClient.java:235) ~[elasticsearch-rest-client-6.3.2.jar:6.3.2]
2021-03-31T14:58:32.297251358Z stdout F 	at org.elasticsearch.client.RestClient.performRequest(RestClient.java:198) ~[elasticsearch-rest-client-6.3.2.jar:6.3.2]
2021-03-31T14:58:32.297255968Z stdout F 	at org.elasticsearch.client.RestClient.performRequest(RestClient.java:160) ~[elasticsearch-rest-client-6.3.2.jar:6.3.2]
2021-03-31T14:58:32.297261214Z stdout F 	at org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient.getTemplate(ElasticSearchClient.java:344) [library-client-8.4.0.3.jar:8.4.0.3]
2021-03-31T14:58:32.297272969Z stdout F 	at org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.StorageEsInstaller.isExists(StorageEsInstaller.java:75) [storage-elasticsearch-plugin-8.4.0.3.jar:8.4.0.3]
2021-03-31T14:58:32.2972777Z stdout F 	at org.apache.skywalking.oap.server.core.storage.model.ModelInstaller.whenCreating(ModelInstaller.java:41) [server-core-8.4.0.3.jar:8.4.0.3]
```

The absence of the root slash of getIndex and getTemplate requests in es client causes Envoy proxy to think they are bad requests, rasing above errors.

