### PR TITLE
Support collection type in dynamic configuration core and add zookeeper implementation 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,7 @@ Release Notes.
 * Add a new API to test log analysis language.
 * Harden the security of Groovy-based DSL, MAL and LAL.
 * Fix distinct in Service/Instance/Endpoint query is not working.
-* Support grouped dynamic configurations in DCS.
+* Support collection type in dynamic configuration core.
 * Support zookeeper grouped dynamic configurations.
 
 #### UI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@ Release Notes.
 * Add a new API to test log analysis language.
 * Harden the security of Groovy-based DSL, MAL and LAL.
 * Fix distinct in Service/Instance/Endpoint query is not working.
+* Support grouped dynamic configurations in DCS.
+* Support zookeeper grouped dynamic configurations.
 
 #### UI
 

--- a/oap-server/analyzer/agent-analyzer/src/test/java/org/apache/skywalking/oap/server/analyzer/provider/trace/TraceLatencyThresholdsAndWatcherTest.java
+++ b/oap-server/analyzer/agent-analyzer/src/test/java/org/apache/skywalking/oap/server/analyzer/provider/trace/TraceLatencyThresholdsAndWatcherTest.java
@@ -24,6 +24,7 @@ import org.apache.skywalking.oap.server.analyzer.provider.AnalyzerModuleProvider
 import org.apache.skywalking.oap.server.configuration.api.ConfigChangeWatcher;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -107,6 +108,11 @@ public class TraceLatencyThresholdsAndWatcherTest {
             ConfigTable table = new ConfigTable();
             table.add(new ConfigTable.ConfigItem("agent-analyzer.default.slowTraceSegmentThreshold", "3000"));
             return Optional.of(table);
+        }
+
+        @Override
+        public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+            return Optional.empty();
         }
     }
 

