### PR TITLE
Fix: MAL function would miss samples name after creating new samples.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ Release Notes.
 * Support WeLink as a channel of alarm notification.
 * Fix: Some defensive codes didn't work in `PercentileFunction combine`.
 * CVE: fix Jetty vulnerability. https://nvd.nist.gov/vuln/detail/CVE-2019-17638
-* Fix: MAL function would miss samples name after do aggregate.
+* Fix: MAL function would miss samples name after creating new samples.
 #### UI
 * Add logo for kong plugin.
 * Add apisix logo.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Release Notes.
 * Fix: Some defensive codes didn't work in `PercentileFunction combine`.
 * CVE: fix Jetty vulnerability. https://nvd.nist.gov/vuln/detail/CVE-2019-17638
 * Fix: MAL function would miss samples name after creating new samples.
+
 #### UI
 * Add logo for kong plugin.
 * Add apisix logo.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ Release Notes.
 * Support WeLink as a channel of alarm notification.
 * Fix: Some defensive codes didn't work in `PercentileFunction combine`.
 * CVE: fix Jetty vulnerability. https://nvd.nist.gov/vuln/detail/CVE-2019-17638
-
+* Fix: MAL function would miss samples name after do aggregate.
 #### UI
 * Add logo for kong plugin.
 * Add apisix logo.

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
@@ -212,7 +212,7 @@ public class SampleFamily {
         }
         if (by == null) {
             double result = Arrays.stream(samples).mapToDouble(Sample::getValue).average().orElse(0.0D);
-            return SampleFamily.build(this.context, InternalOps.newSample(ImmutableMap.of(), samples[0].timestamp, result));
+            return SampleFamily.build(this.context, InternalOps.newSample(samples[0].name, ImmutableMap.of(), samples[0].timestamp, result));
         }
 
         return SampleFamily.build(
@@ -221,6 +221,7 @@ public class SampleFamily {
                   .collect(groupingBy(it -> InternalOps.getLabels(by, it), mapping(identity(), toList())))
                   .entrySet().stream()
                   .map(entry -> InternalOps.newSample(
+                      entry.getValue().get(0).getName(),
                       entry.getKey(),
                       entry.getValue().get(0).getTimestamp(),
                       entry.getValue().stream().mapToDouble(Sample::getValue).average().orElse(0.0D)
@@ -236,7 +237,7 @@ public class SampleFamily {
         }
         if (by == null) {
             double result = Arrays.stream(samples).mapToDouble(s -> s.value).reduce(aggregator).orElse(0.0D);
-            return SampleFamily.build(this.context, InternalOps.newSample(ImmutableMap.of(), samples[0].timestamp, result));
+            return SampleFamily.build(this.context, InternalOps.newSample(samples[0].name, ImmutableMap.of(), samples[0].timestamp, result));
         }
         return SampleFamily.build(
             this.context,
@@ -244,6 +245,7 @@ public class SampleFamily {
                   .collect(groupingBy(it -> InternalOps.getLabels(by, it), mapping(identity(), toList())))
                   .entrySet().stream()
                   .map(entry -> InternalOps.newSample(
+                      entry.getValue().get(0).getName(),
                       entry.getKey(),
                       entry.getValue().get(0).getTimestamp(),
                       entry.getValue().stream().mapToDouble(Sample::getValue).reduce(aggregator).orElse(0.0D)
@@ -355,7 +357,7 @@ public class SampleFamily {
                               .putAll(Maps.filterKeys(s.labels, key -> !Objects.equals(key, le)))
                               .put("le", String.valueOf((long) ((Double.parseDouble(this.context.histogramType == HistogramType.ORDINARY ? s.labels.get(le) : preLe.get())) * scale))).build();
                           preLe.set(s.labels.get(le));
-                          return InternalOps.newSample(ll, s.timestamp, r);
+                          return InternalOps.newSample(s.name, ll, s.timestamp, r);
                       })
             ).toArray(Sample[]::new)
         );
@@ -539,11 +541,12 @@ public class SampleFamily {
             }
         }
 
-        private static Sample newSample(ImmutableMap<String, String> labels, long timestamp, double newValue) {
+        private static Sample newSample(String name, ImmutableMap<String, String> labels, long timestamp, double newValue) {
             return Sample.builder()
                          .value(newValue)
                          .labels(labels)
                          .timestamp(timestamp)
+                         .name(name)
                          .build();
         }
 

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/AggregationTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/AggregationTest.java
@@ -54,7 +54,7 @@ public class AggregationTest {
     @Parameterized.Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-           /* {
+            {
                 "sum",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
@@ -92,7 +92,7 @@ public class AggregationTest {
                 "http_success_request.min()",
                 Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(3).name("http_success_request").build()).build()),
                 false,
-            },*/
+            },
             {
                 "min-by",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
@@ -110,7 +110,6 @@ public class AggregationTest {
                 ).build()),
                 false,
             },
-
             {
                 "max",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/AggregationTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/AggregationTest.java
@@ -54,30 +54,30 @@ public class AggregationTest {
     @Parameterized.Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            {
+           /* {
                 "sum",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                        Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                        Sample.builder().labels(of("idc", "t2")).value(3).build()
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_success_request").build()
                     ).build()),
                 "http_success_request.sum()",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(53).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(53).name("http_success_request").build()).build()),
                 false,
             },
             {
                 "sum-by",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).name("http_success_request").value(50).build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).name("http_success_request").value(3).build()
                 ).build()),
                 "http_success_request.sum(by = ['region', 'idc'])",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1", "region", "")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn")).value(53).build()
+                    Sample.builder().labels(of("idc", "t1", "region", "")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn")).value(53).name("http_success_request").build()
                 ).build()),
                 false,
             },
@@ -85,28 +85,28 @@ public class AggregationTest {
             {
                 "min",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t3")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build()
+                    Sample.builder().labels(of("idc", "t3")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.min()",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(3).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(3).name("http_success_request").build()).build()),
                 false,
-            },
+            },*/
             {
                 "min-by",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.min(by = ['region', 'idc'])",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1", "region", "")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1", "region", "")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn")).value(3).name("http_success_request").build()
                 ).build()),
                 false,
             },
@@ -114,28 +114,28 @@ public class AggregationTest {
             {
                 "max",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t3")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build()
+                    Sample.builder().labels(of("idc", "t3")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.max()",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(100).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(100).name("http_success_request").build()).build()),
                 false,
             },
             {
                 "max-by",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.max(by = ['region', 'idc'])",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1", "region", "")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn")).value(50).build()
+                    Sample.builder().labels(of("idc", "t1", "region", "")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn")).value(50).name("http_success_request").build()
                 ).build()),
                 false,
             },
@@ -143,28 +143,28 @@ public class AggregationTest {
             {
                 "avg",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t3")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build()
+                    Sample.builder().labels(of("idc", "t3")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.avg()",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(51).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(51).name("http_success_request").build()).build()),
                 false,
             },
             {
                 "avg-by",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.avg(by = ['region', 'idc'])",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1", "region", "")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us")).value(75).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn")).value(27).build()
+                    Sample.builder().labels(of("idc", "t1", "region", "")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us")).value(75).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn")).value(27).name("http_success_request").build()
                 ).build()),
                 false,
             },

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/AnalyzerTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/AnalyzerTest.java
@@ -77,10 +77,10 @@ public class AnalyzerTest {
         ImmutableMap<String, SampleFamily> input = ImmutableMap.of(
             "http_success_request", SampleFamilyBuilder.newBuilder(
                 Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
             ).build()
         );
 
@@ -120,10 +120,10 @@ public class AnalyzerTest {
         ImmutableMap<String, SampleFamily> input = ImmutableMap.of(
             "http_success_request", SampleFamilyBuilder.newBuilder(
                 Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
             ).build()
         );
 
@@ -170,20 +170,24 @@ public class AnalyzerTest {
                 Sample.builder()
                       .labels(of("le", "0.025", "service", "service1", "instance", "instance1"))
                       .value(100)
+                      .name("instance_cpu_percentage")
                       .build(),
                 Sample.builder()
                       .labels(of("le", "1.25", "service", "service1", "instance", "instance1"))
                       .value(300)
+                      .name("instance_cpu_percentage")
                       .build(),
                 Sample.builder()
                       .labels(of("le", "0.75", "service", "service1", "instance", "instance2"))
                       .value(122)
+                      .name("instance_cpu_percentage")
                       .build(),
                 Sample.builder()
                       .labels(of("le", String.valueOf(Integer.MAX_VALUE), "service", "service1", "instance",
                                  "instance2"
                       ))
                       .value(410)
+                      .name("instance_cpu_percentage")
                       .build()
             ).build()
         );

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ArithmeticTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ArithmeticTest.java
@@ -57,305 +57,413 @@ public class ArithmeticTest {
             {
                 "plus-scalar-1",
                 of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592418480.0).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(1600592418481.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592418480.0)
+                          .name("instance_cpu_percentage")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("idc", "t2"))
+                          .value(1600592418481.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 "1000 + instance_cpu_percentage.tagEqual('idc','t1')",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592419480.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592419480.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "plus-scalar",
                 of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592418480.0).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(1600592418481.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592418480.0)
+                          .name("instance_cpu_percentage")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("idc", "t2"))
+                          .value(1600592418481.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 "instance_cpu_percentage.tagEqual('idc','t1') + 1000",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592419480.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592419480.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "minus-scalar",
                 of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592418480.0).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(1600592418481.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592418480.0)
