### PR TITLE
Fix the persistent session timeout mechanism bug.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,7 @@ Release Notes.
 * Enhance persistent session timeout mechanism. Because the enhanced session could cache the metadata metrics forever,
   new timeout mechanism is designed for avoiding this specific case.
 * Fix Kafka transport topics are created duplicated with and without namespace issue
+* Fix the persistent session timeout mechanism bug.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
@@ -275,7 +275,8 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> {
                                // Mostly all updatable metadata level metrics are required to do this check.
 
                                if (metricsDAO.isExpiredCache(model, cachedValue, currentTimeMillis, metricsDataTTL)) {
-                                   // The expired metrics should be tagged `not in cache` directly.
+                                   // The expired metrics should be removed from the context and tagged `not in cache` directly.
+                                   context.remove(m);
                                    return true;
                                }
                            }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
@@ -135,7 +135,7 @@ public class MetricsEsDAO extends EsDAO implements IMetricsDAO {
             return false;
         }
         final long deadline = Long.parseLong(new DateTime(currentTimeMillis).plusDays(-ttl).toString("yyyyMMdd"));
-        final long timeBucket = TimeBucket.getTimeBucket(cachedValue.getTimeBucket(), DownSampling.Day);
+        final long timeBucket = TimeBucket.getTimeBucket(metricTimestamp, DownSampling.Day);
         // If time bucket is earlier or equals(mostly) the deadline, then the cached metric is expired.
         if (timeBucket <= deadline) {
             return true;


### PR DESCRIPTION
- [x] Closes #7334.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

If we don't remove old data from context after expiration, the old data will continue to be in the context and continue to generate `UpdateRequest`. Finally, the document missing exception continues to be generated.