--- a/oap-server/analyzer/agent-analyzer/src/test/java/org/apache/skywalking/oap/server/analyzer/provider/trace/TraceSampleRateWatcherTest.java
+++ b/oap-server/analyzer/agent-analyzer/src/test/java/org/apache/skywalking/oap/server/analyzer/provider/trace/TraceSampleRateWatcherTest.java
@@ -22,6 +22,7 @@ import org.apache.skywalking.oap.server.analyzer.provider.AnalyzerModuleProvider
 import org.apache.skywalking.oap.server.configuration.api.ConfigChangeWatcher;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -108,6 +109,11 @@ public class TraceSampleRateWatcherTest {
             ConfigTable table = new ConfigTable();
             table.add(new ConfigTable.ConfigItem("agent-analyzer.default.sampleRate", "9000"));
             return Optional.of(table);
+        }
+
+        @Override
+        public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+            return Optional.empty();
         }
     }
 

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigChangeWatcher.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigChangeWatcher.java
@@ -62,15 +62,8 @@ public abstract class ConfigChangeWatcher {
     public static class ConfigChangeEvent {
         private String newValue;
         private EventType eventType;
-        private String groupItemName;
 
         public ConfigChangeEvent(String newValue, EventType eventType) {
-            this.newValue = newValue;
-            this.eventType = eventType;
-        }
-
-        public ConfigChangeEvent(String groupItemName, String newValue, EventType eventType) {
-            this.groupItemName = groupItemName;
             this.newValue = newValue;
             this.eventType = eventType;
         }

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigChangeWatcher.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigChangeWatcher.java
@@ -37,7 +37,7 @@ public abstract class ConfigChangeWatcher {
         this.module = module;
         this.provider = provider;
         this.itemName = itemName;
-        this.watchType = WatchType.SIMPLE;
+        this.watchType = WatchType.SINGLE;
     }
 
     /**
@@ -81,6 +81,6 @@ public abstract class ConfigChangeWatcher {
     }
 
     public enum WatchType {
-        SIMPLE, GROUP
+        SINGLE, GROUP
     }
 }

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigChangeWatcher.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigChangeWatcher.java
@@ -31,11 +31,13 @@ public abstract class ConfigChangeWatcher {
     private final String module;
     private final ModuleProvider provider;
     private final String itemName;
+    protected WatchType watchType;
 
     public ConfigChangeWatcher(String module, ModuleProvider provider, String itemName) {
         this.module = module;
         this.provider = provider;
         this.itemName = itemName;
+        this.watchType = WatchType.SIMPLE;
     }
 
     /**
@@ -60,8 +62,15 @@ public abstract class ConfigChangeWatcher {
     public static class ConfigChangeEvent {
         private String newValue;
         private EventType eventType;
+        private String groupItemName;
 
         public ConfigChangeEvent(String newValue, EventType eventType) {
+            this.newValue = newValue;
+            this.eventType = eventType;
+        }
+
+        public ConfigChangeEvent(String groupItemName, String newValue, EventType eventType) {
+            this.groupItemName = groupItemName;
             this.newValue = newValue;
             this.eventType = eventType;
         }
@@ -69,5 +78,9 @@ public abstract class ConfigChangeWatcher {
 
     public enum EventType {
         ADD, MODIFY, DELETE
+    }
+
+    public enum WatchType {
+        SIMPLE, GROUP
     }
 }

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigTable.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigTable.java
@@ -20,6 +20,8 @@ package org.apache.skywalking.oap.server.configuration.api;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -31,9 +33,15 @@ import lombok.ToString;
 public class ConfigTable {
     @Getter
     private List<ConfigItem> items = new ArrayList<>();
+    @Getter
+    private List<GroupConfigItems> groupItems = new ArrayList<>();
 
     public void add(ConfigItem item) {
         items.add(item);
+    }
+
+    public void addGroupConfigItems(GroupConfigItems items) {
+        groupItems.add(items);
     }
 
     @Getter
@@ -46,6 +54,22 @@ public class ConfigTable {
         public ConfigItem(String name, String value) {
             this.name = name;
             this.value = value;
+        }
+    }
+
+    @Getter
+    @Setter
+    //@ToString
+    public static class GroupConfigItems {
+        private String name;
+        private Map<String, ConfigItem> items = new ConcurrentHashMap<>();
+
+        public GroupConfigItems(final String name) {
+            this.name = name;
+        }
+
+        public void add(ConfigItem item) {
+            items.put(item.getName(), item);
         }
     }
 }

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigTable.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigTable.java
@@ -31,8 +31,15 @@ import lombok.ToString;
  */
 @ToString
 public class ConfigTable {
+    /**
+     * for WatchType.SIMPLE
+     */
     @Getter
     private List<ConfigItem> items = new ArrayList<>();
+
+    /**
+     * for WatchType.GROUP
+     */
     @Getter
     private List<GroupConfigItems> groupItems = new ArrayList<>();
 
@@ -59,7 +66,7 @@ public class ConfigTable {
 
     @Getter
     @Setter
-    //@ToString
+    @ToString
     public static class GroupConfigItems {
         private String name;
         private Map<String, ConfigItem> items = new ConcurrentHashMap<>();

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigTable.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigTable.java
@@ -32,7 +32,7 @@ import lombok.ToString;
 @ToString
 public class ConfigTable {
     /**
-     * for WatchType.SIMPLE
+     * for WatchType.SINGLE
      */
     @Getter
     private List<ConfigItem> items = new ArrayList<>();

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigWatcherRegister.java
@@ -25,15 +25,14 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.util.RunnableWithExceptionProtection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The default implementor of Config Watcher register.
  */
+@Slf4j
 public abstract class ConfigWatcherRegister implements DynamicConfigurationService {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigWatcherRegister.class);
     public static final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
     private Register singleConfigChangeWatcherRegister = new Register();
     @Getter
@@ -77,13 +76,13 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
     public void start() {
         isStarted = true;
 
-        LOGGER.info("Current configurations after the bootstrap sync." + LINE_SEPARATOR + singleConfigChangeWatcherRegister.toString());
+        log.info("Current configurations after the bootstrap sync." + LINE_SEPARATOR + singleConfigChangeWatcherRegister.toString());
 
         Executors.newSingleThreadScheduledExecutor()
                  .scheduleAtFixedRate(
                      new RunnableWithExceptionProtection(
                          this::configSync,
-                         t -> LOGGER.error("Sync config center error.", t)
+                         t -> log.error("Sync config center error.", t)
                      ), 0, syncPeriod, TimeUnit.SECONDS);
     }
 
@@ -101,7 +100,7 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
                 String itemName = item.getName();
                 WatcherHolder holder = singleConfigChangeWatcherRegister.get(itemName);
                 if (holder == null) {
-                    LOGGER.warn(
+                    log.warn(
                         "Config {} from configuration center, doesn't match any WatchType.SINGLE watcher, ignore.",
                         itemName
                     );
@@ -128,8 +127,8 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
                     }
                 }
             });
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(
+            if (log.isTraceEnabled()) {
+                log.trace(
                     "Current configurations after the sync." + LINE_SEPARATOR + singleConfigChangeWatcherRegister.toString());
             }
         });
@@ -144,7 +143,7 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
                 WatcherHolder holder = groupConfigChangeWatcherRegister.get(groupConfigItemName);
 
                 if (holder == null) {
-                    LOGGER.warn(
+                    log.warn(
                         "Config {} from configuration center, doesn't match any WatchType.GROUP watcher, ignore.",
                         groupConfigItemName
                     );
@@ -198,8 +197,8 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
                     watcher.notifyGroup(changedGroupItems);
                 }
             });
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(
+            if (log.isTraceEnabled()) {
+                log.trace(
                     "Current configurations after the sync." + LINE_SEPARATOR + groupConfigChangeWatcherRegister.toString());
             }
         });

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/GroupConfigChangeWatcher.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/GroupConfigChangeWatcher.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.configuration.api;
+
+import java.util.Map;
+import org.apache.skywalking.oap.server.library.module.ModuleProvider;
+
+public abstract class GroupConfigChangeWatcher extends ConfigChangeWatcher {
+    public GroupConfigChangeWatcher(final String module,
+                                    final ModuleProvider provider,
+                                    final String itemName) {
+        super(module, provider, itemName);
+        super.watchType = WatchType.GROUP;
+    }
+
+    @Override
+    public String value() {
+        throw new UnsupportedOperationException("Unsupported method value() in GroupConfigChangeWatcher");
+    }
+
+    /**
+     * @return current groupConfigs.
+     */
+    public abstract Map<String, String> groupItems();
+}

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/GroupConfigChangeWatcher.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/GroupConfigChangeWatcher.java
@@ -34,8 +34,15 @@ public abstract class GroupConfigChangeWatcher extends ConfigChangeWatcher {
         throw new UnsupportedOperationException("Unsupported method value() in GroupConfigChangeWatcher");
     }
 
+    @Override
+    public void notify(ConfigChangeEvent value) {
+        throw new UnsupportedOperationException("Unsupported method notify() in GroupConfigChangeWatcher");
+    }
+
     /**
      * @return current groupConfigs.
      */
     public abstract Map<String, String> groupItems();
+
+    public abstract void notifyGroup(Map<String , ConfigChangeEvent> groupItems);
 }

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/GroupConfigTable.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/GroupConfigTable.java
@@ -20,32 +20,37 @@ package org.apache.skywalking.oap.server.configuration.api;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
 /**
- * ConfigTable contains all WatchType.SINGLE config.
+ * ConfigTable contains all WatchType.GROUP config.
  */
 @ToString