+                          .name("instance_cpu_percentage")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("idc", "t2"))
+                          .value(1600592418481.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 "instance_cpu_percentage.tagEqual('idc','t1') - 1000",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592417480.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592417480.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "multiply-scalar",
                 of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592418480.0).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(1600592418481.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592418480.0)
+                          .name("instance_cpu_percentage")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("idc", "t2"))
+                          .value(1600592418481.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 "instance_cpu_percentage.tagEqual('idc','t1') * 1000",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592418480000.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592418480000.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "divide-scalar",
                 of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592418480.0).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(1600592418481.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592418480.0)
+                          .name("instance_cpu_percentage")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("idc", "t2"))
+                          .value(1600592418481.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 "instance_cpu_percentage.tagEqual('idc','t1') / 10",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(160059241848.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(160059241848.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "divide-zero",
                 of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(1600592418480.0).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(1600592418481.0).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(1600592418480.0)
+                          .name("instance_cpu_percentage")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("idc", "t2"))
+                          .value(1600592418481.0)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 "instance_cpu_percentage.tagEqual('idc','t1') / 0",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(Double.POSITIVE_INFINITY).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(Double.POSITIVE_INFINITY)
+                          .name("instance_cpu_percentage")
+                          .build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "empty-plus-empty",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamily.EMPTY),
+                   "http_error_request", SampleFamily.EMPTY
+                ),
                 "http_success_request + http_error_request",
                 Result.fail("Parsed result is an EMPTY sample family"),
                 false,
