### PR TITLE
Remove filter for Istiod monitor to reduce the prerequisites of job name matching

### DIFF
--- a/oap-server/server-starter/src/main/resources/otel-oc-rules/istio-controlplane.yaml
+++ b/oap-server/server-starter/src/main/resources/otel-oc-rules/istio-controlplane.yaml
@@ -28,7 +28,6 @@
 #    "-P6H3M"    -- parses as "-6 hours and -3 minutes"
 #    "-P-6H+3M"  -- parses as "+6 hours and -3 minutes"
 # </pre>
-filter: "{ tags -> tags.job_name == 'kubernetes-pods' }" # The OpenTelemetry job name
 expSuffix: tag({tags -> tags.cluster = 'istio-ctrl::' + tags.cluster}).service(['cluster', 'app'])
 metricPrefix: meter_istio
 metricsRules:
@@ -99,11 +98,11 @@ metricsRules:
   ## Webhooks
   # Configuration Validation
   - name: galley_validation_passed
-    exp: galley_validation_passed.sum(['cluster', 'app']).rate('PT1M')
+    exp: galley_validation_passed.tagEqual('app', 'istiod').sum(['cluster', 'app']).rate('PT1M')
   - name: galley_validation_failed
-    exp: galley_validation_failed.sum(['cluster', 'app']).rate('PT1M')
+    exp: galley_validation_failed.tagEqual('app', 'istiod').sum(['cluster', 'app']).rate('PT1M')
   # Sidecar Injection
   - name: sidecar_injection_success_total
-    exp: sidecar_injection_success_total.sum(['cluster', 'app']).rate('PT1M')
+    exp: sidecar_injection_success_total.tagEqual('app', 'istiod').sum(['cluster', 'app']).rate('PT1M')
   - name: sidecar_injection_failure_total
-    exp: sidecar_injection_failure_total.sum(['cluster', 'app']).rate('PT1M')
+    exp: sidecar_injection_failure_total.tagEqual('app', 'istiod').sum(['cluster', 'app']).rate('PT1M')


### PR DESCRIPTION
I found out the reason why there is no conflict between Istio and so11y in https://github.com/apache/skywalking/pull/8157#discussion_r753153239 is the `istio-controlplane.yaml` has already filter the metrics by tag `app == istiod`, and since we also have filter for so11y since https://github.com/apache/skywalking/pull/8157, I think we can safely remove the filter in `istio-controlplane.yaml` so that the users don't bother to check the job name in OTEL and the filter name in our file `istio-controlplane.yaml`, which reduce extra work and confusion if users found there is no data on UI, just because of the names' not matching.
