### PR TITLE
Remove unused jars and bump up netty version in webapp

### DIFF
--- a/apm-webapp/pom.xml
+++ b/apm-webapp/pom.xml
@@ -39,6 +39,7 @@
         <logback-classic.version>1.2.3</logback-classic.version>
         <jackson-version>2.12.2</jackson-version>
         <yaml.version>1.28</yaml.version>
+        <netty.version>4.1.68.Final</netty.version>
 
         <ui.path>${project.parent.basedir}/skywalking-ui</ui.path>
     </properties>
@@ -51,6 +52,13 @@
                 <version>${spring-cloud-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -74,6 +82,10 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -120,9 +132,6 @@
 
     <build>
         <finalName>skywalking-webapp</finalName>
-        <resources>
-
-        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/dist-material/release-docs/LICENSE
+++ b/dist-material/release-docs/LICENSE
@@ -320,7 +320,6 @@ The text of each license is the standard Apache 2.0 license.
     slf4j-api 1.7.30: http://www.slf4j.org, Apache 2.0
     mvel 2.4.8: https://github.com/mvel/mvel, Apache 2.0
     okio 1.17.2: https://github.com/square/okio Apache 2.0
-    caffeine 2.6.2: https://github.com/ben-manes/caffeine Apache 2.0
     simpleclient_httpserver 0.12.0 from prometheus https://github.com/prometheus/client_java Apache 2.0
     jetcd 0.5.3, https://github.com/etcd-io/jetcd, Apache 2.0
     failasfe 2.3.4, https://github.com/jhalterman/failsafe, Apache 2.0


### PR DESCRIPTION
- spring-boot-starter-logging by default adds log4j to class path but since we are using logback we can safely exclude it, to avoid false negative report from tools.
- Bump up netty to the same version as OAP.
- Remove license of unused dependencies (old version used but had been removed)

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