-            },
+                },
             {
                 "empty-plus-sampleFamily",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamilyBuilder.newBuilder(
-                        Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                        Sample.builder().labels(of("idc", "t2")).value(3).build()
-                    ).build()),
+                   "http_error_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
+                    ).build()
+                ),
                 "http_success_request + http_error_request",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "sampleFamily-plus-empty",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamilyBuilder.newBuilder(
-                        Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                        Sample.builder().labels(of("idc", "t2")).value(3).build()
-                    ).build()),
+                   "http_error_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
+                    ).build()
+                ),
                 "http_error_request + http_success_request ",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "sampleFamily-plus-sampleFamily",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(30).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(40).build(),
-                    Sample.builder().labels(of("region", "us")).value(80).build()
+                    Sample.builder().labels(of("idc", "t1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(30).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(40).name("http_success_request").build(),
+                    Sample.builder().labels(of("region", "us")).value(80).name("http_success_request").build()
                 ).build(), "http_error_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build(),
-                    Sample.builder().labels(of("idc", "t5")).value(3).build(),
-                    Sample.builder().labels(of("tz", "en-US")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t5")).value(3).name("http_error_request").build(),
+                    Sample.builder().labels(of("tz", "en-US")).value(3).name("http_error_request").build()
                 ).build()),
                 "http_success_request + http_error_request",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(150).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(33).build()
+                    Sample.builder().labels(of("idc", "t1")).value(150).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(33).name("http_success_request").build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "empty-minus-empty",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamily.EMPTY),
+                   "http_error_request", SampleFamily.EMPTY
+                ),
                 "http_success_request - http_error_request",
                 Result.fail("Parsed result is an EMPTY sample family"),
                 false,
-            },
+                },
             {
                 "empty-minus-sampleFamily",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamilyBuilder.newBuilder(
-                        Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                        Sample.builder().labels(of("idc", "t2")).value(3).build()
-                    ).build()),
+                   "http_error_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
+                    ).build()
+                ),
                 "http_success_request - http_error_request",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(-50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(-3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(-50).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(-3).name("http_error_request").build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "sampleFamily-minus-empty",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamilyBuilder.newBuilder(
-                        Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                        Sample.builder().labels(of("idc", "t2")).value(3).build()
-                    ).build()),
+                   "http_error_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
+                    ).build()
+                ),
                 "http_error_request - http_success_request ",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "sampleFamily-minus-sampleFamily",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(30).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(40).build(),
-                    Sample.builder().labels(of("region", "us")).value(80).build()
+                    Sample.builder().labels(of("idc", "t1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(30).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(40).name("http_success_request").build(),
+                    Sample.builder().labels(of("region", "us")).value(80).name("http_success_request").build()
                 ).build(), "http_error_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build(),
-                    Sample.builder().labels(of("idc", "t5")).value(3).build(),
-                    Sample.builder().labels(of("tz", "en-US")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t5")).value(3).name("http_error_request").build(),
+                    Sample.builder().labels(of("tz", "en-US")).value(3).name("http_error_request").build()
                 ).build()),
                 "http_success_request - http_error_request",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(27).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(27).name("http_success_request").build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "sameSampleFamily-minus-sameSampleFamily",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1" , "service", "service1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t2" , "service", "service1")).value(30).build(),
-                    Sample.builder().labels(of("idc", "t3" , "service", "service1")).value(40).build(),
-                    Sample.builder().labels(of("region", "us" , "service", "service1")).value(80).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1", "service", "service1"))
+                          .value(100)
+                          .name("http_success_request")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("idc", "t2", "service", "service1"))
+                          .value(30)
+                          .name("http_success_request")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("idc", "t3", "service", "service1"))
+                          .value(40)
+                          .name("http_success_request")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("region", "us", "service", "service1"))
+                          .value(80)
+                          .name("http_success_request")
+                          .build()
                 ).build()),
                 "http_success_request.sum(['service']) - http_success_request.sum(['service'])",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("service", "service1")).value(0).build()
+                    Sample.builder().labels(of("service", "service1")).value(0).name("http_success_request").build()
                 ).build()),
                 false,
                 },
             {
                 "empty-multiple-empty",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamily.EMPTY),
+                   "http_error_request", SampleFamily.EMPTY
+                ),
                 "http_success_request * http_error_request",
                 Result.fail("Parsed result is an EMPTY sample family"),
                 false,
-            },
+                },
             {
                 "empty-multiple-sampleFamily",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamilyBuilder.newBuilder(
-                        Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                        Sample.builder().labels(of("idc", "t2")).value(3).build()
-                    ).build()),
+                   "http_error_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
+                    ).build()
+                ),
                 "http_success_request * http_error_request",
                 Result.fail("Parsed result is an EMPTY sample family"),
                 false,
-            },
+                },
             {
                 "sampleFamily-multiple-empty",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamilyBuilder.newBuilder(
-                        Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                        Sample.builder().labels(of("idc", "t2")).value(3).build()
-                    ).build()),
+                   "http_error_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
+                    ).build()
+                ),
                 "http_error_request * http_success_request ",
                 Result.fail("Parsed result is an EMPTY sample family"),
                 false,
