### PR TITLE
Allow updating non-metrics templates when structure changed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ Release Notes.
 * [Break Change] Keep the endpoint avg resp time meter name the same with others scope. (This may break 3rd party integration and existing alarm rule settings)
 * Add Python FastApi component ID(7014).
 * Support all metrics from MAL engine in alarm core, including Prometheus, OC receiver, meter receiver.
+* Allow updating non-metrics templates when structure changed.
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
@@ -81,7 +81,7 @@ public class StorageEsInstaller extends ModelInstaller {
 
         boolean exist = templateExists && lastIndexExists;
 
-        if (exist && IndexController.INSTANCE.isMetricModel(model)) {
+        if (exist) {
             structures.putStructure(
                 tableName, template.get().getMappings()
             );
@@ -119,9 +119,7 @@ public class StorageEsInstaller extends ModelInstaller {
         String indexName = TimeSeriesUtils.latestWriteIndexName(model);
         try {
             boolean shouldUpdateTemplate = !esClient.isExistsTemplate(tableName);
-            if (IndexController.INSTANCE.isMetricModel(model)) {
-                shouldUpdateTemplate = shouldUpdateTemplate || !structures.containsStructure(tableName, mapping);
-            }
+            shouldUpdateTemplate = shouldUpdateTemplate || !structures.containsStructure(tableName, mapping);
             if (shouldUpdateTemplate) {
                 structures.putStructure(tableName, mapping);
                 boolean isAcknowledged = esClient.createOrUpdateTemplate(


### PR DESCRIPTION
We have template structures changes in #8367 but if we upgrade from an older storage, the non-metrics templates (e.g. `service_traffic`) won't get updated.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