-public class ConfigTable {
+public class GroupConfigTable {
     @Getter
-    private List<ConfigItem> items = new ArrayList<>();
+    private List<GroupConfigItems> groupItems = new ArrayList<>();
 
-    public void add(ConfigItem item) {
-        items.add(item);
+    public void addGroupConfigItems(GroupConfigItems items) {
+        groupItems.add(items);
     }
 
     @Getter
     @Setter
     @ToString
-    public static class ConfigItem {
+    public static class GroupConfigItems {
         private String name;
-        private String value;
+        private Map<String, ConfigTable.ConfigItem> items = new ConcurrentHashMap<>();
 
-        public ConfigItem(String name, String value) {
+        public GroupConfigItems(final String name) {
             this.name = name;
-            this.value = value;
+        }
+
+        public void add(ConfigTable.ConfigItem item) {
+            items.put(item.getName(), item);
         }
     }
 }

--- a/oap-server/server-configuration/configuration-api/src/test/java/org/apache/skywalking/oap/server/configuration/api/ConfigWatcherRegisterTest.java
+++ b/oap-server/server-configuration/configuration-api/src/test/java/org/apache/skywalking/oap/server/configuration/api/ConfigWatcherRegisterTest.java
@@ -133,8 +133,8 @@ public class ConfigWatcherRegisterTest {
             ConfigTable.ConfigItem item1 = new ConfigTable.ConfigItem("item1", "abc");
             ConfigTable.ConfigItem item2 = new ConfigTable.ConfigItem("item2", "abc2");
             ConfigTable.ConfigItem item3 = new ConfigTable.ConfigItem("item3", "abc3");
-            ConfigTable.GroupConfigItems groupConfigItems1 = new ConfigTable.GroupConfigItems("GROUP.MockModule.provider.groupItems1");
-            ConfigTable.GroupConfigItems groupConfigItems2 = new ConfigTable.GroupConfigItems("GROUP.MockModule.provider.groupItems2");
+            ConfigTable.GroupConfigItems groupConfigItems1 = new ConfigTable.GroupConfigItems("MockModule.provider.groupItems1");
+            ConfigTable.GroupConfigItems groupConfigItems2 = new ConfigTable.GroupConfigItems("MockModule.provider.groupItems2");
             groupConfigItems1.add(item1);
             groupConfigItems1.add(item2);
             groupConfigItems2.add(item3);

--- a/oap-server/server-configuration/configuration-apollo/src/main/java/org/apache/skywalking/oap/server/configuration/apollo/ApolloConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-apollo/src/main/java/org/apache/skywalking/oap/server/configuration/apollo/ApolloConfigWatcherRegister.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,5 +64,11 @@ public class ApolloConfigWatcherRegister extends ConfigWatcherRegister {
         }
 
         return Optional.of(configTable);
+    }
+
+    @Override
+    public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+        // TODO: implement readGroupConfig
+        return Optional.empty();
     }
 }

--- a/oap-server/server-configuration/configuration-consul/src/main/java/org/apache/skywalking/oap/server/configuration/consul/ConsulConfigurationWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-consul/src/main/java/org/apache/skywalking/oap/server/configuration/consul/ConsulConfigurationWatcherRegister.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,6 +93,12 @@ public class ConsulConfigurationWatcherRegister extends ConfigWatcherRegister {
         });
 
         return Optional.of(table);
+    }
+
+    @Override
+    public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+        // TODO: implement readGroupConfig
+        return Optional.empty();
     }
 
     private void registerKeyListeners(final Set<String> keys) {

--- a/oap-server/server-configuration/configuration-etcd/src/main/java/org/apache/skywalking/oap/server/configuration/etcd/EtcdConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-etcd/src/main/java/org/apache/skywalking/oap/server/configuration/etcd/EtcdConfigWatcherRegister.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.util.StringUtil;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 
 @Slf4j
 public class EtcdConfigWatcherRegister extends ConfigWatcherRegister {
@@ -72,6 +73,12 @@ public class EtcdConfigWatcherRegister extends ConfigWatcherRegister {
             }
         });
         return Optional.of(table);
