### PR TITLE
startup script added start-daemon and start-foreground parameters.

### DIFF
--- a/dist-material/bin/oapService.sh
+++ b/dist-material/bin/oapService.sh
@@ -37,8 +37,23 @@ done
 
 OAP_OPTIONS=" -Doap.logDir=${OAP_LOG_DIR}"
 
-eval exec "\"$_RUNJAVA\" ${JAVA_OPTS} ${OAP_OPTIONS} -classpath $CLASSPATH org.apache.skywalking.oap.server.starter.OAPServerStartUp \
-        2>${OAP_LOG_DIR}/oap.log 1> /dev/null &"
+_help(){
+    echo "USAGE: $0 [help|start-foreground|start-daemon]"
+    exit 1
+}
+COMMAND=$1
+case $COMMAND in
+    start-foreground)
+        eval exec "\"$_RUNJAVA\" ${JAVA_OPTS} ${OAP_OPTIONS} -classpath $CLASSPATH org.apache.skywalking.oap.server.starter.OAPServerStartUp"
+    ;;
+    start-daemon)
+        eval exec "\"$_RUNJAVA\" ${JAVA_OPTS} ${OAP_OPTIONS} -classpath $CLASSPATH org.apache.skywalking.oap.server.starter.OAPServerStartUp \
+            2>${OAP_LOG_DIR}/oap.log 1> /dev/null &"
+    ;;
+    *)
+        _help
+    ;;
+esac
 
 if [ $? -eq 0 ]; then
     sleep 1

--- a/dist-material/bin/startup.sh
+++ b/dist-material/bin/startup.sh
@@ -21,6 +21,6 @@ PRGDIR=`dirname "$PRG"`
 OAP_EXE=oapService.sh
 WEBAPP_EXE=webappService.sh
 
-"$PRGDIR"/"$OAP_EXE"
+"$PRGDIR"/"$OAP_EXE" start-daemon
 
-"$PRGDIR"/"$WEBAPP_EXE"
+"$PRGDIR"/"$WEBAPP_EXE" start-daemon

--- a/dist-material/bin/webappService.sh
+++ b/dist-material/bin/webappService.sh
@@ -32,10 +32,28 @@ LOG_FILE_LOCATION=${WEBAPP_LOG_DIR}/webapp.log
 _RUNJAVA=${JAVA_HOME}/bin/java
 [ -z "$JAVA_HOME" ] && _RUNJAVA=java
 
-eval exec "\"$_RUNJAVA\" ${JAVA_OPTS} -jar ${JAR_PATH}/skywalking-webapp.jar \
-         --spring.config.location=${JAR_PATH}/webapp.yml \
-         --logging.file=${LOG_FILE_LOCATION} \
-        2>${WEBAPP_LOG_DIR}/webapp-console.log 1> /dev/null &"
+_help(){
+    echo "USAGE: $0 [help|start-foreground|start-daemon]"
+    exit 1
+}
+COMMAND=$1
+case $COMMAND in
+    start-foreground)
+        eval exec "\"$_RUNJAVA\" ${JAVA_OPTS} -jar ${JAR_PATH}/skywalking-webapp.jar \
+            --spring.config.location=${JAR_PATH}/webapp.yml \
+            --logging.file=${LOG_FILE_LOCATION}"
+    ;;
+    start-daemon)
+        eval exec "\"$_RUNJAVA\" ${JAVA_OPTS} -jar ${JAR_PATH}/skywalking-webapp.jar \
+            --spring.config.location=${JAR_PATH}/webapp.yml \
+            --logging.file=${LOG_FILE_LOCATION} \
+            2>${WEBAPP_LOG_DIR}/webapp-console.log 1> /dev/null &"
+    ;;
+    *)
+        _help
+    ;;
+esac
+
 
 if [ $? -eq 0 ]; then
     sleep 1

--- a/dist-material/config-examples/skywalking-webapp.service
+++ b/dist-material/config-examples/skywalking-webapp.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Skywalking webapp service
+Documentation=http://skywalking.apache.org/docs/main/v8.5.0/en/setup/backend/backend-cluster/
+After=network.target
+
+[Service]
+Type=forking
+User=sw
+EnvironmentFile=-/var/skywalking/skywalking.env
+ExecStart=/opt/skywalking/bin/webappService.sh start-deamon
+KillMode=process
+Restart=on-failure
+SuccessExitStatus=143
+RestartSec=30s
+
+[Install]
+WantedBy=multi-user.target

