### PR TITLE
fix ETCD cluster config environment variables not working.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 
 * Fix potential NPE in OAL string match and a bug when right-hand-side variable includes double quotes.
 * Bump up Armeria version to fix CVE.
+* Polish ETCD cluster config environment variables.
 
 #### UI
 

--- a/docs/en/setup/backend/backend-cluster.md
+++ b/docs/en/setup/backend/backend-cluster.md
@@ -99,10 +99,10 @@ cluster:
     # etcd cluster nodes, example: 10.0.0.1:2379,10.0.0.2:2379,10.0.0.3:2379
     endpoints: ${SW_CLUSTER_ETCD_ENDPOINTS:localhost:2379}
     namespace: ${SW_CLUSTER_ETCD_NAMESPACE:/skywalking}
-    serviceName: ${SW_SCLUSTER_ETCD_ERVICE_NAME:"SkyWalking_OAP_Cluster"}
+    serviceName: ${SW_CLUSTER_ETCD_SERVICE_NAME:"SkyWalking_OAP_Cluster"}
     authentication: ${SW_CLUSTER_ETCD_AUTHENTICATION:false}
-    user: ${SW_SCLUSTER_ETCD_USER:}
-    password: ${SW_SCLUSTER_ETCD_PASSWORD:}
+    user: ${SW_CLUSTER_ETCD_USER:}
+    password: ${SW_CLUSTER_ETCD_PASSWORD:}
 ```
 
 Same as the Zookeeper coordinator,

--- a/oap-server/server-starter/src/main/resources/application.yml
+++ b/oap-server/server-starter/src/main/resources/application.yml
@@ -41,10 +41,10 @@ cluster:
     # etcd cluster nodes, example: 10.0.0.1:2379,10.0.0.2:2379,10.0.0.3:2379
     endpoints: ${SW_CLUSTER_ETCD_ENDPOINTS:localhost:2379}
     namespace: ${SW_CLUSTER_ETCD_NAMESPACE:/skywalking}
-    serviceName: ${SW_SCLUSTER_ETCD_ERVICE_NAME:"SkyWalking_OAP_Cluster"}
+    serviceName: ${SW_CLUSTER_ETCD_SERVICE_NAME:"SkyWalking_OAP_Cluster"}
     authentication: ${SW_CLUSTER_ETCD_AUTHENTICATION:false}
-    user: ${SW_SCLUSTER_ETCD_USER:}
-    password: ${SW_SCLUSTER_ETCD_PASSWORD:}
+    user: ${SW_CLUSTER_ETCD_USER:}
+    password: ${SW_CLUSTER_ETCD_PASSWORD:}
   nacos:
     serviceName: ${SW_SERVICE_NAME:"SkyWalking_OAP_Cluster"}
     hostPort: ${SW_CLUSTER_NACOS_HOST_PORT:localhost:8848}


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->
Polish ETCD cluster config environment variables.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
