### PR TITLE
Fix: Some incompatibles check codes didn't work in `PercentileFunction combine`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Release Notes.
 * Loop alarm into event system.
 * Support alarm tags.
 * Support WeLink as a channel of alarm notification.
+* Fix: Some defensive codes didn't work in `PercentileFunction combine`.
 
 #### UI
 * Add logo for kong plugin.

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/PercentileFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/PercentileFunction.java
@@ -131,16 +131,16 @@ public abstract class PercentileFunction extends Metrics implements AcceptableVa
             );
             return true;
         }
-        if (ranks.size() > 0) {
+        if (this.ranks.size() > 0) {
             IntList ranksOfThat = percentile.getRanks();
-            if (this.ranks.size() != ranks.size()) {
+            if (this.ranks.size() != ranksOfThat.size()) {
                 log.warn("Incompatible ranks size = [{}}] for current PercentileFunction[{}]",
-                         ranks.size(), this.ranks.size()
+                         ranksOfThat.size(), this.ranks.size()
                 );
                 return true;
             } else {
-                if (!this.ranks.equals(percentile.getRanks())) {
-                    log.warn("Rank {} doesn't exist in the previous ranks {}", percentile.getRanks(), ranks);
+                if (!this.ranks.equals(ranksOfThat)) {
+                    log.warn("Rank {} doesn't exist in the previous ranks {}", ranksOfThat, this.ranks);
                     return true;
                 }
             }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgHistogramPercentileFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgHistogramPercentileFunction.java
@@ -157,15 +157,16 @@ public abstract class AvgHistogramPercentileFunction extends Metrics implements 
     public boolean combine(final Metrics metrics) {
         AvgHistogramPercentileFunction percentile = (AvgHistogramPercentileFunction) metrics;
 
-        if (ranks.size() > 0) {
-            if (this.ranks.size() != ranks.size()) {
+        if (this.ranks.size() > 0) {
+            IntList ranksOfThat = percentile.getRanks();
+            if (this.ranks.size() != ranksOfThat.size()) {
                 log.warn("Incompatible ranks size = [{}}] for current PercentileFunction[{}]",
-                         ranks.size(), this.ranks.size()
+                         ranksOfThat.size(), this.ranks.size()
                 );
                 return true;
             } else {
-                if (!this.ranks.equals(percentile.getRanks())) {
-                    log.warn("Rank {} doesn't exist in the previous ranks {}", percentile.getRanks(), ranks);
+                if (!this.ranks.equals(ranksOfThat)) {
+                    log.warn("Rank {} doesn't exist in the previous ranks {}", ranksOfThat, this.ranks);
                     return true;
                 }
             }


### PR DESCRIPTION
### Fix: Some incompatibles check codes didn't work in `PercentileFunction combine`.
- [ ] Add a unit test to verify that the fix works.
- [X] Explain briefly why the bug exists and how to fix it.
    
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

The condition codes below would always false:
![image](https://user-images.githubusercontent.com/16773043/116194257-318f2e00-a763-11eb-9cdd-2bbfcde71d34.png)