-            },
+                },
             {
                 "sampleFamily-multiple-sampleFamily",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(30).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(40).build(),
-                    Sample.builder().labels(of("region", "us")).value(80).build()
+                    Sample.builder().labels(of("idc", "t1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(30).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(40).name("http_success_request").build(),
+                    Sample.builder().labels(of("region", "us")).value(80).name("http_success_request").build()
                 ).build(), "http_error_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build(),
-                    Sample.builder().labels(of("idc", "t5")).value(3).build(),
-                    Sample.builder().labels(of("tz", "en-US")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t5")).value(3).name("http_error_request").build(),
+                    Sample.builder().labels(of("tz", "en-US")).value(3).name("http_error_request").build()
                 ).build()),
                 "http_success_request * http_error_request",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(5000).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(90).build()
+                    Sample.builder().labels(of("idc", "t1")).value(5000).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(90).name("http_success_request").build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "empty-divide-empty",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamily.EMPTY),
+                   "http_error_request", SampleFamily.EMPTY
+                ),
                 "http_success_request / http_error_request",
                 Result.fail("Parsed result is an EMPTY sample family"),
                 false,
-            },
+                },
             {
                 "empty-divide-sampleFamily",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamilyBuilder.newBuilder(
-                        Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                        Sample.builder().labels(of("idc", "t2")).value(3).build()
-                    ).build()),
+                   "http_error_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
+                    ).build()
+                ),
                 "http_success_request / http_error_request",
                 Result.fail("Parsed result is an EMPTY sample family"),
                 false,
-            },
+                },
             {
                 "sampleFamily-divide-empty",
                 of("http_success_request", SampleFamily.EMPTY,
-                    "http_error_request", SampleFamilyBuilder.newBuilder(
-                        Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                        Sample.builder().labels(of("idc", "t2")).value(3).build()
-                    ).build()),
+                   "http_error_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build()
+                    ).build()
+                ),
                 "http_error_request / http_success_request ",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(Double.POSITIVE_INFINITY).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(Double.POSITIVE_INFINITY).build()
+                    Sample.builder()
+                          .labels(of("idc", "t1"))
+                          .value(Double.POSITIVE_INFINITY)
+                          .name("http_error_request")
+                          .build(),
+                    Sample.builder()
+                          .labels(of("idc", "t2"))
+                          .value(Double.POSITIVE_INFINITY)
+                          .name("http_error_request")
+                          .build()
                 ).build()),
                 false,
-            },
+                },
             {
                 "sampleFamily-divide-sampleFamily",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(30).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(40).build(),
-                    Sample.builder().labels(of("region", "us")).value(80).build()
+                    Sample.builder().labels(of("idc", "t1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(30).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(40).name("http_success_request").build(),
+                    Sample.builder().labels(of("region", "us")).value(80).name("http_success_request").build()
                 ).build(), "http_error_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(3).build(),
-                    Sample.builder().labels(of("idc", "t5")).value(3).build(),
-                    Sample.builder().labels(of("tz", "en-US")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(3).name("http_error_request").build(),
+                    Sample.builder().labels(of("idc", "t5")).value(3).name("http_error_request").build(),
+                    Sample.builder().labels(of("tz", "en-US")).value(3).name("http_error_request").build()
                 ).build()),
                 "http_success_request / http_error_request",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(10).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(10).name("http_success_request").build()
                 ).build()),
                 false,
-            },
-        });
+                },
+            });
     }
 
     @Test

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/BasicTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/BasicTest.java
@@ -63,9 +63,9 @@ public class BasicTest {
             },
             {
                 "single-value",
-                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().value(1600592418480.0).build()).build()),
+                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().value(1600592418480.0).name("instance_cpu_percentage").build()).build()),
                 "instance_cpu_percentage",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().value(1600592418480.0).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().value(1600592418480.0).name("instance_cpu_percentage").build()).build()),
                 false,
             },
         });

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/FunctionTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/FunctionTest.java
@@ -56,70 +56,70 @@ public class FunctionTest {
         return Arrays.asList(new Object[][] {
             {
                 "tag-override",
-                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).build()).build()),
+                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).name("instance_cpu_percentage").build()).build()),
                 "instance_cpu_percentage.tag({ ['svc':'product', 'instance':'10.0.0.1'] })",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("svc", "product", "instance", "10.0.0.1")).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("svc", "product", "instance", "10.0.0.1")).name("instance_cpu_percentage").build()).build()),
                 false,
             },
             {
                 "tag-add",
-                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).build()).build()),
+                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).name("instance_cpu_percentage").build()).build()),
                 "instance_cpu_percentage.tag({tags -> tags.az = 'az1' })",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us", "az", "az1")).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us", "az", "az1")).name("instance_cpu_percentage").build()).build()),
                 false,
             },
             {
                 "tag-remove",
-                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).build()).build()),
+                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).name("instance_cpu_percentage").build()).build()),
                 "instance_cpu_percentage.tag({tags -> tags.remove('region') })",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).name("instance_cpu_percentage").build()).build()),
                 false,
             },
             {
                 "tag-update",
-                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).build()).build()),
+                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).name("instance_cpu_percentage").build()).build()),
                 "instance_cpu_percentage.tag({tags -> if (tags['region'] == 'us') {tags.region = 'zh'} })",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "zh")).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "zh")).name("instance_cpu_percentage").build()).build()),
                 false,
             },
             {
                 "tag-append",
-                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).build()).build()),
+                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "us")).name("instance_cpu_percentage").build()).build()),
                 "instance_cpu_percentage.tag({tags -> tags.region = 'prefix::' + tags.region})",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "prefix::us")).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(of("region", "prefix::us")).name("instance_cpu_percentage").build()).build()),
                 false,
                 },
             {
                 "histogram",
                 of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("le", "0.025")).value(100).build(),
