### PR TITLE
fixed jdk-threading-plugin memory leak #7001

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@ Release Notes.
 * Fixed part of the dynamic configuration of ConfigurationDiscoveryService that does not take effect under certain circumstances.
 * Introduce method interceptor API v2
 * Fix ClassCast issue for RequestHolder/ResponseHolder.
-* fixed `jdk-threading-plugin` memory leak #7001
+* fixed `jdk-threading-plugin` memory leak.
 
 #### OAP-Backend
 * BugFix: filter invalid Envoy access logs whose socket address is empty.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Release Notes.
 * Fixed part of the dynamic configuration of ConfigurationDiscoveryService that does not take effect under certain circumstances.
 * Introduce method interceptor API v2
 * Fix ClassCast issue for RequestHolder/ResponseHolder.
+* fixed `jdk-threading-plugin` memory leak #7001
 
 #### OAP-Backend
 * BugFix: filter invalid Envoy access logs whose socket address is empty.

--- a/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdk/threading/ThreadingMethodInterceptor.java
+++ b/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdk/threading/ThreadingMethodInterceptor.java
@@ -34,10 +34,11 @@ public class ThreadingMethodInterceptor implements InstanceMethodsAroundIntercep
     public void beforeMethod(final EnhancedInstance objInst, final Method method, final Object[] allArguments,
         final Class<?>[] argumentsTypes, final MethodInterceptResult result) {
 
+        AbstractSpan span = ContextManager.createLocalSpan(generateOperationName(objInst, method));
+        span.setComponent(ComponentsDefine.JDK_THREADING);
+
         final Object storedField = objInst.getSkyWalkingDynamicField();
         if (storedField != null) {
-            AbstractSpan span = ContextManager.createLocalSpan(generateOperationName(objInst, method));
-            span.setComponent(ComponentsDefine.JDK_THREADING);
             final ContextSnapshot contextSnapshot = (ContextSnapshot) storedField;
             ContextManager.continued(contextSnapshot);
         }

--- a/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdk/threading/ThreadingMethodInterceptor.java
+++ b/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdk/threading/ThreadingMethodInterceptor.java
@@ -47,12 +47,7 @@ public class ThreadingMethodInterceptor implements InstanceMethodsAroundIntercep
     @Override
     public Object afterMethod(final EnhancedInstance objInst, final Method method, final Object[] allArguments,
         final Class<?>[] argumentsTypes, final Object ret) {
-
-        final Object storedField = objInst.getSkyWalkingDynamicField();
-        if (storedField != null) {
-            ContextManager.stopSpan();
-        }
-
+        ContextManager.stopSpan();
         return ret;
     }
 

--- a/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdk/threading/ThreadingMethodInterceptor.java
+++ b/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdk/threading/ThreadingMethodInterceptor.java
@@ -34,11 +34,10 @@ public class ThreadingMethodInterceptor implements InstanceMethodsAroundIntercep
     public void beforeMethod(final EnhancedInstance objInst, final Method method, final Object[] allArguments,
         final Class<?>[] argumentsTypes, final MethodInterceptResult result) {
 
-        AbstractSpan span = ContextManager.createLocalSpan(generateOperationName(objInst, method));
-        span.setComponent(ComponentsDefine.JDK_THREADING);
-
         final Object storedField = objInst.getSkyWalkingDynamicField();
         if (storedField != null) {
+            AbstractSpan span = ContextManager.createLocalSpan(generateOperationName(objInst, method));
+            span.setComponent(ComponentsDefine.JDK_THREADING);
             final ContextSnapshot contextSnapshot = (ContextSnapshot) storedField;
             ContextManager.continued(contextSnapshot);
         }


### PR DESCRIPTION
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

fixed the issues #7001 

In the following scene, it will cause a memory leak:
```java
	private static final ThreadPoolExecutor TPE = new ThreadPoolExecutor(4, 4,60 , TimeUnit.SECONDS, new ArrayBlockingQueue<>(1000));
	public static void main(String[] args) {
		// do something
		TPE.execute(new Runnable() {
			@Override
			public void run() {
				// do something
			}
		});
		TPE.shutdown();
		try {
			TPE.awaitTermination(2, TimeUnit.HOURS);
		} catch (InterruptedException e) {
			// do something
		}
	}
```

ThreadingMethodInterceptor class, as below：
```java
    @Override
    public void beforeMethod(final EnhancedInstance objInst, final Method method, final Object[] allArguments,
        final Class<?>[] argumentsTypes, final MethodInterceptResult result) {
        
        // this code cause a memory leak
        AbstractSpan span = ContextManager.createLocalSpan(generateOperationName(objInst, method));
        span.setComponent(ComponentsDefine.JDK_THREADING);

        final Object storedField = objInst.getSkyWalkingDynamicField();
        if (storedField != null) {
            final ContextSnapshot contextSnapshot = (ContextSnapshot) storedField;
            ContextManager.continued(contextSnapshot);
        }

    }
```


