### PR TITLE
 Fix the problem of Kafka transport topics are created duplicated with and without namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,7 @@ Release Notes.
 * The `core/syncThreads` setting(added in 8.5.0) is removed due to metrics persistence is fully asynchronous.
 * Optimization: Concurrency mode of execution stage for metrics is removed(added in 8.5.0). Only concurrency of prepare
   stage is meaningful and kept.
+* Fix Kafka transport topics are created duplicated with and without namespace issue
 
 #### UI
 

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/KafkaFetcherProvider.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/provider/KafkaFetcherProvider.java
@@ -69,7 +69,7 @@ public class KafkaFetcherProvider extends ModuleProvider {
     }
 
     @Override
-    public void start() throws ServiceNotProvidedException {
+    public void start() throws ServiceNotProvidedException, ModuleStartException {
         handlerRegister.register(new JVMMetricsHandler(getManager(), config));
         handlerRegister.register(new ServiceManagementHandler(getManager(), config));
         handlerRegister.register(new TraceSegmentHandler(getManager(), config));


### PR DESCRIPTION
Fix (#7326)
- [x] Explain briefly why the bug exists and how to fix it.
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #7326.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

How to fix:
1. wrap the logic of creating kafka topic into a method named <code>createTopicIfNeeded</code>.   
2. move <code>createTopicIfNeeded</code> to start method before consume subscribes topic.   
