### PR TITLE
Disable spring sleuth analyzer by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,10 +9,9 @@ Release Notes.
 
 #### Java Agent
 * Supports modifying span attributes in async mode.
-* Disable Spring sleuth meter analyzer by default.
 
 #### OAP-Backend
-
+* Disable Spring sleuth meter analyzer by default.
 
 #### UI
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Release Notes.
 
 #### Java Agent
 * Supports modifying span attributes in async mode.
+* Disable Spring sleuth meter analyzer by default.
 
 #### OAP-Backend
 

--- a/docs/en/setup/backend/backend-meter.md
+++ b/docs/en/setup/backend/backend-meter.md
@@ -30,6 +30,10 @@ The file is written in YAML format, defined by the scheme described below. Brack
 An example can be found [here](../../../../oap-server/server-bootstrap/src/main/resources/meter-analyzer-config/spring-sleuth.yaml).
 If you're using Spring Sleuth, see [Spring Sleuth Setup](spring-sleuth-setup.md).
 
+| Rule Name | Description | Configuration File | Data Source |
+|-----|-----|-----|-----|
+|spring-sleuth| Metrics of Spring Sleuth Application | meter-analyzer-config/spring-sleuth.yaml | Sprign Sleuth Application --meter format--> SkyWalking OAP Server |
+
 ### Meters configuration
 
 ```yaml

--- a/docs/en/setup/backend/backend-receivers.md
+++ b/docs/en/setup/backend/backend-receivers.md
@@ -160,10 +160,6 @@ The receiver adds labels with `key = service` and `key = instance` to the collec
 and values from service and service instance name defined in SkyWalking Agent,
 for identification of the metric data.
 
-| Rule Name | Description | Configuration File | Data Source |
-|-----|-----|-----|-----|
-|spring-sleuth| Metrics of Spring Sleuth Application | meter-analyzer-config/spring-sleuth.yaml | Sprign Sleuth Application --meter format--> SkyWalking OAP Server |
-
 ## Zipkin receiver
 The Zipkin receiver makes the OAP server work as an alternative Zipkin server implementation. It supports Zipkin v1/v2 formats through HTTP service.
 Make sure you use this with `SW_STORAGE=zipkin-elasticsearch7` option to activate Zipkin storage implementation.

--- a/docs/en/setup/backend/backend-receivers.md
+++ b/docs/en/setup/backend/backend-receivers.md
@@ -148,6 +148,22 @@ receiver-meter:
   default:
 ```
 
+To activate the meter rule files:
+```yaml
+agent-analyzer:
+  selector: ${SW_AGENT_ANALYZER:default}
+  default:
+    meterAnalyzerActiveFiles: ${SW_METER_ANALYZER_ACTIVE_FILES:} # Which files could be meter analyzed, files split by ","
+```
+
+The receiver adds labels with `key = service` and `key = instance` to the collected data samples,
+and values from service and service instance name defined in SkyWalking Agent,
+for identification of the metric data.
+
+| Rule Name | Description | Configuration File | Data Source |
+|-----|-----|-----|-----|
+|spring-sleuth| Metrics of Spring Sleuth Application | meter-analyzer-config/spring-sleuth.yaml | Sprign Sleuth Application --meter format--> SkyWalking OAP Server |
+
 ## Zipkin receiver
 The Zipkin receiver makes the OAP server work as an alternative Zipkin server implementation. It supports Zipkin v1/v2 formats through HTTP service.
 Make sure you use this with `SW_STORAGE=zipkin-elasticsearch7` option to activate Zipkin storage implementation.

--- a/docs/en/setup/backend/spring-sleuth-setup.md
+++ b/docs/en/setup/backend/spring-sleuth-setup.md
@@ -38,6 +38,14 @@ receiver-meter:
 
 2. Configure the meter config file, It already has the [spring sleuth meter config](../../../../oap-server/server-bootstrap/src/main/resources/meter-analyzer-config/spring-sleuth.yaml).
 If you also has some customized meter at the agent side, please read [meter document](backend-meter.md#meters-configure) to configure meter.
+   
+3. Enable Spring sleuth config in the `applicaiton.yml`.
+```yaml
+agent-analyzer:
+  selector: ${SW_AGENT_ANALYZER:default}
+  default:
+    meterAnalyzerActiveFiles: ${SW_METER_ANALYZER_ACTIVE_FILES:spring-sleuth}
+```
 
 ## Add UI dashboard
 

--- a/oap-server/server-bootstrap/src/main/resources/application.yml
+++ b/oap-server/server-bootstrap/src/main/resources/application.yml
@@ -256,7 +256,7 @@ agent-analyzer:
     # Exit spans with the component in the list would not generate the client-side instance relation metrics.
     noUpstreamRealAddressAgents: ${SW_NO_UPSTREAM_REAL_ADDRESS:6000,9000}
     slowTraceSegmentThreshold: ${SW_SLOW_TRACE_SEGMENT_THRESHOLD:-1} # Setting this threshold about the latency would make the slow trace segments sampled if they cost more time, even the sampling mechanism activated. The default value is `-1`, which means would not sample slow traces. Unit, millisecond.
-    meterAnalyzerActiveFiles: ${SW_METER_ANALYZER_ACTIVE_FILES:spring-sleuth} # Which files could be meter analyzed, files split by ","
+    meterAnalyzerActiveFiles: ${SW_METER_ANALYZER_ACTIVE_FILES:} # Which files could be meter analyzed, files split by ","
 
 log-analyzer:
   selector: ${SW_LOG_ANALYZER:default}


### PR DESCRIPTION
# Ref #7091 
- Disable spring sleuth analyzer by default
- Add `agent-analyzer.meterAnalyzerActiveFiles` config description in the document.
- Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).