### PR TITLE
Fixed instanceTraffic update problem after enhanced the storage session mechanism.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,7 @@ Release Notes.
 * The `core/syncThreads` setting(added in 8.5.0) is removed due to metrics persistence is fully asynchronous.
 * Optimization: Concurrency mode of execution stage for metrics is removed(added in 8.5.0). Only concurrency of prepare
   stage is meaningful and kept.
+* Fixed instanceTraffic update problem after enhanced the storage session mechanism.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/instance/InstanceTraffic.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/instance/InstanceTraffic.java
@@ -79,12 +79,7 @@ public class InstanceTraffic extends Metrics {
         if (instanceTraffic.getProperties() != null && instanceTraffic.getProperties().size() > 0) {
             this.properties = instanceTraffic.getProperties();
         }
-        /**
-         * Keep the time bucket as the same time inserted.
-         */
-        if (this.getTimeBucket() > metrics.getTimeBucket()) {
-            this.setTimeBucket(metrics.getTimeBucket());
-        }
+        this.setTimeBucket(metrics.getTimeBucket());
         return true;
     }
 


### PR DESCRIPTION
- [x] Explain briefly why the bug exists and how to fix it.

![image](https://user-images.githubusercontent.com/28091237/126110540-bd97f7ae-670a-41b2-bee6-562901bd053e.png)

   After the session mechanism is enhanced, the older `InstanceTraffic` data of `timeBucket` will always be cached in the context.
   
   And because of the logic of `combine` method in `InstanceTraffic`, we will continue to use the older `timeBucket` when updating.

   This causes OAP to update `InstanceTraffic` and report an error after cleaning up the index related to `InstanceTraffic` that has reached the specified TTL. 

   Because we have got the start time of the instance in other ways, I don't think we need to save the older `timeBucket`.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