-                    Sample.builder().labels(of("le", "1.25")).value(300).build(),
-                    Sample.builder().labels(of("le", "0.75")).value(122).build(),
-                    Sample.builder().labels(of("le", String.valueOf(Integer.MAX_VALUE))).value(410).build()).build()
+                    Sample.builder().labels(of("le", "0.025")).value(100).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "1.25")).value(300).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "0.75")).value(122).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", String.valueOf(Integer.MAX_VALUE))).value(410).name("instance_cpu_percentage").build()).build()
                 ),
                 "instance_cpu_percentage.histogram()",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("le", "0")).value(100).build(),
-                    Sample.builder().labels(of("le", "25")).value(22).build(),
-                    Sample.builder().labels(of("le", "750")).value(178).build(),
-                    Sample.builder().labels(of("le", "1250")).value(110).build()).build()
+                    Sample.builder().labels(of("le", "0")).value(100).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "25")).value(22).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "750")).value(178).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "1250")).value(110).name("instance_cpu_percentage").build()).build()
                 ),
                 false,
             },
             {
                 "histogram_percentile",
                 of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("le", "0.025")).value(100).build(),
-                    Sample.builder().labels(of("le", "1.25")).value(300).build(),
-                    Sample.builder().labels(of("le", "0.75")).value(122).build(),
-                    Sample.builder().labels(of("le", String.valueOf(Integer.MAX_VALUE))).value(410).build()).build()
+                    Sample.builder().labels(of("le", "0.025")).value(100).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "1.25")).value(300).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "0.75")).value(122).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", String.valueOf(Integer.MAX_VALUE))).value(410).name("instance_cpu_percentage").build()).build()
                 ),
                 "instance_cpu_percentage.histogram().histogram_percentile([75,99])",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("le", "0")).value(100).build(),
-                    Sample.builder().labels(of("le", "25")).value(22).build(),
-                    Sample.builder().labels(of("le", "750")).value(178).build(),
-                    Sample.builder().labels(of("le", "1250")).value(110).build()).build()
+                    Sample.builder().labels(of("le", "0")).value(100).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "25")).value(22).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "750")).value(178).name("instance_cpu_percentage").build(),
+                    Sample.builder().labels(of("le", "1250")).value(110).name("instance_cpu_percentage").build()).build()
                 ),
                 false,
             },

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/IncreaseTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/IncreaseTest.java
@@ -62,54 +62,54 @@ public class IncreaseTest {
                 asList(
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(50).build(),
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(50).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(150).build()
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(150).name("http_success_request").build()
                     ).build()),
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(80).build(),
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(80).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(250).build()
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(250).name("http_success_request").build()
                     ).build()),
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(90).build(),
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(90).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(280).build()
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(280).name("http_success_request").build()
                     ).build()),
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(130).build(),
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(130).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(330).build()
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(330).name("http_success_request").build()
                     ).build())
                 ),
                 "http_success_request.increase('PT5M')",
                 asList(
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).build(),
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).build()
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).name("http_success_request").build()
                     ).build()),
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(30).build(),
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(30).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(100).build()
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(100).name("http_success_request").build()
                     ).build()),
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(40).build(),
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(40).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(130).build()
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(130).name("http_success_request").build()
                     ).build()),
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(50).build(),
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(50).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(80).build()
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(80).name("http_success_request").build()
                     ).build())
                 ),
                 false,
@@ -119,54 +119,54 @@ public class IncreaseTest {
                 asList(
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(50).build(),
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(50).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(150).build()
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(150).name("http_success_request").build()
                     ).build()),
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(330).build(),
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(330).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(500).build()
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(500).name("http_success_request").build()
                     ).build()),
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(380).build(),
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(380).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(810).build()
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(810).name("http_success_request").build()
                     ).build()),
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(1380).build(),
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(1380).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(1900).build()
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(1900).name("http_success_request").build()
                     ).build())
                 ),
                 "http_success_request.rate('PT5M')",
                 asList(
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).build(),
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).build()
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).name("http_success_request").build()
                     ).build()),
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(1.75D).build(),
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(1.75D).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(2.1875D).build()
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(2.1875D).name("http_success_request").build()
                     ).build()),
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(1D).build(),
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(1D).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(2D).build()
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(2D).name("http_success_request").build()
                     ).build()),
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(3D).build(),
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(3D).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(4D).build()
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(4D).name("http_success_request").build()
                     ).build())
                 ),
                 false,
@@ -176,54 +176,54 @@ public class IncreaseTest {
                 asList(
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(50).build(),
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(50).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(150).build()
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(150).name("http_success_request").build()
                     ).build()),
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(330).build(),
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(330).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(500).build()
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(500).name("http_success_request").build()
                     ).build()),
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(500).build(),
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(500).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(840).build()
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(840).name("http_success_request").build()
                     ).build()),
                     of("http_success_request", SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(1040).build(),
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(1040).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(1560).build()
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(1560).name("http_success_request").build()
                     ).build())
                 ),
                 "http_success_request.irate()",
                 asList(
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).build(),
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).build()
+                            .timestamp(parse("2020-09-11T11:11:01.00Z").toEpochMilli()).value(0).name("http_success_request").build()
                     ).build()),
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(1.75D).build(),
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(1.75D).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(2.1875D).build()
+                            .timestamp(parse("2020-09-11T11:13:41.00Z").toEpochMilli()).value(2.1875D).name("http_success_request").build()
                     ).build()),
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(1D).build(),
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(1D).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(2D).build()
+                            .timestamp(parse("2020-09-11T11:16:31.00Z").toEpochMilli()).value(2D).name("http_success_request").build()
                     ).build()),
                     Result.success(SampleFamilyBuilder.newBuilder(
                         Sample.builder().name("http_success_request").labels(of("svc", "product"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(3D).build(),
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(3D).name("http_success_request").build(),
                         Sample.builder().name("http_success_request").labels(of("svc", "catalog"))
-                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(4D).build()
+                            .timestamp(parse("2020-09-11T11:19:31.02Z").toEpochMilli()).value(4D).name("http_success_request").build()
                     ).build())
                 ),
                 false,

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/K8sTagTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/K8sTagTest.java
@@ -75,6 +75,7 @@ public class K8sTagTest {
                                   "my-nginx-5dc4865748-mbczh"
                               ))
                           .value(2)
