### PR TITLE
Fix OAL doc example bug (#7093)

### DIFF
--- a/docs/en/concepts-and-designs/oal.md
+++ b/docs/en/concepts-and-designs/oal.md
@@ -59,8 +59,8 @@ In this case, all input are requests of each endpoint, condition is `endpoint.st
 In this case, all input are requests of each browser app traffic, `numerator` condition is `trafficCategory == BrowserAppTrafficCategory.FIRST_ERROR` and `denominator` condition is `trafficCategory == BrowserAppTrafficCategory.NORMAL`.
 The parameter (1) is the `numerator` condition.
 The parameter (2) is the `denominator` condition.
-- `sum`. The sum calls per scope entity.
-> service_calls_sum = from(Service.*).sum();
+- `count`. The sum calls per scope entity.
+> service_calls_sum = from(Service.*).count();
 
 In this case, calls of each service. 
 
@@ -121,13 +121,13 @@ endpoint_percentile = from(Endpoint.latency).percentile(10)
 endpoint_success = from(Endpoint.*).filter(status == true).percent()
 
 // Caculate the sum of response code in [404, 500, 503], for each service.
-endpoint_abnormal = from(Endpoint.*).filter(responseCode in [404, 500, 503]).sum()
+endpoint_abnormal = from(Endpoint.*).filter(responseCode in [404, 500, 503]).count()
 
 // Caculate the sum of request type in [RequestType.PRC, RequestType.gRPC], for each service.
-endpoint_rpc_calls_sum = from(Endpoint.*).filter(type in [RequestType.PRC, RequestType.gRPC]).sum()
+endpoint_rpc_calls_sum = from(Endpoint.*).filter(type in [RequestType.PRC, RequestType.gRPC]).count()
 
 // Caculate the sum of endpoint name in ["/v1", "/v2"], for each service.
-endpoint_url_sum = from(Endpoint.*).filter(endpointName in ["/v1", "/v2"]).sum()
+endpoint_url_sum = from(Endpoint.*).filter(name in ["/v1", "/v2"]).count()
 
 // Caculate the sum of calls for each service.
 endpoint_calls = from(Endpoint.*).sum()


### PR DESCRIPTION
The doc example error on `website-docs/8.2.0` branch
- `sum` should be modified to `count`
- the `endpointName` not in the scope of `Endpoint`, should be modified to `name`