### PR TITLE
Use skywalking-eyes GHA instead of manually compile

### DIFF
--- a/.github/actions/e2e-test/action.yml
+++ b/.github/actions/e2e-test/action.yml
@@ -44,15 +44,7 @@ runs:
         fi
         echo "::endgroup::"
     - name: Check License
-      shell: bash
-      run: |
-        echo "::group::Build License-Eye Binary"
-        git clone https://github.com/apache/skywalking-eyes.git
-        git -C skywalking-eyes reset --hard a63f4afcc287dfb3727ecc45a4afc55a5e69c15f
-        make -C skywalking-eyes docker || make -C skywalking-eyes docker  # Retry if fail
-        rm -rf skywalking-eyes
-        docker run --rm -v $(pwd):/github/workspace license-eye:latest header check
-        echo "::endgroup::"
+      uses: apache/skywalking-eyes@a63f4afcc287dfb3727ecc45a4afc55a5e69c15f
     - name: Build Docker Image
       shell: bash
       env:

--- a/.github/actions/plugins-test/action.yml
+++ b/.github/actions/plugins-test/action.yml
@@ -48,15 +48,7 @@ runs:
         fi
         echo "::endgroup::"
     - name: Check License
-      shell: bash
-      run: |
-        echo "::group::Build License-Eye Binary"
-        git clone https://github.com/apache/skywalking-eyes.git
-        git -C skywalking-eyes reset --hard a63f4afcc287dfb3727ecc45a4afc55a5e69c15f
-        make -C skywalking-eyes docker || make -C skywalking-eyes docker
-        rm -rf skywalking-eyes
-        docker run --rm -v $(pwd):/github/workspace license-eye:latest header check
-        echo "::endgroup::"
+      uses: apache/skywalking-eyes@a63f4afcc287dfb3727ecc45a4afc55a5e69c15f
     - name: Add checkstyle-plugin
       shell: bash
       run: |

--- a/.github/workflows/ci-it.yaml
+++ b/.github/workflows/ci-it.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: 'Install & Test'
         if: env.SKIP_CI != 'true'
         run: |