+    }
+
+    @Override
+    public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+        // TODO: implement readGroupConfig
+        return Optional.empty();
     }
 
 }

--- a/oap-server/server-configuration/configuration-k8s-configmap/src/main/java/org/apache/skywalking/oap/server/configuration/configmap/ConfigmapConfigurationWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-k8s-configmap/src/main/java/org/apache/skywalking/oap/server/configuration/configmap/ConfigmapConfigurationWatcherRegister.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 
 @Slf4j
 public class ConfigmapConfigurationWatcherRegister extends ConfigWatcherRegister {
@@ -48,6 +49,12 @@ public class ConfigmapConfigurationWatcherRegister extends ConfigWatcherRegister
             configTable.add(new ConfigTable.ConfigItem(name, value));
         }
         return Optional.of(configTable);
+    }
+
+    @Override
+    public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+        // TODO: implement readGroupConfig
+        return Optional.empty();
     }
 
 }

--- a/oap-server/server-configuration/configuration-nacos/src/main/java/org/apache/skywalking/oap/server/configuration/nacos/NacosConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-nacos/src/main/java/org/apache/skywalking/oap/server/configuration/nacos/NacosConfigWatcherRegister.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Executor;
 import org.apache.skywalking.apm.util.StringUtil;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,6 +88,12 @@ public class NacosConfigWatcherRegister extends ConfigWatcherRegister {
         }
 
         return Optional.of(table);
