### PR TITLE
Fixed part of the dynamic configuration of ConfigurationDiscoveryService that does not take effect under certain circumstances.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Release Notes.
 * Add `okhttp-4.x` plugin.
 * Fix NPE when thrift field is nested in plugin `thrift`
 * Fix possible NullPointerException in agent's ES plugin.
+* Fixed part of the dynamic configuration of ConfigurationDiscoveryService that does not take effect under certain circumstances.
 
 #### OAP-Backend
 * BugFix: filter invalid Envoy access logs whose socket address is empty.

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/dynamic/ConfigurationDiscoveryService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/dynamic/ConfigurationDiscoveryService.java
@@ -62,6 +62,8 @@ public class ConfigurationDiscoveryService implements BootService, GRPCChannelLi
     private String uuid;
     private final Register register = new Register();
 
+    private int lastRegisterWatcherSize;
+
     private volatile ScheduledFuture<?> getDynamicConfigurationFuture;
     private volatile GRPCChannelStatus status = GRPCChannelStatus.DISCONNECT;
     private volatile ConfigurationDiscoveryServiceGrpc.ConfigurationDiscoveryServiceBlockingStub configurationDiscoveryServiceBlockingStub;
@@ -206,6 +208,15 @@ public class ConfigurationDiscoveryService implements BootService, GRPCChannelLi
             try {
                 ConfigurationSyncRequest.Builder builder = ConfigurationSyncRequest.newBuilder();
                 builder.setService(Config.Agent.SERVICE_NAME);
+
+                // Some plugin will register watcher later.
+                final int size = register.keys().size();
+                if (lastRegisterWatcherSize != size) {
+                    // reset uuid, avoid the same uuid causing the configuration not to be updated.
+                    uuid = null;
+                    lastRegisterWatcherSize = size;
+                }
+
                 if (null != uuid) {
                     builder.setUuid(uuid);
                 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/dynamic/ConfigurationDiscoveryService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/dynamic/ConfigurationDiscoveryService.java
@@ -62,7 +62,7 @@ public class ConfigurationDiscoveryService implements BootService, GRPCChannelLi
     private String uuid;
     private final Register register = new Register();
 
-    private int lastRegisterWatcherSize;
+    private volatile int lastRegisterWatcherSize;
 
     private volatile ScheduledFuture<?> getDynamicConfigurationFuture;
     private volatile GRPCChannelStatus status = GRPCChannelStatus.DISCONNECT;


### PR DESCRIPTION

### Fix part of the dynamic configuration of ConfigurationDiscoveryService that does not take effect under certain circumstances.
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

The dynamic configuration service is started early, and the dynamic configuration of some plugins may be loaded late, which results in that after the configuration is obtained from the oap for the first time, some watchers have not been registered at this time, and later registered, but the server may return The id is the same as the current one, and will not be updated.