### PR TITLE
Perf: cache regex pattern and result, optimize string concatenation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@ Release Notes.
 * Fix CounterWindow increase computing issue.
 * Performance: optimize Envoy ALS analyzer performance in high traffic load scenario (reduce ~1cpu in ~10k RPS).
 * Performance: trim useless metadata fields in Envoy ALS metadata to improve performance.
+* Performance: cache regex pattern and result, optimize string concatenation in Envy ALS analyzer.
 
 #### UI
 * Fix the date component for log conditions.

--- a/oap-server/oal-rt/src/main/resources/code-templates/metrics/id.ftl
+++ b/oap-server/oal-rt/src/main/resources/code-templates/metrics/id.ftl
@@ -1,13 +1,10 @@
 public String id() {
-String splitJointId = String.valueOf(getTimeBucket());
+StringBuilder splitJointId = new StringBuilder(String.valueOf(getTimeBucket()));
 <#list fieldsFromSource as sourceField>
     <#if sourceField.isID()>
-        <#if sourceField.getTypeName() == "java.lang.String">
-            splitJointId += org.apache.skywalking.oap.server.core.Const.ID_CONNECTOR + ${sourceField.fieldName};
-        <#else>
-            splitJointId += org.apache.skywalking.oap.server.core.Const.ID_CONNECTOR + String.valueOf(${sourceField.fieldName});
-        </#if>
+        splitJointId.append(org.apache.skywalking.oap.server.core.Const.ID_CONNECTOR)
+                    .append(${sourceField.fieldName});
     </#if>
 </#list>
-return splitJointId;
+return splitJointId.toString();
 }


### PR DESCRIPTION
### Improve the performance of Envoy ALS analyzer

The possible metrics names are relatively fixed in an OAP run, we previously always escape the metrics names, building a new regex Pattern from scratch, which is cpu-consuming.

In this patch, I cache the escaped metrics names, and if it is missing, use a pre-compiled regex Pattern to escape the metrics name.

This patch also replace string concatenation `+` with `StringBuilder` in runtime-generated classes, which won't get optimized by Java compiler.

This may reduce 1~1.5 vCPU under 20K RPS environment.

- [x] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
```java
    String str;
    Pattern pattern;

    @Setup
    public void setup() {
        str = "abc.def.ghi";
        pattern = Pattern.compile("\\.");
    }

    @Benchmark
    public void precompile(Blackhole bh) {
        bh.consume(pattern.matcher(str).replaceAll("_"));
    }

    @Benchmark
    public void compileOnTheFly(Blackhole bh) {
        bh.consume(str.replaceAll("\\.", "_"));
    }

    public static void main(String[] args) throws RunnerException {
        Options opt = new OptionsBuilder()
                .include(MyBenchmark.class.getSimpleName())
                .addProfiler(GCProfiler.class)
                .build();

        new Runner(opt).run();
    }
```
- [x] The benchmark result.
```text

Benchmark                                                      Mode  Cnt        Score        Error   Units
MyBenchmark.compileOnTheFly                                   thrpt   25  4325522.212 ± 181192.055   ops/s
MyBenchmark.compileOnTheFly:·gc.alloc.rate                    thrpt   25     3487.521 ±    146.028  MB/sec
MyBenchmark.compileOnTheFly:·gc.alloc.rate.norm               thrpt   25      888.042 ±      0.002    B/op
MyBenchmark.compileOnTheFly:·gc.churn.G1_Eden_Space           thrpt   25     3488.556 ±    146.839  MB/sec
MyBenchmark.compileOnTheFly:·gc.churn.G1_Eden_Space.norm      thrpt   25      888.306 ±      3.488    B/op
MyBenchmark.compileOnTheFly:·gc.churn.G1_Survivor_Space       thrpt   25        0.018 ±      0.002  MB/sec
MyBenchmark.compileOnTheFly:·gc.churn.G1_Survivor_Space.norm  thrpt   25        0.004 ±      0.001    B/op
MyBenchmark.compileOnTheFly:·gc.count                         thrpt   25     1993.000               counts
MyBenchmark.compileOnTheFly:·gc.time                          thrpt   25     2196.000                   ms
MyBenchmark.precompile                                        thrpt   25  6473465.669 ± 293798.296   ops/s
MyBenchmark.precompile:·gc.alloc.rate                         thrpt   25     2351.370 ±    106.732  MB/sec
MyBenchmark.precompile:·gc.alloc.rate.norm                    thrpt   25      400.026 ±      0.002    B/op
MyBenchmark.precompile:·gc.churn.G1_Eden_Space                thrpt   25     2353.410 ±    108.659  MB/sec
MyBenchmark.precompile:·gc.churn.G1_Eden_Space.norm           thrpt   25      400.358 ±      1.799    B/op
MyBenchmark.precompile:·gc.churn.G1_Survivor_Space            thrpt   25        0.007 ±      0.002  MB/sec
MyBenchmark.precompile:·gc.churn.G1_Survivor_Space.norm       thrpt   25        0.001 ±      0.001    B/op
MyBenchmark.precompile:·gc.count                              thrpt   25     1838.000               counts
MyBenchmark.precompile:·gc.time                               thrpt   25     1905.000                   ms

```
- [x] Links/URLs to the theory proof or discussion articles/blogs. NO
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>. NO
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
