### PR TITLE
Fix the conversion problem of float type in ConfigInitializer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Release Notes.
 * Add `okhttp-4.x` plugin.
 * Fix NPE when thrift field is nested in plugin `thrift`
 * Fix possible NullPointerException in agent's ES plugin.
+* Fix the conversion problem of float type in ConfigInitializer.
 
 #### OAP-Backend
 * BugFix: filter invalid Envoy access logs whose socket address is empty.

--- a/apm-commons/apm-util/src/main/java/org/apache/skywalking/apm/util/ConfigInitializer.java
+++ b/apm-commons/apm-util/src/main/java/org/apache/skywalking/apm/util/ConfigInitializer.java
@@ -112,7 +112,7 @@ public class ConfigInitializer {
         } else if (boolean.class.equals(type) || Boolean.class.equals(type)) {
             result = Boolean.valueOf(value);
         } else if (float.class.equals(type) || Float.class.equals(type)) {
-            result = Boolean.valueOf(value);
+            result = Float.valueOf(value);
         } else if (double.class.equals(type) || Double.class.equals(type)) {
             result = Double.valueOf(value);
         } else if (List.class.equals(type)) {


### PR DESCRIPTION
### Fix the conversion problem of float type in ConfigInitializer.
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.