### PR TITLE
Remove inapplicable example for enforcer / dropper sampler in LAL doc

### DIFF
--- a/docs/en/concepts-and-designs/lal.md
+++ b/docs/en/concepts-and-designs/lal.md
@@ -336,21 +336,3 @@ filter {
     }
 }
 ```
-
-You can use `enforcer` and `dropper` to simulate a probabilistic sampler like this.
-
-```groovy
-filter {
-    // ... parser
-
-    sink {
-        sampler { // simulate a probabilistic sampler with sampler rate 30% (not accurate though)
-            if (Math.abs(Math.random()) > 0.3) {
-                enforcer {}
-            } else {
-                dropper {}
-            }
-        }
-    }
-}
-```


### PR DESCRIPTION
Looks like 8.9.1 is not protected.