### PR TITLE
Fix that `Query` cannot be updated after it's set in `SearchBuilder`

### DIFF
--- a/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/requests/search/MatchQuery.java
+++ b/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/requests/search/MatchQuery.java
@@ -38,10 +38,14 @@ public final class MatchQuery extends Query {
         public void serialize(final MatchQuery value, final JsonGenerator gen,
                               final SerializerProvider provider)
             throws IOException {
-            gen.writeFieldName("match");
             gen.writeStartObject();
             {
-                gen.writeStringField(value.getName(), value.getText());
+                gen.writeFieldName("match");
+                gen.writeStartObject();
+                {
+                    gen.writeStringField(value.getName(), value.getText());
+                }
+                gen.writeEndObject();
             }
             gen.writeEndObject();
         }

--- a/oap-server/server-library/library-elasticsearch-client/src/test/java/org/apache/skywalking/library/elasticsearch/requests/search/SearchBuilderTest.java
+++ b/oap-server/server-library/library-elasticsearch-client/src/test/java/org/apache/skywalking/library/elasticsearch/requests/search/SearchBuilderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.library.elasticsearch.requests.search;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SearchBuilderTest {
+    @Test
+    public void searchQueryShouldBeUpdatableAfterSet() {
+        final BoolQueryBuilder queryBuilder = Query.bool();
+        final SearchBuilder searchBuilder = Search.builder().query(queryBuilder);
+        queryBuilder.must(Query.term("t", "v"));
+        queryBuilder.should(Query.term("t", "v"));
+        queryBuilder.mustNot(Query.term("t2", "v2"));
+        queryBuilder.shouldNot(Query.term("t2", "v2"));
+        queryBuilder.shouldNot(Query.term("t2", "v2"));
+
+        final BoolQuery query = (BoolQuery) searchBuilder.build().getQuery();
+        assertThat(query.getMust()).hasSize(1);
+        assertThat(query.getShould()).hasSize(1);
+        assertThat(query.getMustNot()).hasSize(1);
+        assertThat(query.getShouldNot()).hasSize(2);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void searchQueryBuilderShouldNotBeSetMultipleTimes() {
+        final BoolQueryBuilder queryBuilder = Query.bool();
+        final SearchBuilder searchBuilder = Search.builder().query(queryBuilder);
+        searchBuilder.query(Query.bool());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void searchQueryShouldNotBeSetMultipleTimes() {
+        final SearchBuilder searchBuilder = Search.builder().query(Query.bool().build());
+        searchBuilder.query(Query.bool().build());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void searchQueryAndBuilderShouldNotBeSetSimultaneously() {
+        final SearchBuilder searchBuilder = Search.builder().query(Query.bool().build());
+        searchBuilder.query(Query.bool());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@
         <jmh.version>1.21</jmh.version>
         <gmaven-plugin.version>1.5</gmaven-plugin.version>
         <checkstyle.fails.on.error>true</checkstyle.fails.on.error>
+        <assertj-core.version>3.20.2</assertj-core.version>
 
     </properties>
 
@@ -232,6 +233,10 @@
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
 
         <dependency>
@@ -285,6 +290,12 @@
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
                 <version>${objenesis.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj-core.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
### Fix that `Query` cannot be updated after it's set in `SearchBuilder`
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
When `QueryBuilder` is set in `SearchBuilder`, the following updates to `QueryBuilder` (like `queryBuilder.must(Query.term(GROUP, "abc")` takes no effect, because when `SearchBuilder` accepts an `QueryBuilder`, it builds a `Query` from the builder and not keep the builder itself.
This patch also fixes a serialization error of `MatchQuery`.
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>. NO
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md). NO NEED, not released yet.
