### PR TITLE
remove the logic of generated instance name in KafkaServiceManagementServiceClient prepare phase(#7357)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Release Notes.
 * Chore: polish methods naming for `Spring-Kafka` plugins.
 * Remove plugins for ShardingSphere legacy version.
 * Update agent plugin for ElasticJob GA version
+* Remove the logic of generating instance name in `KafkaServiceManagementServiceClient` class.
 
 #### OAP-Backend
 

--- a/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/src/main/java/org/apache/skywalking/apm/agent/core/kafka/KafkaServiceManagementServiceClient.java
+++ b/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/src/main/java/org/apache/skywalking/apm/agent/core/kafka/KafkaServiceManagementServiceClient.java
@@ -20,7 +20,6 @@ package org.apache.skywalking.apm.agent.core.kafka;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +41,6 @@ import org.apache.skywalking.apm.network.common.v3.KeyStringValuePair;
 import org.apache.skywalking.apm.network.management.v3.InstancePingPkg;
 import org.apache.skywalking.apm.network.management.v3.InstanceProperties;
 import org.apache.skywalking.apm.util.RunnableWithExceptionProtection;
-import org.apache.skywalking.apm.util.StringUtil;
 
 /**
  * A service management data(Instance registering properties and Instance pinging) reporter.
@@ -74,10 +72,6 @@ public class KafkaServiceManagementServiceClient implements BootService, Runnabl
                                                               .setValue(Config.Agent.INSTANCE_PROPERTIES.get(key))
                                                               .build());
         }
-
-        Config.Agent.INSTANCE_NAME = StringUtil.isEmpty(Config.Agent.INSTANCE_NAME)
-            ? UUID.randomUUID().toString().replaceAll("-", "") + "@" + OSUtil.getIPV4()
-            : Config.Agent.INSTANCE_NAME;
     }
 
     @Override

--- a/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/src/test/java/org/apache/skywalking/apm/agent/core/kafka/KafkaServiceManagementServiceClientTest.java
+++ b/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/src/test/java/org/apache/skywalking/apm/agent/core/kafka/KafkaServiceManagementServiceClientTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.agent.core.kafka;
+
+import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
+import org.apache.skywalking.apm.agent.core.conf.Config;
+import org.apache.skywalking.apm.util.StringUtil;
+import org.junit.Test;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class KafkaServiceManagementServiceClientTest {
+
+    @Test
+    public void testInstanceName() throws Exception {
+        ServiceManager instance = ServiceManager.INSTANCE;
+        Method loadAllServicesMethod = instance.getClass().getDeclaredMethod("loadAllServices");
+        loadAllServicesMethod.setAccessible(true);
+        Object loadAllServices = loadAllServicesMethod.invoke(instance);
+
+        Field bootedServicesField = instance.getClass().getDeclaredField("bootedServices");
+        bootedServicesField.setAccessible(true);
+        bootedServicesField.set(instance, loadAllServices);
+
+        Method prepare = instance.getClass().getDeclaredMethod("prepare");
+        prepare.setAccessible(true);
+        prepare.invoke(instance);
+
+        assertThat(StringUtil.isNotBlank(Config.Agent.INSTANCE_NAME), is(true));
+    }
+}


### PR DESCRIPTION
Fix (#7357)


- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
> Instance name is generated in <code>KafkaServiceManagementServiceClient</code> prepare phase. it's incorrected and redundant, because instance name should be generated in <code>ServiceInstanceGenerator</code>.  Further more, when all boot services are loaded and finish preparation, instance name has been generated. 
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #7357.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).