### PR TITLE
fix StorageModuleElasticsearchProvider doesn't watch on TrustStorePath

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@ Release Notes.
 * Support using IoTDB as a new storage option.
 * Add customized envoy ALS protocol receiver for satellite transmit batch data.
 * Remove `logback` dependencies in IoTDB plugin.
+* Fix `StorageModuleElasticsearchProvider` doesn't watch on `trustStorePath`.
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchProvider.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchProvider.java
@@ -145,7 +145,7 @@ public class StorageModuleElasticsearchProvider extends ModuleProvider {
                     elasticSearchClient.setTrustStorePass(config.getTrustStorePass());
                     elasticSearchClient.connect();
                 }
-            }, config.getSecretsManagementFile(), config.getTrustStorePass());
+            }, config.getSecretsManagementFile(), config.getTrustStorePath());
             /*
              * By leveraging the sync update check feature when startup.
              */


### PR DESCRIPTION
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #8204
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