+                          .name("container_cpu_usage_seconds_total")
                           .build(),
                     Sample.builder()
                           .labels(
@@ -83,6 +84,7 @@ public class K8sTagTest {
                                   "kube-state-metrics-6f979fd498-z7xwx"
                               ))
                           .value(1)
+                          .name("container_cpu_usage_seconds_total")
                           .build()
                 ).build()),
                 "container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod' , 'namespace')",
@@ -95,6 +97,7 @@ public class K8sTagTest {
                                   "service", "nginx-service.default"
                               ))
                           .value(2)
+                          .name("container_cpu_usage_seconds_total")
                           .build(),
                     Sample.builder()
                           .labels(
@@ -104,6 +107,7 @@ public class K8sTagTest {
                                   "service", "kube-state-metrics.kube-system"
                               ))
                           .value(1)
+                          .name("container_cpu_usage_seconds_total")
                           .build()
                 ).build()),
                 false,
@@ -118,6 +122,7 @@ public class K8sTagTest {
                                   "my-nginx-5dc4865748-no-pod"
                               ))
                           .value(2)
+                          .name("container_cpu_usage_seconds_total")
                           .build(),
                     Sample.builder()
                           .labels(
@@ -126,6 +131,7 @@ public class K8sTagTest {
                                   "kube-state-metrics-6f979fd498-z7xwx"
                               ))
                           .value(1)
+                          .name("container_cpu_usage_seconds_total")
                           .build()
                 ).build()),
                 "container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod' , 'namespace')",
@@ -137,6 +143,7 @@ public class K8sTagTest {
                                   "my-nginx-5dc4865748-no-pod" , "service", Retag.BLANK
                               ))
                           .value(2)
+                          .name("container_cpu_usage_seconds_total")
                           .build(),
                     Sample.builder()
                           .labels(
@@ -146,6 +153,7 @@ public class K8sTagTest {
                                   "service", "kube-state-metrics.kube-system"
                               ))
                           .value(1)
+                          .name("container_cpu_usage_seconds_total")
                           .build()
                 ).build()),
                 false,
@@ -160,6 +168,7 @@ public class K8sTagTest {
                                   "my-nginx-5dc4865748-no-service"
                               ))
                           .value(2)
+                          .name("container_cpu_usage_seconds_total")
                           .build(),
                     Sample.builder()
                           .labels(
@@ -168,6 +177,7 @@ public class K8sTagTest {
                                   "kube-state-metrics-6f979fd498-z7xwx"
                               ))
                           .value(1)
+                          .name("container_cpu_usage_seconds_total")
                           .build()
                 ).build()),
                 "container_cpu_usage_seconds_total.retagByK8sMeta('service' , K8sRetagType.Pod2Service , 'pod' , 'namespace')",
@@ -179,6 +189,7 @@ public class K8sTagTest {
                                   "my-nginx-5dc4865748-no-service" , "service", Retag.BLANK
                               ))
                           .value(2)
+                          .name("container_cpu_usage_seconds_total")
                           .build(),
                     Sample.builder()
                           .labels(
@@ -188,6 +199,7 @@ public class K8sTagTest {
                                   "service", "kube-state-metrics.kube-system"
                               ))
                           .value(1)
