### PR TITLE
Fix wrong implementation of "Double-Checked Locking".

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
@@ -57,7 +57,7 @@ public class AgentClassLoader extends ClassLoader {
     /**
      * The default class loader for the agent.
      */
-    private static AgentClassLoader DEFAULT_LOADER;
+    private static volatile AgentClassLoader DEFAULT_LOADER;
 
     private List<File> classpath;
     private List<Jar> allJars;


### PR DESCRIPTION
### Fix wrong implementation of "Double-Checked Locking".
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it. 
Add volatile to avoid only parts fields of DEFAULT_LOADER are visible, reference http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html
