### PR TITLE
Could org.apache.skywalking:hbase-scenario:5.0.0 drop off redundant dependencies to loose weight?

### DIFF
--- a/test/plugin/scenarios/hbase-scenario/pom.xml
+++ b/test/plugin/scenarios/hbase-scenario/pom.xml
@@ -51,6 +51,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Spring Boot-->
@@ -88,6 +92,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot-version}</version>
+            <exclusions>
+                  <exclusion>
+                      <groupId>javax.validation</groupId>
+                      <artifactId>validation-api</artifactId>
+                  </exclusion>
+                  <exclusion>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter</artifactId>
+                  </exclusion>
+              </exclusions>
         </dependency>
     </dependencies>
 
@@ -134,4 +148,88 @@
             </plugin>
         </plugins>
     </build>
+    <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>org.apache.tomcat.embed</groupId>
+              <artifactId>tomcat-embed-core</artifactId>
+              <version>8.5.11</version>
+          </dependency>
+          <dependency>
+              <groupId>org.apache.tomcat.embed</groupId>
+              <artifactId>tomcat-embed-el</artifactId>
+              <version>8.5.11</version>
+          </dependency>
+          <dependency>
+              <groupId>org.apache.tomcat.embed</groupId>
+              <artifactId>tomcat-embed-websocket</artifactId>
+              <version>8.5.11</version>
+          </dependency>
+          <dependency>
+              <groupId>org.hibernate</groupId>
+              <artifactId>hibernate-validator</artifactId>
+              <version>5.3.4.Final</version>
+          </dependency>
+          <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-databind</artifactId>
+              <version>2.8.7</version>
+          </dependency>
+          <dependency>
+              <groupId>org.springframework</groupId>
+              <artifactId>spring-web</artifactId>
+              <version>4.3.7.RELEASE</version>
+          </dependency>
+          <dependency>
+              <groupId>org.springframework</groupId>
+              <artifactId>spring-webmvc</artifactId>
+              <version>4.3.7.RELEASE</version>
+          </dependency>
+          <dependency>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot</artifactId>
+              <version>1.5.2.RELEASE</version>
+          </dependency>
+          <dependency>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-autoconfigure</artifactId>
+              <version>1.5.2.RELEASE</version>
+          </dependency>
+          <dependency>
+              <groupId>org.springframework</groupId>
+              <artifactId>spring-core</artifactId>
+              <version>4.3.7.RELEASE</version>
+          </dependency>
+          <dependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+              <version>1.1.11</version>
+          </dependency>
+          <dependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>jcl-over-slf4j</artifactId>
+              <version>1.7.24</version>
+          </dependency>
+          <dependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>jul-to-slf4j</artifactId>
+              <version>1.7.24</version>
+          </dependency>
+          <dependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>log4j-over-slf4j</artifactId>
+              <version>1.7.24</version>
+          </dependency>
+          <dependency>
+              <groupId>log4j</groupId>
+              <artifactId>log4j</artifactId>
+              <version>1.2.17</version>
+          </dependency>
+          <dependency>
+              <groupId>junit</groupId>
+              <artifactId>junit</artifactId>
+              <version>4.12</version>
+          </dependency>
+      </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
Hi, I deployed project **_org.apache.skywalking:hbase-scenario:5.0.0_** and found that its pom file introduced **_98_** dependencies. However, among them, **_4_** libraries (**_4%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. Meanwhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for this project. 
This PR helps **_org.apache.skywalking:hbase-scenario:5.0.0_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.
 
Best regards