### PR TITLE
Openapi-definitions file loader fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Release Notes.
 * Add `event` http receiver
 * Support Metric level function `serviceRelation` in `MAL`. 
 * Support envoy metrics binding into the topology.
+* Fix openapi-definitions folder not being read correctly.
 
 #### UI
 

--- a/apm-dist-es7/src/main/assembly/binary-es7.xml
+++ b/apm-dist-es7/src/main/assembly/binary-es7.xml
@@ -63,6 +63,7 @@
                 <include>envoy-metrics-rules/*.yaml</include>
                 <include>meter-analyzer-config/*.yaml</include>
                 <include>zabbix-rules/*.yaml</include>
+                <include>openapi-definitions/*</include>
                 <include>otel-oc-rules/*</include>
                 <include>ui-initialized-templates/*</include>
                 <include>lal/*</include>

--- a/apm-dist/src/main/assembly/binary.xml
+++ b/apm-dist/src/main/assembly/binary.xml
@@ -63,6 +63,7 @@
                 <include>envoy-metrics-rules/*.yaml</include>
                 <include>meter-analyzer-config/*.yaml</include>
                 <include>zabbix-rules/*.yaml</include>
+                <include>openapi-definitions/*</include>
                 <include>otel-oc-rules/*</include>
                 <include>ui-initialized-templates/*</include>
                 <include>lal/*</include>

--- a/oap-server/server-bootstrap/pom.xml
+++ b/oap-server/server-bootstrap/pom.xml
@@ -280,6 +280,7 @@
                         <exclude>fetcher-prom-rules/</exclude>
                         <exclude>envoy-metrics-rules/</exclude>
                         <exclude>meter-analyzer-config/</exclude>
+                        <exclude>openapi-definitions/</exclude>
                         <exclude>otel-oc-rules/</exclude>
                         <exclude>ui-initialized-templates/</exclude>
                         <exclude>zabbix-rules/</exclude>


### PR DESCRIPTION
### Fix <bug description or the bug issue number or bug issue link>
- [  ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #7414 .
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

This fixes openapi-definitions under the server-bootstrap module resources being included in server-boostrap.jar. Because of this issue one can not attach their own openapi-definitions folder as classloader will always return resources under server-bootstrap jar.