+                          .name("container_cpu_usage_seconds_total")
                           .build()
                 ).build()),
                 false,

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ScopeTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ScopeTest.java
@@ -59,11 +59,11 @@ public class ScopeTest {
             {
                 "sum_service",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.sum(['idc']).service(['idc'])",
                 false,
@@ -71,11 +71,11 @@ public class ScopeTest {
                     {
                         put(
                             MeterEntity.newService("t1"),
-                            new Sample[] {Sample.builder().labels(of()).value(200).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(200).name("http_success_request").build()}
                         );
                         put(
                             MeterEntity.newService("t3"),
-                            new Sample[] {Sample.builder().labels(of()).value(54).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(54).name("http_success_request").build()}
                         );
                     }
                 }
@@ -83,11 +83,11 @@ public class ScopeTest {
             {
                 "sum_service_labels",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.sum(['region', 'idc']).service(['idc'])",
                 false,
@@ -96,13 +96,13 @@ public class ScopeTest {
                         put(
                             MeterEntity.newService("t1"),
                             new Sample[] {
-                                Sample.builder().labels(of("region", "")).value(50).build(),
-                                Sample.builder().labels(of("region", "us")).value(150).build()
+                                Sample.builder().labels(of("region", "")).value(50).name("http_success_request").build(),
+                                Sample.builder().labels(of("region", "us")).value(150).name("http_success_request").build()
                             }
                         );
                         put(
                             MeterEntity.newService("t3"),
-                            new Sample[] {Sample.builder().labels(of("region", "cn")).value(54).build()}
+                            new Sample[] {Sample.builder().labels(of("region", "cn")).value(54).name("http_success_request").build()}
                         );
                     }
                 }
@@ -110,11 +110,11 @@ public class ScopeTest {
             {
                 "sum_service_m",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.sum(['idc', 'region']).service(['idc' , 'region'])",
                 false,
@@ -122,15 +122,15 @@ public class ScopeTest {
                     {
                         put(
                             MeterEntity.newService("t1.us"),
-                            new Sample[] {Sample.builder().labels(of()).value(150).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(150).name("http_success_request").build()}
                         );
                         put(
                             MeterEntity.newService("t3.cn"),
-                            new Sample[] {Sample.builder().labels(of()).value(54).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(54).name("http_success_request").build()}
                         );
                         put(
                             MeterEntity.newService("t1"),
-                            new Sample[] {Sample.builder().labels(of()).value(50).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(50).name("http_success_request").build()}
                         );
                     }
                 }
@@ -138,11 +138,11 @@ public class ScopeTest {
             {
                 "sum_service_endpiont",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.sum(['region', 'idc']).endpoint(['idc'] , ['region'])",
                 false,
@@ -150,15 +150,15 @@ public class ScopeTest {
                     {
                         put(
                             MeterEntity.newEndpoint("t1", "us"),
-                            new Sample[] {Sample.builder().labels(of()).value(150).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(150).name("http_success_request").build()}
                         );
                         put(
                             MeterEntity.newEndpoint("t3", "cn"),
-                            new Sample[] {Sample.builder().labels(of()).value(54).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(54).name("http_success_request").build()}
                         );
                         put(
                             MeterEntity.newEndpoint("t1", ""),
-                            new Sample[] {Sample.builder().labels(of()).value(50).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(50).name("http_success_request").build()}
                         );
                     }
                 }
@@ -167,11 +167,11 @@ public class ScopeTest {
             {
                 "sum_service_endpiont_labels",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.sum(['region', 'idc' , 'instance']).endpoint(['idc'] , ['region'])",
                 false,
@@ -180,20 +180,20 @@ public class ScopeTest {
                         put(
                             MeterEntity.newEndpoint("t1", "us"),
                             new Sample[] {
-                                Sample.builder().labels(of("instance", "")).value(50).build(),
-                                Sample.builder().labels(of("instance", "10.0.0.1")).value(100).build()
+                                Sample.builder().labels(of("instance", "")).value(50).name("http_success_request").build(),
+                                Sample.builder().labels(of("instance", "10.0.0.1")).value(100).name("http_success_request").build()
                             }
                         );
                         put(
                             MeterEntity.newEndpoint("t3", "cn"),
                             new Sample[] {
-                                Sample.builder().labels(of("instance", "")).value(51).build(),
-                                Sample.builder().labels(of("instance", "10.0.0.1")).value(3).build()
+                                Sample.builder().labels(of("instance", "")).value(51).name("http_success_request").build(),
+                                Sample.builder().labels(of("instance", "10.0.0.1")).value(3).name("http_success_request").build()
                             }
                         );
                         put(
                             MeterEntity.newEndpoint("t1", ""),
-                            new Sample[] {Sample.builder().labels(of("instance", "")).value(50).build()}
+                            new Sample[] {Sample.builder().labels(of("instance", "")).value(50).name("http_success_request").build()}
                         );
                     }
                 }
@@ -201,16 +201,18 @@ public class ScopeTest {
             {
                 "sum_service_endpiont_labels_m",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "product")).value(51).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "catalog")).value(50).build(),
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "product")).value(51).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "catalog")).value(50).name("http_success_request").build(),
                     Sample.builder()
                           .labels(of("idc", "t1", "region", "us", "svc", "catalog", "instance", "10.0.0.1"))
                           .value(100)
+                          .name("http_success_request")
                           .build(),
                     Sample.builder()
                           .labels(of("idc", "t3", "region", "cn", "svc", "product", "instance", "10.0.0.1"))
                           .value(3)
+                          .name("http_success_request")
                           .build()
                 ).build()),
                 "http_success_request.sum(['region', 'idc' , 'svc' , 'instance']).endpoint(['idc'] , ['region','svc'])",
@@ -220,20 +222,20 @@ public class ScopeTest {
                         put(
                             MeterEntity.newEndpoint("t1", "us.catalog"),
                             new Sample[] {
-                                Sample.builder().labels(of("instance", "")).value(50).build(),
-                                Sample.builder().labels(of("instance", "10.0.0.1")).value(100).build()
+                                Sample.builder().labels(of("instance", "")).value(50).name("http_success_request").build(),
+                                Sample.builder().labels(of("instance", "10.0.0.1")).value(100).name("http_success_request").build()
                             }
                         );
                         put(
                             MeterEntity.newEndpoint("t3", "cn.product"),
                             new Sample[] {
-                                Sample.builder().labels(of("instance", "")).value(51).build(),
-                                Sample.builder().labels(of("instance", "10.0.0.1")).value(3).build()
+                                Sample.builder().labels(of("instance", "")).value(51).name("http_success_request").build(),
+                                Sample.builder().labels(of("instance", "10.0.0.1")).value(3).name("http_success_request").build()
                             }
                         );
                         put(
                             MeterEntity.newEndpoint("t1", ""),
-                            new Sample[] {Sample.builder().labels(of("instance", "")).value(50).build()}
+                            new Sample[] {Sample.builder().labels(of("instance", "")).value(50).name("http_success_request").build()}
                         );
                     }
                 }
