### PR TITLE
Enhance the compatibility of `mysql-8.x-plugin` plugin.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Release Notes.
 * Fix async finish repeatedly in `spring-webflux-5.x-webclient` plugin.
 * Add agent plugin to support Sentinel.
 * Move `ehcache-2.x` plugin as an optional plugin.
+* Enhance the compatibility of `mysql-8.x-plugin` plugin.
 
 #### OAP-Backend
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v8/ConnectionCreateInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v8/ConnectionCreateInterceptor.java
@@ -22,7 +22,7 @@ import com.mysql.cj.conf.HostInfo;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
-import org.apache.skywalking.apm.plugin.jdbc.connectionurl.parser.URLParser;
+import org.apache.skywalking.apm.plugin.jdbc.mysql.ConnectionCache;
 import org.apache.skywalking.apm.plugin.jdbc.trace.ConnectionInfo;
 
 import java.lang.reflect.Method;
@@ -40,7 +40,7 @@ public class ConnectionCreateInterceptor implements StaticMethodsAroundIntercept
         Object ret) {
         if (ret instanceof EnhancedInstance) {
             final HostInfo hostInfo = (HostInfo) allArguments[0];
-            ConnectionInfo connectionInfo = URLParser.parser(hostInfo.getDatabaseUrl());
+            ConnectionInfo connectionInfo = ConnectionCache.get(hostInfo.getHostPortPair());
             ((EnhancedInstance) ret).setSkyWalkingDynamicField(connectionInfo);
         }
         return ret;

--- a/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v8/define/CacheIpsInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v8/define/CacheIpsInstrumentation.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.jdbc.mysql.v8.define;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.skywalking.apm.agent.core.plugin.match.MultiClassNameMatch.byMultiClassMatch;
+import static org.apache.skywalking.apm.plugin.jdbc.mysql.Constants.DRIVER_CONNECT_INTERCEPTOR;
+
+public class CacheIpsInstrumentation extends AbstractMysqlInstrumentation {
+
+    private static final String ENHANCE_CLASS_NON_REG = "com.mysql.cj.jdbc.NonRegisteringDriver";
+
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return new ConstructorInterceptPoint[0];
+    }
+
+    @Override
+    public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[] {
+            new InstanceMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named("connect");
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return DRIVER_CONNECT_INTERCEPTOR;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return byMultiClassMatch(ENHANCE_CLASS_NON_REG);
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/src/main/resources/skywalking-plugin.def
@@ -22,3 +22,4 @@ mysql-8.x=org.apache.skywalking.apm.plugin.jdbc.mysql.v8.define.StatementInstrum
 mysql-8.x=org.apache.skywalking.apm.plugin.jdbc.mysql.v8.define.PreparedStatementSetterInstrumentation
 mysql-8.x=org.apache.skywalking.apm.plugin.jdbc.mysql.v8.define.PreparedStatementNullSetterInstrumentation
 mysql-8.x=org.apache.skywalking.apm.plugin.jdbc.mysql.v8.define.PreparedStatementIgnoredSetterInstrumentation
+mysql-8.x=org.apache.skywalking.apm.plugin.jdbc.mysql.v8.define.CacheIpsInstrumentation

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/ConnectionCache.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/ConnectionCache.java
@@ -29,8 +29,12 @@ public class ConnectionCache {
     private static final String CONNECTION_SPLIT_STR = ",";
 
     public static ConnectionInfo get(String host, String port) {
-        final String connStr = String.format("%s:%s", host, port);
-        return CONNECTIONS_MAP.get(connStr);
+        final String hostPortPair = String.format("%s:%s", host, port);
+        return CONNECTIONS_MAP.get(hostPortPair);
+    }
+
+    public static ConnectionInfo get(String hostPortPair) {
+        return CONNECTIONS_MAP.get(hostPortPair);
     }
 
     public static void save(ConnectionInfo connectionInfo) {

--- a/test/plugin/scenarios/mysql-scenario/support-version.list
+++ b/test/plugin/scenarios/mysql-scenario/support-version.list
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-8.0.25
 8.0.19
 8.0.15
 6.0.6

--- a/test/plugin/scenarios/mysql-scenario/support-version.list
+++ b/test/plugin/scenarios/mysql-scenario/support-version.list
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+8.0.25
+8.0.19
 8.0.15
 6.0.6
 5.1.44


### PR DESCRIPTION
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

When I used the mysql-connector-java SDK version 8.0.19 or above and enable `jdbc:mysql:replication`, I got the following exception. And this leads to no creation of MySQL related exit span.

![image](https://user-images.githubusercontent.com/28091237/124860162-c6c06580-dfe3-11eb-8724-35a64c496469.png)

By debugging the agent, I found that when I used the mysql-connector-java SDK version 8.0.19 or above and enable `jdbc:mysql:replication`, the `hostInfo.getDatabaseUrl()`result changes. And this leads to `URLParser.parser()` failed.

![image](https://user-images.githubusercontent.com/28091237/124860199-d50e8180-dfe3-11eb-85a1-e0a2673cf228.png)

`hostInfo.getDatabaseUrl()` result in version 8.0.19 or above:

```java
jdbc:mysql:loadbalance://**internally_generated**1620805591623**
```

`hostInfo.getDatabaseUrl()` result in version 8.0.18 or below:

```java
jdbc:mysql:replication://127.0.0.1:3306,127.0.0.1:3306,127.0.0.1:3306/mer_goods_admin_sit?useSSL=true&useUnicode=true&autoReconnect=true&rewriteBatchedStatements=TRUE&allowMultiQueries=true&serverTimezone=GMT%2B8
```

By reading the source code of 8.0.18 and 8.0.19, I found that the logic of `LoadBalanceConnectionUrl` class is somewhat different.

In 8.0.18, the hostinfo passed in directly from the `ReplicationConnectionProxy` was used.

In 8.0.19, the newly built hostinfo is used.

Initialize connection:

![image](https://user-images.githubusercontent.com/28091237/124860343-12730f00-dfe4-11eb-9046-9820f532cd88.png)

In 8.0.18:

![image](https://user-images.githubusercontent.com/28091237/124860375-1e5ed100-dfe4-11eb-8fba-5ed396ca2f1c.png)

In 8.0.19:

![image](https://user-images.githubusercontent.com/28091237/124860398-29196600-dfe4-11eb-9171-e5a08d65f36f.png)

Finally, I solved this problem by intercepting `NonRegisteringDriver.connect()` method and caching `ConnectionInfo` in the same way as `mysql-5.x-plugin` and `mysql-6.x-plugin`.