--- a/dist-material/config-examples/skywalking.ini
+++ b/dist-material/config-examples/skywalking.ini
@@ -1,0 +1,55 @@
+[program:skywalking]
+command = /data/apps/opt/skywalking/bin/oapService.sh start-foreground
+directory = /data/apps/opt/skywalking
+autostart = true
+autorestart = true
+startsecs = 10
+startretries = 3
+stopsignal=TERM
+killasgroup = true
+user = sw
+environment=
+    SW_JDBC_URL="jdbc:mysql://10.0.0.2:3307/swtest",
+    SW_DATA_SOURCE_USER="swtest",
+    SW_DATA_SOURCE_PASSWORD="swtest123",
+    OAP_LOG_DIR="/data/apps/log/skywalking",
+    SW_STORAGE="mysql",
+    JAVA_OPTS="-Xms2048M -Xmx2048M",
+    SW_RECEIVER_ZIPKIN="default",
+    PATH="/data/apps/opt/mysql/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
+    redirect_stderr = false
+stdout_logfile=/data/apps/log/skywalking/%(program_name)s_std.log
+stdout_logfile_maxbytkafka = 300MB
+stdout_logfile_backups= 20
+stdout_events_enabled = false
+stderr_logfile=/data/apps/log/skywalking/%(program_name)s_err.log
+stderr_logfile_maxbytkafka=300MB
+stderr_logfile_backups=10
+stderr_capture_maxbytkafka=3MB
+stderr_events_enabled= false
+
+
+[program:skywalking-webapp]
+command = /data/apps/opt/skywalking/bin/webappService.sh start-foreground
+directory = /data/apps/opt/skywalking
+autostart = true
+autorestart = true
+startsecs = 10
+startretries = 3
+stopsignal=TERM
+killasgroup = true
+user = sw
+environment=
+    WEBAPP_LOG_DIR="/data/apps/log/skywalking",
+    JAVA_OPTS="-Xms2048M -Xmx2048M",
+    PATH="/data/apps/opt/mysql/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
+redirect_stderr = false
+stdout_logfile=/data/apps/log/skywalking/%(program_name)s_std.log
+stdout_logfile_maxbytkafka = 300MB
+stdout_logfile_backups= 20
+stdout_events_enabled = false
+stderr_logfile=/data/apps/log/skywalking/%(program_name)s_err.log
+stderr_logfile_maxbytkafka=300MB
+stderr_logfile_backups=10
+stderr_capture_maxbytkafka=3MB
+stderr_events_enabled= false

--- a/dist-material/config-examples/skywalking.service
+++ b/dist-material/config-examples/skywalking.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Skywalking OAP service
+Documentation=http://skywalking.apache.org/docs/main/v8.5.0/en/setup/backend/backend-cluster/
+After=network.target
+
+[Service]
+Type=forking
+EnvironmentFile=-/var/skywalking/skywalking.env
+ExecStart=/opt/skywalking/bin/oapService.sh start-deamon
+KillMode=process
+Restart=on-failure
+SuccessExitStatus=143
+RestartSec=42s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# 情况说明
在下近来部署skywalking,使用的是直接在vm上部署（未使用docker）,我觉得了解一个应用最好的方式就是手动开始，而不是使用一些“包装”性的方式。

但是我发现skywalking的启动脚本中是使用了 `eval exec &`这种放在了后台的方式，且没有其他选项。

刚开始我想使用supervisor管理skywalking, 没办法，还自己修改了`oapService.sh`和`webappService.sh`使其在前台运行。

后来，我又在不修改上述脚本的情况下，编写了`oap`和`webapp`的 `systemd`配置文件。

# 修改
现在我作了如下修改
1. 修改`oapService.sh`和`webappService.sh`脚本，以支持参数可在前台或后台启动
    * start-daemon|start-foreground分别在后台和前台启动
    * 如若不妥，烦请给予意见
2. 代码目录中给出 supervisor 和 systemd 的配置文件，方便管理skywalking进程。
    * 文件存放在`dist-material/config-examples`