### PR TITLE
fix wrong parameterized type in MeterSystem

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/MeterSystem.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/MeterSystem.java
@@ -58,7 +58,7 @@ public class MeterSystem implements Service {
     private static final String METER_CLASS_PACKAGE = "org.apache.skywalking.oap.server.core.analysis.meter.dynamic.";
     private ModuleManager manager;
     private ClassPool classPool;
-    private Map<String, Class<? extends MeterFunction>> functionRegister = new HashMap<>();
+    private Map<String, Class<? extends AcceptableValue>> functionRegister = new HashMap<>();
     /**
      * Host the dynamic meter prototype classes. These classes could be create dynamically through {@link
      * Object#clone()} in the runtime;
@@ -87,7 +87,7 @@ public class MeterSystem implements Service {
                 }
                 functionRegister.put(
                     metricsFunction.functionName(),
-                    (Class<? extends MeterFunction>) functionClass
+                    (Class<? extends AcceptableValue>) functionClass
                 );
             }
         }
@@ -105,7 +105,7 @@ public class MeterSystem implements Service {
     public synchronized <T> void create(String metricsName,
         String functionName,
         ScopeType type) throws IllegalArgumentException {
-        final Class<? extends MeterFunction> meterFunction = functionRegister.get(functionName);
+        final Class<? extends AcceptableValue> meterFunction = functionRegister.get(functionName);
 
         if (meterFunction == null) {
             throw new IllegalArgumentException("Function " + functionName + " can't be found.");
@@ -144,7 +144,7 @@ public class MeterSystem implements Service {
         /**
          * Create a new meter class dynamically.
          */
-        final Class<? extends MeterFunction> meterFunction = functionRegister.get(functionName);
+        final Class<? extends AcceptableValue> meterFunction = functionRegister.get(functionName);
 
         if (meterFunction == null) {
             throw new IllegalArgumentException("Function " + functionName + " can't be found.");


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

I don't think `functionClass` inherits from MeterFunction. Actually, it was marked by @MeterFunction. 

https://github.com/apache/skywalking/blob/f6f5af1b437bd1f65d0f4452fb54429c2ee6e617/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/MeterSystem.java#L84

According to the above code, it seems like inherit from `AcceptableValue`. It works well because generic type would be removed(type erasure) at runtime. 