### PR TITLE
optimize db.statement of jedis blocking api with timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,9 @@ Release Notes.
 * Add Python celery plugin.
 * Fix default config for metrics.
 
+#### jedis-2.x-plugin
+* add `db.statement` for block command with a timeout parameter like `blpop`
+
 #### Documentation
 
 

--- a/apm-sniffer/apm-sdk-plugin/jedis-2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jedis/v2/JedisMethodInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/jedis-2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jedis/v2/JedisMethodInterceptorTest.java
@@ -195,7 +195,7 @@ public class JedisMethodInterceptorTest {
 
     private Method getMockBlpopMethod() {
         try {
-            return Jedis.class.getMethod("blpop", String[].class);
+            return Jedis.class.getMethod("blpop", int.class, String[].class);
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
             return null;


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->


### Fix miss db.statement of jedis blocking api with a timeout parameter [#7170](https://github.com/apache/skywalking/issues/7170)
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
`JedisMethodInterceptor` only check `String` and `byte[]` as the first argument type, but some commands like `blpop` use `int` as timeout, so it won't have a `db.statement` tag in this case.

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<7170>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
