### PR TITLE
FIX: NPE when thrift field is nested

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Release Notes.
 * Add an optional agent plugin to support mybatis.
 * Add `spring-cloud-gateway-3.x` optional plugin.
 * Add `okhttp-4.x` plugin.
+* Fix NPE when thrift field is nested in plugin `thrift`
 
 #### OAP-Backend
 * BugFix: filter invalid Envoy access logs whose socket address is empty.


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

When thrift message has nested field, ServerInProtocolWrapper read Inner fieldStop and make context = null, then ServerInProtocolWrapper read outer fieldStop, which cause NPE.
So I move this logic to readMessageEnd() so that make sure it's invoked only once
```java
ServerInProtocolWrapper#readFieldBegin()
    @Override
    public TField readFieldBegin() throws TException {
       ................
        if (field.type == TType.STOP) {
            Boolean haveCreatedSpan =
                    (Boolean) ContextManager.getRuntimeContext().get(HAVE_CREATED_SPAN);
            if (haveCreatedSpan != null && !haveCreatedSpan) {
                try {
                    AbstractSpan span = ContextManager.createEntrySpan(
                            context.getOperatorName(), createContextCarrier(null));
                    span.start(context.startTime);
                    span.tag(TAG_ARGS, context.getArguments());
                    span.setComponent(ComponentsDefine.THRIFT_SERVER);
                    SpanLayer.asRPCFramework(span);
                } catch (Throwable throwable) {
                    LOGGER.error("Failed to create EntrySpan.", throwable);
                } finally {
                    context = null;
                }

        return field;
    }
```

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
