### PR TITLE
Fix CVE-2022-23221

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@ Release Notes.
 * Bump up GraphQL related dependencies to latest versions.
 * Add `normal` to V9 service meta query.
 * Support `scope=ALL` catalog for metrics.
+* Fix CVE-2022-23221. H2 Console before 2.1.210 allows remote attackers to execute arbitrary code via a jdbc:h2:mem JDBC URL containing the IGNORE_UNKNOWN_SETTINGS=TRUE;FORBID_CREATION=FALSE;INIT=RUNSCRIPT substring.
 
 #### UI
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,7 @@ Release Notes.
 * Bump up GraphQL related dependencies to latest versions.
 * Add `normal` to V9 service meta query.
 * Support `scope=ALL` catalog for metrics.
-* Fix CVE-2022-23221. H2 Console before 2.1.210 allows remote attackers to execute arbitrary code via a jdbc:h2:mem JDBC URL containing the IGNORE_UNKNOWN_SETTINGS=TRUE;FORBID_CREATION=FALSE;INIT=RUNSCRIPT substring.
+* Bump up H2 to 2.1.210 to fix CVE-2022-23221.
 
 #### UI
 

--- a/dist-material/release-docs/LICENSE
+++ b/dist-material/release-docs/LICENSE
@@ -385,7 +385,7 @@ MPL 2.0 licenses
 The following components are provided under a MPL 2.0 license. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    H2 Database 2.0.206: http://www.h2database.com/html/main.html , MPL 2.0 or EPL 1.0
+    H2 Database 2.1.210: http://www.h2database.com/html/main.html , MPL 2.0 or EPL 1.0
 
 ========================================
 CC0-1.0 licenses

--- a/oap-server-bom/pom.xml
+++ b/oap-server-bom/pom.xml
@@ -35,7 +35,7 @@
         <graphql-java-extended-scalars.version>17.0</graphql-java-extended-scalars.version>
         <okhttp.version>3.14.9</okhttp.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <h2.version>2.0.206</h2.version>
+        <h2.version>2.1.210</h2.version>
         <joda-time.version>2.10.5</joda-time.version>
         <zookeeper.version>3.5.7</zookeeper.version>
         <guava.version>28.1-jre</guava.version>

--- a/test/e2e-v2/java-test-service/pom.xml
+++ b/test/e2e-v2/java-test-service/pom.xml
@@ -48,7 +48,7 @@
         <jupeter.version>5.6.0</jupeter.version>
         <jackson.version>2.9.7</jackson.version>
         <guava.version>30.1.1-jre</guava.version>
-        <h2.version>2.0.202</h2.version>
+        <h2.version>2.1.210</h2.version>
         <mysql.version>8.0.13</mysql.version>
         <lombok.version>1.18.20</lombok.version>
         <kafka-clients.version>2.4.1</kafka-clients.version>

--- a/tools/dependencies/known-oap-backend-dependencies.txt
+++ b/tools/dependencies/known-oap-backend-dependencies.txt
@@ -57,7 +57,7 @@ gson-2.8.6.jar
 gson-fire-1.8.5.jar
 guava-28.1-jre.jar
 guice-4.1.0.jar
-h2-2.0.206.jar
+h2-2.1.210.jar
 httpasyncclient-4.1.3.jar
 httpclient-4.5.13.jar
 httpcore-4.4.13.jar


### PR DESCRIPTION
H2 Console before 2.1.210 allows remote attackers to execute arbitrary code via a jdbc:h2:mem JDBC URL containing the IGNORE_UNKNOWN_SETTINGS=TRUE;FORBID_CREATION=FALSE;INIT=RUNSCRIPT substring

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
