### PR TITLE
Fix possible version_conflict_engine_exception in bulk execution.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,7 @@ Release Notes.
 * Enhance persistent session timeout mechanism. Because the enhanced session could cache the metadata metrics forever,
   new timeout mechanism is designed for avoiding this specific case.
 * Fix Kafka transport topics are created duplicated with and without namespace issue
+* Fix possible version_conflict_engine_exception in bulk execution.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/endpoint/EndpointRelationServerSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/endpoint/EndpointRelationServerSideMetrics.java
@@ -102,10 +102,9 @@ public class EndpointRelationServerSideMetrics extends Metrics {
 
     @Override
     public int remoteHashCode() {
-        int result = 17;
-        result = 31 * result + entityId.hashCode();
-        result = (int) (31 * result + getTimeBucket());
-        return result;
+        int n = 17;
+        n = 31 * n + this.entityId.hashCode();
+        return n;
     }
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationClientSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationClientSideMetrics.java
@@ -114,7 +114,9 @@ public class ServiceInstanceRelationClientSideMetrics extends Metrics {
 
     @Override
     public int remoteHashCode() {
-        return hashCode();
+        int n = 17;
+        n = 31 * n + this.entityId.hashCode();
+        return n;
     }
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationServerSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/instance/ServiceInstanceRelationServerSideMetrics.java
@@ -114,7 +114,9 @@ public class ServiceInstanceRelationServerSideMetrics extends Metrics {
 
     @Override
     public int remoteHashCode() {
-        return hashCode();
+        int n = 17;
+        n = 31 * n + this.entityId.hashCode();
+        return n;
     }
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationClientSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationClientSideMetrics.java
@@ -100,7 +100,9 @@ public class ServiceRelationClientSideMetrics extends Metrics {
 
     @Override
     public int remoteHashCode() {
-        return this.hashCode();
+        int n = 17;
+        n = 31 * n + this.entityId.hashCode();
+        return n;
     }
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationServerSideMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/relation/service/ServiceRelationServerSideMetrics.java
@@ -100,7 +100,9 @@ public class ServiceRelationServerSideMetrics extends Metrics {
 
     @Override
     public int remoteHashCode() {
-        return this.hashCode();
+        int n = 17;
+        n = 31 * n + this.entityId.hashCode();
+        return n;
     }
 
     @Override


### PR DESCRIPTION
- [x] Closes #7293.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

When I adjusted the aggregator from cluster deployment to stand-alone deployment, I found that this exception disappeared, so I concluded that it was an OAP problem. And I found that the exception is always related to the relation's  hour and day dimensionality metrics. Finally, I found that the `remoteHashCode` method of some relation metrics was not set reasonably and related to `timeBucket`. This causes metrics with the same entityId to be sent to multiple aggregators.

