### PR TITLE
Perf: cache metrics id and entity id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ Release Notes.
 * Performance: trim useless metadata fields in Envoy ALS metadata to improve performance.
 * Fix: slowDBAccessThreshold dynamic config error when not configured.
 * Performance: cache regex pattern and result, optimize string concatenation in Envy ALS analyzer.
+* Performance: cache metrics id and entity id in `Metrics` and `ISource`.
 
 #### UI
 * Fix the date component for log conditions.

--- a/oap-server/exporter/src/test/java/org/apache/skywalking/oap/server/exporter/provider/grpc/MockMetrics.java
+++ b/oap-server/exporter/src/test/java/org/apache/skywalking/oap/server/exporter/provider/grpc/MockMetrics.java
@@ -24,7 +24,7 @@ import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
 public class MockMetrics extends Metrics {
 
     @Override
-    public String id() {
+    protected String id0() {
         return "mock-metrics";
     }
 

--- a/oap-server/oal-rt/src/main/resources/code-templates/metrics/id.ftl
+++ b/oap-server/oal-rt/src/main/resources/code-templates/metrics/id.ftl
@@ -1,4 +1,4 @@
-public String id() {
+protected String id0() {
 StringBuilder splitJointId = new StringBuilder(String.valueOf(getTimeBucket()));
 <#list fieldsFromSource as sourceField>
     <#if sourceField.isID()>

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRuleTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRuleTest.java
@@ -429,7 +429,7 @@ public class RunningRuleTest {
         private int value;
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 
@@ -486,7 +486,7 @@ public class RunningRuleTest {
         }
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 
@@ -538,7 +538,7 @@ public class RunningRuleTest {
         private DataTable value;
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/endpoint/EndpointTraffic.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/endpoint/EndpointTraffic.java
@@ -56,7 +56,7 @@ public class EndpointTraffic extends Metrics {
     private String name = Const.EMPTY_STRING;
 
     @Override
-    public String id() {
+    protected String id0() {
         // Downgrade the time bucket to day level only.
         // supportDownSampling == false for this entity.
         return IDManager.EndpointID.buildId(

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/instance/InstanceTraffic.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/instance/InstanceTraffic.java
@@ -121,7 +121,7 @@ public class InstanceTraffic extends Metrics {
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return IDManager.ServiceInstanceID.buildId(serviceId, name);
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/networkalias/NetworkAddressAlias.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/networkalias/NetworkAddressAlias.java
@@ -82,7 +82,7 @@ public class NetworkAddressAlias extends Metrics {
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return IDManager.NetworkAddressAliasDefine.buildId(address);
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/endpoint/EndpointRelationServerSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/endpoint/EndpointRelationServerSideMetrics.java
@@ -62,7 +62,7 @@ public class EndpointRelationServerSideMetrics extends Metrics {
     private String entityId;
 
     @Override
-    public String id() {
+    protected String id0() {
         String splitJointId = String.valueOf(getTimeBucket());
         splitJointId += Const.ID_CONNECTOR + entityId;
         return splitJointId;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationClientSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationClientSideMetrics.java
@@ -72,7 +72,7 @@ public class ServiceInstanceRelationClientSideMetrics extends Metrics {
     private String entityId;
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationServerSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationServerSideMetrics.java
@@ -72,7 +72,7 @@ public class ServiceInstanceRelationServerSideMetrics extends Metrics {
     private String entityId;
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationClientSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationClientSideMetrics.java
@@ -62,7 +62,7 @@ public class ServiceRelationClientSideMetrics extends Metrics {
     private String entityId;
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationServerSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationServerSideMetrics.java
@@ -62,7 +62,7 @@ public class ServiceRelationServerSideMetrics extends Metrics {
     private String entityId;
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceTraffic.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceTraffic.java
@@ -67,7 +67,7 @@ public class ServiceTraffic extends Metrics {
     private String group;
 
     @Override
-    public String id() {
+    protected String id0() {
         return IDManager.ServiceID.buildId(name, nodeType);
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/HistogramFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/HistogramFunction.java
@@ -138,7 +138,7 @@ public abstract class HistogramFunction extends Metrics implements AcceptableVal
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/PercentileFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/PercentileFunction.java
@@ -246,7 +246,7 @@ public abstract class PercentileFunction extends Metrics implements AcceptableVa
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgFunction.java
@@ -148,7 +148,7 @@ public abstract class AvgFunction extends Metrics implements AcceptableValue<Lon
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgHistogramFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgHistogramFunction.java
@@ -167,7 +167,7 @@ public abstract class AvgHistogramFunction extends Metrics implements Acceptable
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgHistogramPercentileFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgHistogramPercentileFunction.java
@@ -318,7 +318,7 @@ public abstract class AvgHistogramPercentileFunction extends Metrics implements 
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgLabeledFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgLabeledFunction.java
@@ -150,7 +150,7 @@ public abstract class AvgLabeledFunction extends Metrics implements AcceptableVa
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/latest/LatestFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/latest/LatestFunction.java
@@ -129,7 +129,7 @@ public abstract class LatestFunction extends Metrics implements AcceptableValue<
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + entityId;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sum/SumFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sum/SumFunction.java
@@ -123,7 +123,7 @@ public abstract class SumFunction extends Metrics implements AcceptableValue<Lon
     }
 
     @Override
-    public String id() {
+    protected String id0() {
         return getTimeBucket() + Const.ID_CONNECTOR + getEntityId();
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/Metrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/Metrics.java
@@ -131,4 +131,16 @@ public abstract class Metrics extends StreamData implements StorageData {
     private boolean isDayBucket() {
         return TimeBucket.isDayBucket(timeBucket);
     }
+
+    private volatile String id;
+
+    @Override
+    public String id() {
+        if (id == null) {
+            id = id0();
+        }
+        return id;
+    }
+
+    protected abstract String id0();
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Event.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Event.java
@@ -73,7 +73,7 @@ public class Event extends Metrics implements ISource, WithMetadata, LongValueHo
     public static final String END_TIME = "end_time";
 
     @Override
-    public String id() {
+    protected String id0() {
         return getUuid();
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Service.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Service.java
@@ -31,6 +31,8 @@ import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SE
 @ScopeDeclaration(id = SERVICE, name = "Service", catalog = SERVICE_CATALOG_NAME)
 @ScopeDefaultColumn.VirtualColumnDefinition(fieldName = "entityId", columnName = "entity_id", isID = true, type = String.class)
 public class Service extends Source {
+    private volatile String entityId;
+
     @Override
     public int scope() {
         return DefaultScopeDefine.SERVICE;
@@ -38,7 +40,10 @@ public class Service extends Source {
 
     @Override
     public String getEntityId() {
-        return IDManager.ServiceID.buildId(name, nodeType);
+        if (entityId == null) {
+            entityId = IDManager.ServiceID.buildId(name, nodeType);
+        }
+        return entityId;
     }
 
     @Getter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstance.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstance.java
@@ -31,6 +31,8 @@ import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SE
 @ScopeDeclaration(id = SERVICE_INSTANCE, name = "ServiceInstance", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 @ScopeDefaultColumn.VirtualColumnDefinition(fieldName = "entityId", columnName = "entity_id", isID = true, type = String.class)
 public class ServiceInstance extends Source {
+    private volatile String entityId;
+
     @Override
     public int scope() {
         return DefaultScopeDefine.SERVICE_INSTANCE;
@@ -38,7 +40,10 @@ public class ServiceInstance extends Source {
 
     @Override
     public String getEntityId() {
-        return IDManager.ServiceInstanceID.buildId(serviceId, name);
+        if (entityId == null) {
+            entityId = IDManager.ServiceInstanceID.buildId(serviceId, name);
+        }
+        return entityId;
     }
 
     @Getter

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/ApdexMetricsTest.java
@@ -104,7 +104,7 @@ public class ApdexMetricsTest {
     public class ApdexMetricsImpl extends ApdexMetrics {
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/CountMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/CountMetricsTest.java
@@ -56,7 +56,7 @@ public class CountMetricsTest {
 
     public class CountMetricsImpl extends CountMetrics {
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/HeatMapMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/HeatMapMetricsTest.java
@@ -88,7 +88,7 @@ public class HeatMapMetricsTest {
     public class HistogramMetricsMocker extends HistogramMetrics {
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/LongAvgMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/LongAvgMetricsTest.java
@@ -52,7 +52,7 @@ public class LongAvgMetricsTest {
     public class LongAvgMetricsImpl extends LongAvgMetrics {
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/MaxLongMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/MaxLongMetricsTest.java
@@ -54,7 +54,7 @@ public class MaxLongMetricsTest {
     public class MaxLongMetricsImpl extends MaxLongMetrics {
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/MetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/MetricsTest.java
@@ -73,7 +73,7 @@ public class MetricsTest {
     public class MetricsMocker extends Metrics {
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/MinLongMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/MinLongMetricsTest.java
@@ -59,7 +59,7 @@ public class MinLongMetricsTest {
     public class MinLongMetricsImpl extends MinLongMetrics {
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentMetricsTest.java
@@ -67,7 +67,7 @@ public class PercentMetricsTest {
     public class PercentMetricsImpl extends PercentMetrics {
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentileMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/PercentileMetricsTest.java
@@ -118,7 +118,7 @@ public class PercentileMetricsTest {
     public class PercentileMetricsMocker extends PercentileMetrics {
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/PxxMetricsTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/metrics/PxxMetricsTest.java
@@ -97,7 +97,7 @@ public class PxxMetricsTest {
         }
 
         @Override
-        public String id() {
+        protected String id0() {
             return null;
         }
 


### PR DESCRIPTION
There are a lot of calls to `Metrics.id()` and `ISource.getEntityId`, which calculates the id by manipulating strings in every single call, producing many garbage objects.

In this patch, I cache the id and only calculate the id if it's requested for the first time.

### Improve the performance of `Metrics` and `ISource`
- [x] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
    ```java
    AvgFunction function0;
    AvgFunction function1;
    Random random = new Random();
    long timebucket;
    Object name;

    @Setup
    public void setup() {
        timebucket = random.nextLong();
        name = RandomStringUtils.random(5);
        function0 = new AvgFunction() {
            @Override
            public AcceptableValue<Long> createNew() {
                throw new UnexpectedException("createNew should not be called");
            }

            @Override
            public String id0() {
                return timebucket + ID_CONNECTOR + name;
            }
        };
        function1 = new AvgFunction() {
            @Override
            public AcceptableValue<Long> createNew() {
                throw new UnexpectedException("createNew should not be called");
            }

            @Override
            public String id() {
                return timebucket + ID_CONNECTOR + name;
            }
        };
    }

    @Benchmark
    public void id(Blackhole b) {
        for (int i = 0; i < 10; i++) {
            b.consume(function1.id());
        }
    }

    @Benchmark
    public void id0(Blackhole b) {
        for (int i = 0; i < 10; i++) {
            b.consume(function0.id());
        }
    }

    public static void main(String[] args) throws RunnerException {
        Options opt = new OptionsBuilder()
                .include(MyBenchmark.class.getSimpleName())
                .addProfiler(GCProfiler.class)
                .build();

        new Runner(opt).run();
    }
    ```
- [x] The benchmark result.
  ```text
  Benchmark                                         Mode  Cnt         Score         Error   Units
  MyBenchmark.id                                   thrpt   25   1201376.291 ±  152856.703   ops/s
  MyBenchmark.id:·gc.alloc.rate                    thrpt   25      3683.137 ±     375.101  MB/sec
  MyBenchmark.id:·gc.alloc.rate.norm               thrpt   25      3392.168 ±      73.398    B/op
  MyBenchmark.id:·gc.churn.G1_Eden_Space           thrpt   25      3686.722 ±     376.161  MB/sec
  MyBenchmark.id:·gc.churn.G1_Eden_Space.norm      thrpt   25      3395.417 ±      74.860    B/op
  MyBenchmark.id:·gc.churn.G1_Survivor_Space       thrpt   25         0.005 ±       0.001  MB/sec
  MyBenchmark.id:·gc.churn.G1_Survivor_Space.norm  thrpt   25         0.005 ±       0.001    B/op
  MyBenchmark.id:·gc.count                         thrpt   25      2181.000                counts
  MyBenchmark.id:·gc.time                          thrpt   25      2336.000                    ms
  MyBenchmark.id0                                  thrpt   25  39069507.415 ± 1553343.663   ops/s
  MyBenchmark.id0:·gc.alloc.rate                   thrpt   25        ≈ 10⁻⁴                MB/sec
  MyBenchmark.id0:·gc.alloc.rate.norm              thrpt   25        ≈ 10⁻⁶                  B/op
  MyBenchmark.id0:·gc.count                        thrpt   25           ≈ 0                counts
  ```
- [x] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here> NO
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>. NO
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