@@ -241,11 +243,11 @@ public class ScopeTest {
             {
                 "sum_service_instance",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.sum(['region', 'idc']).instance(['idc'] , ['region'])",
                 false,
@@ -253,15 +255,15 @@ public class ScopeTest {
                     {
                         put(
                             MeterEntity.newServiceInstance("t1", "us"),
-                            new Sample[] {Sample.builder().labels(of()).value(150).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(150).name("http_success_request").build()}
                         );
                         put(
                             MeterEntity.newServiceInstance("t3", "cn"),
-                            new Sample[] {Sample.builder().labels(of()).value(54).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(54).name("http_success_request").build()}
                         );
                         put(
                             MeterEntity.newServiceInstance("t1", ""),
-                            new Sample[] {Sample.builder().labels(of()).value(50).build()}
+                            new Sample[] {Sample.builder().labels(of()).value(50).name("http_success_request").build()}
                         );
                     }
                 }
@@ -269,11 +271,11 @@ public class ScopeTest {
             {
                 "sum_service_instance_labels",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).build(),
-                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).build(),
-                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).build()
+                    Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "svc", "catalog")).value(51).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "svc", "product")).value(50).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.1")).value(100).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3", "region", "cn", "instance", "10.0.0.1")).value(3).name("http_success_request").build()
                 ).build()),
                 "http_success_request.sum(['region', 'idc' , 'instance']).instance(['idc'] , ['region'])",
                 false,
@@ -282,20 +284,20 @@ public class ScopeTest {
                         put(
                             MeterEntity.newServiceInstance("t1", "us"),
                             new Sample[] {
-                                Sample.builder().labels(of("instance", "")).value(50).build(),
-                                Sample.builder().labels(of("instance", "10.0.0.1")).value(100).build()
+                                Sample.builder().labels(of("instance", "")).value(50).name("http_success_request").build(),
+                                Sample.builder().labels(of("instance", "10.0.0.1")).value(100).name("http_success_request").build()
                             }
                         );
                         put(
                             MeterEntity.newServiceInstance("t3", "cn"),
                             new Sample[] {
-                                Sample.builder().labels(of("instance", "")).value(51).build(),
-                                Sample.builder().labels(of("instance", "10.0.0.1")).value(3).build()
+                                Sample.builder().labels(of("instance", "")).value(51).name("http_success_request").build(),
+                                Sample.builder().labels(of("instance", "10.0.0.1")).value(3).name("http_success_request").build()
                             }
                         );
                         put(
                             MeterEntity.newServiceInstance("t1", ""),
-                            new Sample[] {Sample.builder().labels(of("instance", "")).value(50).build()}
+                            new Sample[] {Sample.builder().labels(of("instance", "")).value(50).name("http_success_request").build()}
                         );
                     }
                 }

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/TagFilterTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/TagFilterTest.java
@@ -63,9 +63,9 @@ public class TagFilterTest {
             },
             {
                 "single-value",
-                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().value(1600592418480.0).build()).build()),
+                of("instance_cpu_percentage", SampleFamilyBuilder.newBuilder(Sample.builder().value(1600592418480.0).name("instance_cpu_percentage").build()).build()),
                 "instance_cpu_percentage",
-                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().value(1600592418480.0).build()).build()),
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().value(1600592418480.0).name("instance_cpu_percentage").build()).build()),
                 false,
             },
         });

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ValueFilterTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/ValueFilterTest.java
@@ -56,84 +56,84 @@ public class ValueFilterTest {
             {
                 "valueEqual",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 "http_success_request.valueEqual(1)",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 false,
                 },
             {
                 "valueNotEqual",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 "http_success_request.valueNotEqual(1)",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build()
                 ).build()),
                 false,
                 },
             {
                 "valueGreater",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 "http_success_request.valueGreater(1)",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build()
                 ).build()),
                 false,
                 },
             {
                 "valueGreaterEqual",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 "http_success_request.valueGreaterEqual(1)",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 false,
                 },
             {
                 "valueLess",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 "http_success_request.valueLess(2)",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 false,
                 },
             {
                 "valueLessEqual",
                 of("http_success_request", SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 "http_success_request.valueLessEqual(2)",
                 Result.success(SampleFamilyBuilder.newBuilder(
-                    Sample.builder().labels(of("idc", "t1")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t2")).value(2).build(),
-                    Sample.builder().labels(of("idc", "t3")).value(1).build()
+                    Sample.builder().labels(of("idc", "t1")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t2")).value(2).name("http_success_request").build(),
+                    Sample.builder().labels(of("idc", "t3")).value(1).name("http_success_request").build()
                 ).build()),
                 false,
                 },


### PR DESCRIPTION
### Fix MAL function would miss samples name after creating new samples.
- [X] Add a unit test to verify that the fix works.
- [X] Explain briefly why the bug exists and how to fix it.
- [X] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #6857
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

When MAL do `aggregate` like `sum/max/min` or do `avg`/`histogram`, there used `InternalOps.newSample`.
But this function missed the samples name:

![image](https://user-images.githubusercontent.com/16773043/116363577-dd08b300-a835-11eb-9478-87db7d94b07c.png)

That is impacted the `rate/irate/increase` functions because when we do increase count we use sample `name` and `labels` 
as the `id` to separate the samples.

![image](https://user-images.githubusercontent.com/16773043/116364181-818af500-a836-11eb-9c24-b30070bba4ba.png)

So, in some scenario, for example:
```yaml
  - name: cpu_total_percentage
    exp: (node_cpu_seconds_total * 100).tagNotEqual('mode' , 'idle').sum(['node_identifier_host_name']).rate('PT1M')
  - name: disk_written
    exp: node_disk_written_bytes_total.sum(['node_identifier_host_name']).rate('PT1M')
```
These 2 expressions will make the samples have the same labels if the sample name missed, the `id` above would the same.
The cache and calculate of the value would incorrect, this caused issue #6857.

