### PR TITLE
NPE fix for IndexController#getPhysicalTableName

### DIFF
--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexController.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexController.java
@@ -88,7 +88,7 @@ public enum IndexController {
         public static final String METRIC_TABLE_NAME = "metric_table";
 
         public static String getPhysicalTableName(String logicName) {
-            return Optional.of(LOGIC_INDICES_CATALOG.get(logicName)).orElse(logicName);
+            return Optional.ofNullable(LOGIC_INDICES_CATALOG.get(logicName)).orElse(logicName);
         }
 
         public static void registerRelation(String logicName, String physicalName) {


### PR DESCRIPTION
`Optional.of().orElse()` doesn't make sense. I got an NPE when I searched for a missing table name. I'm not sure if this is the correct fix. Maybe the NPE is expected? If so, the `orElse` should be removed then as it's pointless.