### PR TITLE
DataCarrier changes a `#consume` API to add properties as a parameter to initialize consumer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,10 @@ Release Notes.
 ------------------
 
 #### Project
+
 * Upgrade jdk 11 in dockerfile and remove unused java_opts.
+* DataCarrier changes a `#consume` API to add properties as a parameter to initialize consumer when
+  use `Class<? extends IConsumer<T>> consumerClass`.
 
 #### Java Agent
 
@@ -31,7 +34,7 @@ Release Notes.
   MacOS.
 * [Break Change] Remove page path in the browser log query condition. Only support `query by page path id`.
 * [Break Change] Remove endpoint name in the backend log query condition. Only support `query by endpoint id`.
-* [Break Change] Fix typo for a column `page_path_id`(was `pate_path_id`) of storage entity `browser_error_log`.   
+* [Break Change] Fix typo for a column `page_path_id`(was `pate_path_id`) of storage entity `browser_error_log`.
 * Add component id for Python falcon plugin.
 
 #### UI

--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/DataCarrier.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/DataCarrier.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.apm.commons.datacarrier;
 
+import java.util.Properties;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.BufferStrategy;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.Channels;
 import org.apache.skywalking.apm.commons.datacarrier.consumer.ConsumeDriver;
@@ -90,12 +91,16 @@ public class DataCarrier<T> {
      *
      * @param consumerClass class of consumer
      * @param num           number of consumer threads
+     * @param properties    for initializing consumer.
      */
-    public DataCarrier consume(Class<? extends IConsumer<T>> consumerClass, int num, long consumeCycle) {
+    public DataCarrier consume(Class<? extends IConsumer<T>> consumerClass,
+                               int num,
+                               long consumeCycle,
+                               Properties properties) {
         if (driver != null) {
             driver.close(channels);
         }
-        driver = new ConsumeDriver<T>(this.name, this.channels, consumerClass, num, consumeCycle);
+        driver = new ConsumeDriver<T>(this.name, this.channels, consumerClass, num, consumeCycle, properties);
         driver.begin(channels);
         return this;
     }
@@ -108,7 +113,7 @@ public class DataCarrier<T> {
      * @param num           number of consumer threads
      */
     public DataCarrier consume(Class<? extends IConsumer<T>> consumerClass, int num) {
-        return this.consume(consumerClass, num, 20);
+        return this.consume(consumerClass, num, 20, new Properties());
     }
 
     /**

--- a/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/IConsumer.java
+++ b/apm-commons/apm-datacarrier/src/main/java/org/apache/skywalking/apm/commons/datacarrier/consumer/IConsumer.java
@@ -19,9 +19,10 @@
 package org.apache.skywalking.apm.commons.datacarrier.consumer;
 
 import java.util.List;
+import java.util.Properties;
 
 public interface IConsumer<T> {
-    void init();
+    void init(final Properties properties);
 
     void consume(List<T> data);
 

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/DataCarrierTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/DataCarrierTest.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.apm.commons.datacarrier;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.BufferStrategy;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.Channels;
 import org.apache.skywalking.apm.commons.datacarrier.buffer.QueueBuffer;
@@ -120,7 +121,7 @@ public class DataCarrierTest {
                 int i = 0;
 
                 @Override
-                public void init() {
+                public void init(final Properties properties) {
 
                 }
 

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerTest.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/ConsumerTest.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.commons.datacarrier.consumer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.skywalking.apm.commons.datacarrier.DataCarrier;
 import org.apache.skywalking.apm.commons.datacarrier.SampleData;
@@ -104,7 +105,7 @@ public class ConsumerTest {
         public boolean onError = false;
 
         @Override
-        public void init() {
+        public void init(final Properties properties) {
 
         }
 

--- a/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/SampleConsumer.java
+++ b/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/consumer/SampleConsumer.java
@@ -19,13 +19,14 @@
 package org.apache.skywalking.apm.commons.datacarrier.consumer;
 
 import java.util.List;
+import java.util.Properties;
 import org.apache.skywalking.apm.commons.datacarrier.SampleData;
 
 public class SampleConsumer implements IConsumer<SampleData> {
     public int i = 1;
 
     @Override
-    public void init() {
+    public void init(final Properties properties) {
 
     }
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/LogReportServiceClient.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/LogReportServiceClient.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.apm.agent.core.remote;
 
 import java.util.List;
 
+import java.util.Properties;
 import org.apache.skywalking.apm.agent.core.boot.BootService;
 import org.apache.skywalking.apm.agent.core.boot.DefaultImplementor;
 import org.apache.skywalking.apm.commons.datacarrier.consumer.IConsumer;
@@ -49,7 +50,7 @@ public class LogReportServiceClient implements BootService, IConsumer<LogData> {
     }
 
     @Override
-    public void init() {
+    public void init(final Properties properties) {
 
     }
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/TraceSegmentServiceClient.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/TraceSegmentServiceClient.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.agent.core.remote;
 import io.grpc.Channel;
 import io.grpc.stub.StreamObserver;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.skywalking.apm.agent.core.boot.BootService;
 import org.apache.skywalking.apm.agent.core.boot.DefaultImplementor;
@@ -80,7 +81,7 @@ public class TraceSegmentServiceClient implements BootService, IConsumer<TraceSe
     }
 
     @Override
-    public void init() {
+    public void init(final Properties properties) {
 
     }
 

--- a/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/src/main/java/org/apache/skywalking/apm/agent/core/kafka/KafkaTraceSegmentServiceClient.java
+++ b/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/src/main/java/org/apache/skywalking/apm/agent/core/kafka/KafkaTraceSegmentServiceClient.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.apm.agent.core.kafka;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.utils.Bytes;
@@ -77,7 +78,7 @@ public class KafkaTraceSegmentServiceClient implements BootService, IConsumer<Tr
     }
 
     @Override
-    public void init() {
+    public void init(final Properties properties) {
 
     }
 

--- a/oap-server/exporter/src/main/java/org/apache/skywalking/oap/server/exporter/provider/grpc/GRPCExporter.java
+++ b/oap-server/exporter/src/main/java/org/apache/skywalking/oap/server/exporter/provider/grpc/GRPCExporter.java
@@ -22,6 +22,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
@@ -121,7 +122,7 @@ public class GRPCExporter extends MetricFormatter implements MetricValuesExportS
     }
 
     @Override
-    public void init() {
+    public void init(final Properties properties) {
 
     }
 

--- a/oap-server/exporter/src/test/java/org/apache/skywalking/oap/server/exporter/provider/grpc/GRPCExporterTest.java
+++ b/oap-server/exporter/src/test/java/org/apache/skywalking/oap/server/exporter/provider/grpc/GRPCExporterTest.java
@@ -78,7 +78,7 @@ public class GRPCExporterTest {
 
     @Test
     public void init() {
-        exporter.init();
+        exporter.init(properties);
     }
 
     @Test

--- a/oap-server/exporter/src/test/java/org/apache/skywalking/oap/server/exporter/provider/grpc/GRPCExporterTest.java
+++ b/oap-server/exporter/src/test/java/org/apache/skywalking/oap/server/exporter/provider/grpc/GRPCExporterTest.java
@@ -78,7 +78,7 @@ public class GRPCExporterTest {
 
     @Test
     public void init() {
-        exporter.init(properties);
+        exporter.init(null);
     }
 
     @Test

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.oap.server.core.analysis.worker;
 
 import java.util.List;
+import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.commons.datacarrier.DataCarrier;
 import org.apache.skywalking.apm.commons.datacarrier.consumer.BulkConsumePool;
@@ -117,7 +118,7 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
 
     private class AggregatorConsumer implements IConsumer<Metrics> {
         @Override
-        public void init() {
+        public void init(final Properties properties) {
         }
 
         @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.commons.datacarrier.DataCarrier;
@@ -321,7 +322,7 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> {
      */
     private class PersistentConsumer implements IConsumer<Metrics> {
         @Override
-        public void init() {
+        public void init(final Properties properties) {
 
         }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/TopNWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/TopNWorker.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.commons.datacarrier.DataCarrier;
 import org.apache.skywalking.apm.commons.datacarrier.consumer.IConsumer;
@@ -100,7 +101,7 @@ public class TopNWorker extends PersistenceWorker<TopN> {
 
     private class TopNConsumer implements IConsumer<TopN> {
         @Override
-        public void init() {
+        public void init(final Properties properties) {
         }
 
         @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/client/GRPCRemoteClient.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/client/GRPCRemoteClient.java
@@ -23,6 +23,7 @@ import io.grpc.stub.StreamObserver;
 import io.netty.handler.ssl.SslContext;
 import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
@@ -153,7 +154,7 @@ public class GRPCRemoteClient implements RemoteClient {
 
     class RemoteMessageConsumer implements IConsumer<RemoteMessage> {
         @Override
-        public void init() {
+        public void init(final Properties properties) {
         }
 
         @Override

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2BatchDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2BatchDAO.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.commons.datacarrier.DataCarrier;
 import org.apache.skywalking.apm.commons.datacarrier.consumer.BulkConsumePool;
@@ -94,7 +95,7 @@ public class H2BatchDAO implements IBatchDAO {
         }
 
         @Override
-        public void init() {
+        public void init(final Properties properties) {
 
         }
 


### PR DESCRIPTION
… to initialize consumer.

<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking/blob/master/docs/en/guides/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

DataCarrier changes a `#consume` API to add properties as a parameter to initialize consumer when use `Class<? extends IConsumer<T>> consumerClass`.

The usage of this API  in the banyanDB client API. We need to initialize multiple consumer instances(> 2) with class type, but we need to pass the parameters to the initialization process. 
