### PR TITLE
Fetch further data only when they're requested

### DIFF
--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/AlarmQuery.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/AlarmQuery.java
@@ -97,7 +97,7 @@ public class AlarmQuery implements GraphQLQueryResolver {
         Alarms alarms = getQueryService().getAlarm(
             scopeId, keyword, paging, startSecondTB, endSecondTB, tags);
 
-        final boolean selectEvents = env.getSelectionSet().get().containsKey("items/events");
+        final boolean selectEvents = env.getSelectionSet().get().entrySet().stream().anyMatch(it -> it.getKey().contains("/events/"));
 
         if (selectEvents) {
             return findRelevantEvents(alarms, conditionPrototype);

--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/AlarmQuery.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/AlarmQuery.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.oap.query.graphql.resolver;
 
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 
+import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +80,8 @@ public class AlarmQuery implements GraphQLQueryResolver {
     }
 
     public Alarms getAlarm(final Duration duration, final Scope scope, final String keyword,
-                           final Pagination paging, final List<Tag> tags) throws Exception {
+                           final Pagination paging, final List<Tag> tags,
+                           final DataFetchingEnvironment env) throws Exception {
         Integer scopeId = null;
         if (scope != null) {
             scopeId = scope.getScopeId();
@@ -94,7 +96,14 @@ public class AlarmQuery implements GraphQLQueryResolver {
         }
         Alarms alarms = getQueryService().getAlarm(
             scopeId, keyword, paging, startSecondTB, endSecondTB, tags);
-        return findRelevantEvents(alarms, conditionPrototype);
+
+        final boolean selectEvents = env.getSelectionSet().get().containsKey("items/events");
+
+        if (selectEvents) {
+            return findRelevantEvents(alarms, conditionPrototype);
+        }
+
+        return alarms;
     }
 
     private Alarms findRelevantEvents(


### PR DESCRIPTION
Follow up #6888 , nowadays our GraphQL queries always fetch all data from DB, and only some of them are requested by frontend (web ui), this is typically obvious in #6888 so this PR determines whether we should fetch events when querying alarms.

#6888 was no released yet so I don't update change log here.

@wu-sheng do you have any other similar situations in mind that we also need to check?