### PR TITLE
Fix `ZookeeperConfigWatcherRegister.readConfig()` could cause `NPE` when `data.getData()` is null

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ Release Notes.
   by `agent-analyzer.default.traceSamplingPolicySettingsFile`.
 * Fix dynamic configuration watch implementation current value not null when the config is deleted.
 * Fix `LoggingConfigWatcher` return `watch.value` would not consistent with the real configuration content.
+* Fix `ZookeeperConfigWatcherRegister.readConfig()` could cause `NPE` when `data.getData()` is null.
 
 #### UI
 

--- a/oap-server/server-configuration/configuration-zookeeper/src/main/java/org/apache/skywalking/oap/server/configuration/zookeeper/ZookeeperConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-zookeeper/src/main/java/org/apache/skywalking/oap/server/configuration/zookeeper/ZookeeperConfigWatcherRegister.java
@@ -52,7 +52,11 @@ public class ZookeeperConfigWatcherRegister extends ConfigWatcherRegister {
         ConfigTable table = new ConfigTable();
         keys.forEach(s -> {
             ChildData data = this.childrenCache.getCurrentData(this.prefix + s);
-            table.add(new ConfigTable.ConfigItem(s, data == null ? null : new String(data.getData())));
+            String itemValue = null;
+            if (data != null && data.getData() != null) {
+                itemValue = new String(data.getData());
+            }
+            table.add(new ConfigTable.ConfigItem(s, itemValue));
         });
         return Optional.of(table);
     }


### PR DESCRIPTION
### Fix  `ZookeeperConfigWatcherRegister.readConfig()` could cause `NPE` when `data.getData()` is null
- [ ] Add a unit test to verify that the fix works.
- [X] Explain briefly why the bug exists and how to fix it.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

`new String(data.getData())` could cause NPE, when clear data bytes or set data byte[] null.