+    }
+
+    @Override
+    public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+        // TODO: implement readGroupConfig
+        return Optional.empty();
     }
 
     private void registerKeyListeners(final Set<String> keys) {

--- a/oap-server/server-configuration/configuration-zookeeper/src/main/java/org/apache/skywalking/oap/server/configuration/zookeeper/ZookeeperConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-zookeeper/src/main/java/org/apache/skywalking/oap/server/configuration/zookeeper/ZookeeperConfigWatcherRegister.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.oap.server.configuration.zookeeper;
 
 import java.util.Optional;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -29,11 +30,9 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
 import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class ZookeeperConfigWatcherRegister extends ConfigWatcherRegister {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperConfigWatcherRegister.class);
     private final CuratorFramework client;
     private final PathChildrenCache childrenCache;
     private final String prefix;
@@ -69,13 +68,13 @@ public class ZookeeperConfigWatcherRegister extends ConfigWatcherRegister {
                         try {
                             data = client.getData().forPath(this.prefix + key + "/" + itemName);
                         } catch (Exception e) {
-                            LOGGER.error(e.getMessage(), e);
+                            log.error(e.getMessage(), e);
                         }
                         groupConfigItems.add(
                             new ConfigTable.ConfigItem(itemName, data == null ? null : new String(data)));
                     });
                 } catch (Exception e) {
-                    LOGGER.error(e.getMessage(), e);
+                    log.error(e.getMessage(), e);
                 }
                 table.addGroupConfigItems(groupConfigItems);
         });

