### PR TITLE
Pin the openjdk docker version

### DIFF
--- a/test/plugin/containers/jvm-container/pom.xml
+++ b/test/plugin/containers/jvm-container/pom.xml
@@ -49,7 +49,7 @@
                                 <image>
                                     <name>skywalking/agent-test-jvm:jdk8-${project.version}</name>
                                     <build>
-                                        <from>openjdk:8</from>
+                                        <from>openjdk:8u102</from>
                                         <workdir>/usr/local/skywalking/scenario</workdir>
                                         <assembly>
                                             <mode>dir</mode>


### PR DESCRIPTION
Because `openjdk:8` is always pointed to the latest revision of `8` series, the latest one disabled TLS 1.0 (~16 hours ago) thus causes the mysql test to fail, this PR pins the Docker image to an older tag with specific revision so that it won't be overrode again