### PR TITLE
Fix "ProfileThreadSnapshotQuery.queryProfiledSegments" adopts a wrong sort function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@ Release Notes.
 * Unified the config word `namespace` in the project.
 * Switch JRE base image for dev images.
 * Support apollo grouped dynamic configurations.
+* Fix `ProfileThreadSnapshotQuery.queryProfiledSegments` adopts a wrong sort function
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/ProfileThreadSnapshotQuery.java
+++ b/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/ProfileThreadSnapshotQuery.java
@@ -77,7 +77,7 @@ public class ProfileThreadSnapshotQuery implements IProfileThreadSnapshotQueryDA
         }
 
         final WhereQueryImpl<SelectQueryImpl> whereQuery = select()
-            .function(InfluxConstants.SORT_ASC, SegmentRecord.START_TIME, segments.size())
+            .function(InfluxConstants.SORT_DES, SegmentRecord.START_TIME, segments.size())
             .column(SegmentRecord.SEGMENT_ID)
             .column(SegmentRecord.START_TIME)
             .column(SegmentRecord.ENDPOINT_ID)


### PR DESCRIPTION
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #7695.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).