### PR TITLE
Fix H2EventQueryDAO doesn't sort data by Event.START_TIME and uses a wrong pagination query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,7 +64,7 @@ Release Notes.
 * Support apollo grouped dynamic configurations.
 * Fix `ProfileThreadSnapshotQuery.queryProfiledSegments` adopts a wrong sort function
 * Support gRPC sync grouped dynamic configurations.
-* Fix `H2EventQueryDAO` doesn't sort data by Event.START_TIME.
+* Fix `H2EventQueryDAO` doesn't sort data by Event.START_TIME and uses a wrong pagination query.
 
 #### UI
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@ Release Notes.
 * Support apollo grouped dynamic configurations.
 * Fix `ProfileThreadSnapshotQuery.queryProfiledSegments` adopts a wrong sort function
 * Support gRPC sync grouped dynamic configurations.
+* Fix `H2EventQueryDAO` doesn't sort data by Event.START_TIME.
 
 #### UI
 


### PR DESCRIPTION
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #7713.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
