### PR TITLE
Remove the useless metric in `vm.yaml`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,7 @@ Release Notes.
 * Using "service.istio.io/canonical-name" to replace "app" label to resolve Envoy ALS service name.
 * Append the root slash(/) to getIndex and getTemplate requests in ES client.
 * Fix `disable` statement not working. This bug exists since 8.0.0.
+* Remove the useless metric in `vm.yaml`.
 
 #### UI
 * Update selector scroller to show in all pages.

--- a/oap-server/server-bootstrap/src/main/resources/otel-oc-rules/vm.yaml
+++ b/oap-server/server-bootstrap/src/main/resources/otel-oc-rules/vm.yaml
@@ -89,8 +89,6 @@ metricsRules:
     #node filefd
   - name: filefd_allocated
     exp: node_filefd_allocated
-  - name: filefd_maximum
-    exp: node_filefd_maximum
 
 
 


### PR DESCRIPTION
### Fix: Remove the useless metric in `vm.yaml`
- [ ] Add a unit test to verify that the fix works.
- [X] Explain briefly why the bug exists and how to fix it.
   
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

Since the metric `filefd_maximum` was never used, so remove it to avoid waste storage.