--- a/oap-server/server-configuration/configuration-zookeeper/src/main/java/org/apache/skywalking/oap/server/configuration/zookeeper/ZookeeperConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-zookeeper/src/main/java/org/apache/skywalking/oap/server/configuration/zookeeper/ZookeeperConfigWatcherRegister.java
@@ -52,7 +52,7 @@ public class ZookeeperConfigWatcherRegister extends ConfigWatcherRegister {
     public Optional<ConfigTable> readConfig(Set<String> keys) {
         ConfigTable table = new ConfigTable();
         keys.forEach(key -> {
-            if (key.startsWith(ConfigChangeWatcher.WatchType.GROUP.name())) {
+            if (this.getRegister().get(key).getWatcher().getWatchType() == ConfigChangeWatcher.WatchType.GROUP) {
                 ConfigTable.GroupConfigItems groupConfigItems = new ConfigTable.GroupConfigItems(key);
                 try {
                     client.getChildren().forPath(this.prefix + key).forEach(itemName -> {

--- a/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/ITZookeeperConfigurationTest.java
+++ b/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/ITZookeeperConfigurationTest.java
@@ -96,7 +96,7 @@ public class ITZookeeperConfigurationTest {
     @Test(timeout = 20000)
     public void shouldReadUpdated4GroupConfig() throws Exception {
         String nameSpace = "/default";
-        String key = "GROUP.test-module.default.testKeyGroup";
+        String key = "test-module.default.testKeyGroup";
         assertEquals("{}", provider.groupWatcher.groupItems().toString());
 
         String zkAddress = System.getProperty("zk.address");
@@ -105,7 +105,6 @@ public class ITZookeeperConfigurationTest {
         RetryPolicy retryPolicy = new ExponentialBackoffRetry(1000, 3);
         CuratorFramework client = CuratorFrameworkFactory.newClient(zkAddress, retryPolicy);
         client.start();
-
         LOGGER.info("per path: " + nameSpace + "/" + key);
 
         assertTrue(client.create().creatingParentsIfNeeded().forPath(nameSpace + "/" + key + "/item1", "100".getBytes()) != null);

--- a/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/ITZookeeperConfigurationTest.java
+++ b/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/ITZookeeperConfigurationTest.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.Reader;
 import java.util.Map;
 import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -33,8 +34,6 @@ import org.apache.skywalking.oap.server.library.util.CollectionUtils;
 import org.apache.skywalking.oap.server.library.util.ResourceUtils;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
 import static org.junit.Assert.assertEquals;
@@ -42,9 +41,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@Slf4j
 public class ITZookeeperConfigurationTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ITZookeeperConfigurationTest.class);
-
     private final Yaml yaml = new Yaml();
 
     private MockZookeeperConfigurationProvider provider;
@@ -71,16 +69,16 @@ public class ITZookeeperConfigurationTest {
         assertNull(provider.watcher.value());
 
         String zkAddress = System.getProperty("zk.address");
-        LOGGER.info("zkAddress: " + zkAddress);
+        log.info("zkAddress: " + zkAddress);
 
         RetryPolicy retryPolicy = new ExponentialBackoffRetry(1000, 3);
         CuratorFramework client = CuratorFrameworkFactory.newClient(zkAddress, retryPolicy);
         client.start();
-        LOGGER.info("per path: " + nameSpace + "/" + key);
+        log.info("per path: " + nameSpace + "/" + key);
 
         assertTrue(client.create().creatingParentsIfNeeded().forPath(nameSpace + "/" + key, "500".getBytes()) != null);
 
-        LOGGER.info("data: " + new String(client.getData().forPath(nameSpace + "/" + key)));
+        log.info("data: " + new String(client.getData().forPath(nameSpace + "/" + key)));
 
         for (String v = provider.watcher.value(); v == null; v = provider.watcher.value()) {
         }
@@ -100,18 +98,18 @@ public class ITZookeeperConfigurationTest {
         assertEquals("{}", provider.groupWatcher.groupItems().toString());
 
         String zkAddress = System.getProperty("zk.address");
-        LOGGER.info("zkAddress: " + zkAddress);
+        log.info("zkAddress: " + zkAddress);
 
         RetryPolicy retryPolicy = new ExponentialBackoffRetry(1000, 3);
         CuratorFramework client = CuratorFrameworkFactory.newClient(zkAddress, retryPolicy);
         client.start();
-        LOGGER.info("per path: " + nameSpace + "/" + key);
+        log.info("per path: " + nameSpace + "/" + key);
 
         assertTrue(client.create().creatingParentsIfNeeded().forPath(nameSpace + "/" + key + "/item1", "100".getBytes()) != null);
         assertTrue(client.create().creatingParentsIfNeeded().forPath(nameSpace + "/" + key + "/item2", "200".getBytes()) != null);
 
-        LOGGER.info("data: " + new String(client.getData().forPath(nameSpace + "/" + key + "/item1")));
-        LOGGER.info("data: " + new String(client.getData().forPath(nameSpace + "/" + key + "/item2")));
+        log.info("data: " + new String(client.getData().forPath(nameSpace + "/" + key + "/item1")));
+        log.info("data: " + new String(client.getData().forPath(nameSpace + "/" + key + "/item2")));
 
         for (String v = provider.groupWatcher.groupItems().get("item1"); v == null; v = provider.groupWatcher.groupItems().get("item1")) {
         }

--- a/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/MockZookeeperConfigurationProvider.java
+++ b/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/MockZookeeperConfigurationProvider.java
@@ -78,13 +78,15 @@ public class MockZookeeperConfigurationProvider extends ModuleProvider {
             private Map<String, String> config = new ConcurrentHashMap<>();
 
             @Override
-            public void notify(final ConfigChangeEvent value) {
-                LOGGER.info("ConfigChangeWatcher.ConfigChangeEvent: {}", value);
-                if (EventType.DELETE.equals(value.getEventType())) {
-                    config.remove(value.getGroupItemName());
-                } else {
-                    config.put(value.getGroupItemName(), value.getNewValue());
-                }
+            public void notifyGroup(Map<String , ConfigChangeEvent> groupItems) {
+                LOGGER.info("GroupConfigChangeWatcher.ConfigChangeEvents: {}", groupItems);
+                groupItems.forEach((groupItemName , event) -> {
+                    if (EventType.DELETE.equals(event.getEventType())) {
+                        config.remove(groupItemName);
+                    } else {
+                        config.put(groupItemName, event.getNewValue());
+                    }
+                });
             }
 
             @Override

--- a/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/MockZookeeperConfigurationProvider.java
+++ b/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/MockZookeeperConfigurationProvider.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.oap.server.configuration.zookeeper.it;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.configuration.api.ConfigChangeWatcher;
 import org.apache.skywalking.oap.server.configuration.api.ConfigurationModule;
 import org.apache.skywalking.oap.server.configuration.api.DynamicConfigurationService;
@@ -28,12 +29,9 @@ import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
 import org.apache.skywalking.oap.server.library.module.ModuleProvider;
 import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class MockZookeeperConfigurationProvider extends ModuleProvider {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MockZookeeperConfigurationProvider.class);
-
     ConfigChangeWatcher watcher;
     GroupConfigChangeWatcher groupWatcher;
 
@@ -60,7 +58,7 @@ public class MockZookeeperConfigurationProvider extends ModuleProvider {
 
             @Override
             public void notify(ConfigChangeEvent value) {
-                LOGGER.info("ConfigChangeWatcher.ConfigChangeEvent: {}", value);
+                log.info("ConfigChangeWatcher.ConfigChangeEvent: {}", value);
                 if (EventType.DELETE.equals(value.getEventType())) {
                     testValue = null;
                 } else {
@@ -79,7 +77,7 @@ public class MockZookeeperConfigurationProvider extends ModuleProvider {
 
             @Override
             public void notifyGroup(Map<String , ConfigChangeEvent> groupItems) {
-                LOGGER.info("GroupConfigChangeWatcher.ConfigChangeEvents: {}", groupItems);
+                log.info("GroupConfigChangeWatcher.ConfigChangeEvents: {}", groupItems);
                 groupItems.forEach((groupItemName , event) -> {
                     if (EventType.DELETE.equals(event.getEventType())) {
                         config.remove(groupItemName);

--- a/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/ut/MockZookeeperConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/ut/MockZookeeperConfigWatcherRegister.java
@@ -24,6 +24,7 @@ import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 import org.apache.skywalking.oap.server.configuration.zookeeper.ZookeeperServerSettings;
 
 public class MockZookeeperConfigWatcherRegister extends ConfigWatcherRegister {
@@ -43,5 +44,10 @@ public class MockZookeeperConfigWatcherRegister extends ConfigWatcherRegister {
             table.add(new ConfigTable.ConfigItem(s, data == null ? null : new String(data.getData())));
         });
         return Optional.of(table);
+    }
+
+    @Override
+    public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+        return Optional.empty();
     }
 }

--- a/oap-server/server-configuration/grpc-configuration-sync/src/main/java/org/apache/skywalking/oap/server/configuration/grpc/GRPCConfigWatcherRegister.java
+++ b/oap-server/server-configuration/grpc-configuration-sync/src/main/java/org/apache/skywalking/oap/server/configuration/grpc/GRPCConfigWatcherRegister.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 import org.apache.skywalking.oap.server.configuration.service.ConfigurationRequest;
 import org.apache.skywalking.oap.server.configuration.service.ConfigurationResponse;
 import org.apache.skywalking.oap.server.configuration.service.ConfigurationServiceGrpc;
@@ -72,5 +73,11 @@ public class GRPCConfigWatcherRegister extends ConfigWatcherRegister {
             LOGGER.error("Remote config center [" + settings + "] is not available.", e);
         }
         return Optional.of(table);
+    }
+
+    @Override
+    public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+        // TODO: implement readGroupConfig
+        return Optional.empty();
     }
 }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/ApdexThresholdConfigTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/ApdexThresholdConfigTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.skywalking.oap.server.configuration.api.ConfigTable;
 import org.apache.skywalking.oap.server.configuration.api.ConfigWatcherRegister;
+import org.apache.skywalking.oap.server.configuration.api.GroupConfigTable;
 import org.apache.skywalking.oap.server.core.CoreModuleProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,6 +74,11 @@ public class ApdexThresholdConfigTest {
             ConfigTable table = new ConfigTable();
             table.add(new ConfigTable.ConfigItem("core.default.apdexThreshold", "default: 1000 \nfoo: 200"));
             return Optional.of(table);
+        }
+
+        @Override
+        public Optional<GroupConfigTable> readGroupConfig(final Set<String> keys) {
+            return Optional.empty();
         }
     }
 }


### PR DESCRIPTION
### Support collection type in dynamic configuration core and add zookeeper implementation
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [X] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

related to #7081

add `GroupConfigTable` and  `GroupConfigChangeWatcher` to watch grouped dynamic configurations
