### PR TITLE
fix:delete accept-encoding

### DIFF
--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanProcessor.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanProcessor.java
@@ -56,15 +56,7 @@ public class SpanProcessor {
     }
 
     private InputStream getInputStream(HttpServletRequest request) throws IOException {
-        InputStream requestInStream;
-
-        String headEncoding = request.getHeader("accept-encoding");
-        if (headEncoding != null && (headEncoding.indexOf("gzip") != -1)) {
-            requestInStream = new GZIPInputStream(request.getInputStream());
-        } else {
-            requestInStream = request.getInputStream();
-        }
-
+        InputStream requestInStream = request.getInputStream();
         return requestInStream;
     }
 


### PR DESCRIPTION
### Fix <zipkin trace accept-encoding handle error>
- [x] Explain briefly why the bug exists and how to fix it.
     The HTTP request header Accept-Encoding informs (to the server) the content encoding method that the client can understand—usually a certain compression algorithm. Through content negotiation, the server will choose a method proposed by the client, use and notify the client of the choice in the response header Content-Encoding. It is to inform the server that I support a certain compression method, and when the web page responds, it uses the corresponding method to compress the data and transmits it to us, rather than specifying what kind of transmission and decoding method the server uses to decompress and accept. @link https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Accept-Encoding

