### PR TITLE
Fix `H2MetadataQueryDAO.searchService` doesn't support auto grouping.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@ Release Notes.
 * Support mTLS for gRPC channel.
 * Add yaml file suffix limit when reading ui templates.
 * Support consul grouped dynamic configurations.
+* Fix `H2MetadataQueryDAO.searchService` doesn't support auto grouping.
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
@@ -163,6 +163,7 @@ public class H2MetadataQueryDAO implements IMetadataQueryDAO {
                     Service service = new Service();
                     service.setId(resultSet.getString(H2TableInstaller.ID_COLUMN));
                     service.setName(resultSet.getString(ServiceTraffic.NAME));
+                    service.setGroup(resultSet.getString(ServiceTraffic.GROUP));
                     return service;
                 }
             }


### PR DESCRIPTION
 [issue #7653]

H2MetadataQueryDAO.searchService (Line 162-167) doesn't support group. Related to Pull Request #5851.  
We should call service.setGroup in H2MetadataQueryDAO.searchService.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #7653.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
