### PR TITLE
Allow exclusive mode for WitnessMethod

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
@@ -67,7 +67,7 @@ public abstract class AbstractClassEnhancePluginDefine {
         String[] witnessClasses = witnessClasses();
         if (witnessClasses != null) {
             for (String witnessClass : witnessClasses) {
-                if (!finder.exist(witnessClass, classLoader)) {
+                if (!finder.satisfy(witnessClass, classLoader)) {
                     LOGGER.warn("enhance class {} by plugin {} is not working. Because witness class {} is not existed.", transformClassName, interceptorDefineClassName, witnessClass);
                     return null;
                 }
@@ -76,7 +76,7 @@ public abstract class AbstractClassEnhancePluginDefine {
         List<WitnessMethod> witnessMethods = witnessMethods();
         if (!CollectionUtil.isEmpty(witnessMethods)) {
             for (WitnessMethod witnessMethod : witnessMethods) {
-                if (!finder.exist(witnessMethod, classLoader)) {
+                if (!finder.satisfy(witnessMethod, classLoader)) {
                     LOGGER.warn("enhance class {} by plugin {} is not working. Because witness method {} is not existed.", transformClassName, interceptorDefineClassName, witnessMethod);
                     return null;
                 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/WitnessFinder.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/WitnessFinder.java
@@ -36,7 +36,7 @@ public enum WitnessFinder {
      * @param classLoader for finding the witnessClass
      * @return true, if the given witnessClass exists, through the given classLoader.
      */
-    public boolean exist(String witnessClass, ClassLoader classLoader) {
+    public boolean satisfy(String witnessClass, ClassLoader classLoader) {
         return getResolution(witnessClass, classLoader)
                 .isResolved();
     }
@@ -68,7 +68,7 @@ public enum WitnessFinder {
      * and the given witness method does not exist in the exclusive mode
      * through the given classLoader.
      */
-    public boolean exist(WitnessMethod witnessMethod, ClassLoader classLoader) {
+    public boolean satisfy(WitnessMethod witnessMethod, ClassLoader classLoader) {
         TypePool.Resolution resolution = getResolution(witnessMethod.getDeclaringClassName(), classLoader);
         if (!resolution.isResolved()) {
             return false;

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/WitnessFinder.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/WitnessFinder.java
@@ -43,8 +43,9 @@ public enum WitnessFinder {
 
     /**
      * get TypePool.Resolution of the witness class
+     *
      * @param witnessClass class name
-     * @param classLoader classLoader for finding the witnessClass
+     * @param classLoader  classLoader for finding the witnessClass
      * @return TypePool.Resolution
      */
     private TypePool.Resolution getResolution(String witnessClass, ClassLoader classLoader) {
@@ -70,10 +71,17 @@ public enum WitnessFinder {
         if (!resolution.isResolved()) {
             return false;
         }
-        return !resolution.resolve()
+        // i.e. inclusive mode
+        if (!witnessMethod.isExclusiveMode()) {
+            return !resolution.resolve()
+                    .getDeclaredMethods()
+                    .filter(witnessMethod.getElementMatcher())
+                    .isEmpty();
+        }
+        // check with exclusive mode
+        return resolution.resolve()
                 .getDeclaredMethods()
-                .filter(witnessMethod.getElementMatcher())
-                .isEmpty();
+                .filter(witnessMethod.getElementMatcher()).isEmpty();
     }
 
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/WitnessFinder.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/WitnessFinder.java
@@ -64,7 +64,9 @@ public enum WitnessFinder {
 
     /**
      * @param classLoader for finding the witness method
-     * @return true, if the given witness method exists, through the given classLoader.
+     * @return true, if the given witness method exists in inclusive mode
+     * and the given witness method does not exist in the exclusive mode
+     * through the given classLoader.
      */
     public boolean exist(WitnessMethod witnessMethod, ClassLoader classLoader) {
         TypePool.Resolution resolution = getResolution(witnessMethod.getDeclaringClassName(), classLoader);

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/WitnessMethod.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/WitnessMethod.java
@@ -19,7 +19,6 @@
 package org.apache.skywalking.apm.agent.core.plugin;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -28,7 +27,6 @@ import net.bytebuddy.matcher.ElementMatcher;
  * Witness Method for plugin activation
  */
 @ToString
-@RequiredArgsConstructor
 public class WitnessMethod {
 
     /**
@@ -36,10 +34,34 @@ public class WitnessMethod {
      */
     @Getter
     private final String declaringClassName;
+
     /**
      * matcher to match the witness method
      */
     @Getter
     private final ElementMatcher<? super MethodDescription.InDefinedShape> elementMatcher;
 
+    /**
+     * if exclusiveMode is {@link java.lang.Boolean#TRUE}, we do not want the selected method exists.
+     * But in either cases, the declaring class should exist.
+     */
+    @Getter
+    private final boolean exclusiveMode;
+
+    /**
+     * Shorthand constructor for WitnessMethod without breaking existing methods.
+     * By default, the witness method works in the inclusive mode
+     *
+     * @param declaringClassName the class to find the specific method
+     * @param elementMatcher     element matcher used to filter the declared methods in the class
+     */
+    public WitnessMethod(String declaringClassName, ElementMatcher<? super MethodDescription.InDefinedShape> elementMatcher) {
+        this(declaringClassName, elementMatcher, false);
+    }
+
+    public WitnessMethod(String declaringClassName, ElementMatcher<? super MethodDescription.InDefinedShape> elementMatcher, boolean exclusiveMode) {
+        this.declaringClassName = declaringClassName;
+        this.elementMatcher = elementMatcher;
+        this.exclusiveMode = exclusiveMode;
+    }
 }

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/plugin/witness/WitnessTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/plugin/witness/WitnessTest.java
@@ -40,7 +40,7 @@ public class WitnessTest {
 
     @Test
     public void testWitnessClass() {
-        Assert.assertTrue(finder.exist(className, this.getClass().getClassLoader()));
+        Assert.assertTrue(finder.satisfy(className, this.getClass().getClassLoader()));
     }
 
     @Test
@@ -50,14 +50,24 @@ public class WitnessTest {
                 .and(ElementMatchers.takesGenericArgument(0, target -> "java.util.List<java.util.Map<java.lang.String, java.lang.Object>>".equals(target.getTypeName())))
                 .and(ElementMatchers.takesArgument(1, target -> "java.lang.String".equals(target.getName())));
         WitnessMethod witnessMethod = new WitnessMethod(className, junction);
-        Assert.assertTrue(finder.exist(witnessMethod, this.getClass().getClassLoader()));
+        Assert.assertTrue(finder.satisfy(witnessMethod, this.getClass().getClassLoader()));
+    }
+
+    @Test
+    public void testWitnessMethodInExclusiveMode() {
+        ElementMatcher.Junction<MethodDescription> junction = ElementMatchers.named("bar")
+                .and(ElementMatchers.returnsGeneric(target -> "java.util.List<java.util.Map<java.lang.String, java.lang.Object>>".equals(target.getTypeName())))
+                .and(ElementMatchers.takesGenericArgument(0, target -> "java.util.List<java.util.Map<java.lang.String, java.lang.Object>>".equals(target.getTypeName())))
+                .and(ElementMatchers.takesArgument(1, target -> "java.lang.String".equals(target.getName())));
+        WitnessMethod witnessMethod = new WitnessMethod(className, junction, true);
+        Assert.assertTrue(finder.satisfy(witnessMethod, this.getClass().getClassLoader()));
     }
 
     @Test
     public void testWitnessMethodOnlyUsingName() {
         ElementMatcher.Junction<MethodDescription> junction = ElementMatchers.named("foo");
         WitnessMethod witnessMethod = new WitnessMethod(className, junction);
-        Assert.assertTrue(finder.exist(witnessMethod, this.getClass().getClassLoader()));
+        Assert.assertTrue(finder.satisfy(witnessMethod, this.getClass().getClassLoader()));
     }
 
     public List<Map<String, Object>> foo(List<Map<String, Object>> param, String s) {


### PR DESCRIPTION
### Allow exclusive mode for WitnessMethod
- [x] It is trivial.
- [ ] Update the documentation to include this new feature.
- [x] Tests(including UT, IT, E2E) are added to verify the new feature.
- [x] Not related to UI

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

From skywalking 8.4.0, witness method has been introduced. This feature enables those plugins to conduct enhancements only if some specific methods are found.

In our scenarios, we would like to enhance some classes in Kafka client module, but only if `public Object metricValue()` can be found in the `KafkaMetric` class (which means Kafka version >= 1.0.0) since we are using this method in plugin.

Also, we want to make enhancements targeting legacy Kafka versions (< 1.0.0) with other different interceptors.

The most intuitive way is to do the opposite, searching for `KafkaMetric` class but without `public Object metricValue()` method. However, this method is not support yet in Skywalking agent. Thus, this PR is to provide this possibility.

Currently, we can do this in the following ways,

- use `MethodUtil.isMethodExist` during the runtime like what we have done in Tomcat, Jetty plugins for servlet version compatibility.
- in this specific case, we can check `@Deprecation` annotation on `@Deprecated public double value()` method. But this method will be totally removed in the next major release due to [KAFKA-12573](https://github.com/apache/kafka/pull/10425)

I suppose this PR can make improvement to the `WitnessMethod` feature.