-          ./mvnw --batch-mode -P"agent,backend,ui,dist,CI-with-IT" clean cobertura:cobertura verify install javadoc:javadoc
+          ./mvnw -q --batch-mode -P"agent,backend,ui,dist,CI-with-IT" clean cobertura:cobertura verify install javadoc:javadoc
           bash <(curl -s https://codecov.io/bash)
       - name: 'Check Dependencies Licenses'
         if: env.SKIP_CI != 'true'
@@ -96,7 +96,7 @@ jobs:
           java-version: 11
       - name: 'Install & Test'
         if: env.SKIP_CI != 'true'
-        run: ./mvnw --batch-mode -P"agent,backend,ui,dist" clean verify install
+        run: ./mvnw -q --batch-mode -P"agent,backend,ui,dist" clean verify install
 
   CI-on-Windows:
     if: (github.event_name == 'schedule' && github.repository == 'apache/skywalking') || (github.event_name != 'schedule')
@@ -115,7 +115,7 @@ jobs:
       - name: 'Install & Test'
         if: env.SKIP_CI != 'true'
         run: |
-          ./mvnw --batch-mode -P"agent,backend,ui,dist" clean verify install
+          ./mvnw -q --batch-mode -P"agent,backend,ui,dist" clean verify install
 
 
   CI-on-MacOS:
@@ -144,5 +144,5 @@ jobs:
         if: env.SKIP_CI != 'true'
         run: |
           # Given packaging on Mac has a high possibility to fail, we retry one more time here
-          ./mvnw --batch-mode -P"agent,backend,ui,dist" clean verify install || \
-          ./mvnw --batch-mode -P"agent,backend,ui,dist" clean verify install
+          ./mvnw -q --batch-mode -P"agent,backend,ui,dist" clean verify install || \
+          ./mvnw -q --batch-mode -P"agent,backend,ui,dist" clean verify install

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -50,7 +50,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
 
-    - run: ./mvnw -Dmaven.test.skip=true clean install || ./mvnw -Dmaven.test.skip=true clean install
+    - run: ./mvnw -q -Dmaven.test.skip=true clean install || ./mvnw -q -Dmaven.test.skip=true clean install
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/e2e.istio.yaml
+++ b/.github/workflows/e2e.istio.yaml
@@ -158,10 +158,10 @@ jobs:
 
           export SW_VERSION=$(./mvnw -q -DforceStdout -N org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version)
 
-          ./mvnw -DskipTests -N install
-          ./mvnw -f apm-application-toolkit -DskipTests -am install
+          ./mvnw -q -DskipTests -N install
+          ./mvnw -q -f apm-application-toolkit -DskipTests -am install
 
-          ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false -Dsw.version=${SW_VERSION} verify -Dit.test=org.apache.skywalking.e2e.mesh.ALSE2E
+          ./mvnw -q --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false -Dsw.version=${SW_VERSION} verify -Dit.test=org.apache.skywalking.e2e.mesh.ALSE2E
 
       - name: Logs
         if: ${{ failure() }}
@@ -301,10 +301,10 @@ jobs:
 
           export SW_VERSION=$(./mvnw -q -DforceStdout -N org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version)
 
-          ./mvnw -DskipTests -N install
-          ./mvnw -f apm-application-toolkit -DskipTests -am install
+          ./mvnw -q -DskipTests -N install
+          ./mvnw -q -f apm-application-toolkit -DskipTests -am install
 
-          ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false -Dsw.version=${SW_VERSION} verify -Dit.test=org.apache.skywalking.e2e.mesh.MetricsServiceE2E
+          ./mvnw -q --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false -Dsw.version=${SW_VERSION} verify -Dit.test=org.apache.skywalking.e2e.mesh.MetricsServiceE2E
 
       - name: Logs
         if: ${{ failure() }}

--- a/.github/workflows/plugins-test.3.yaml
+++ b/.github/workflows/plugins-test.3.yaml
@@ -104,14 +104,14 @@ jobs:
       - name: Add checkstyle-plugin
         run: sed -i '/<\/sourceDirectories>/i <sourceDirectory>scenarios\/oracle-scenario<\/sourceDirectory>' test/plugin/pom.xml
       - name: Build SkyWalking Agent
-        run: ./mvnw --batch-mode clean package -DskipTests -Pagent
+        run: ./mvnw -q --batch-mode clean package -DskipTests -Pagent
       - name: Build Docker image
-        run: ./mvnw --batch-mode -f test/plugin/pom.xml clean package -DskipTests
+        run: ./mvnw -q --batch-mode -f test/plugin/pom.xml clean package -DskipTests
       - name: Oracle 10.2.0.4.0 (1)
         run: |
           curl -O https://skyapm.github.io/ci-assist/jars/ojdbc14-10.2.0.4.0.jar
           curl -L -o ./skywalking-agent/plugins/apm-oracle-10.x-plugin-2.0.0.jar https://github.com/SkyAPM/java-plugin-extensions/releases/download/2.0.0/apm-oracle-10.x-plugin-2.0.0.jar
-          ./mvnw --batch-mode install:install-file -Dfile=ojdbc14-10.2.0.4.0.jar -DgroupId=com.oracle -DartifactId=ojdbc14 -Dversion=10.2.0.4.0 -Dpackaging=jar
+          ./mvnw -q --batch-mode install:install-file -Dfile=ojdbc14-10.2.0.4.0.jar -DgroupId=com.oracle -DartifactId=ojdbc14 -Dversion=10.2.0.4.0 -Dpackaging=jar
           bash test/plugin/run.sh oracle-scenario
       - name: Report Coverage
         run: bash -x tools/coverage/report.sh


### PR DESCRIPTION
Also use `quiet` mode for all maven commands in GHA to avoid too MANY logs when we want to spot some outlier cases, we can still see errors when there is failure. And the compile logs never expose real errors
