### PR TITLE
Fix Zipkin receiver wrong condition for decoding `gzip`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ Release Notes.
 * Set default connection timeout of ElasticSearch to 3000 milliseconds.
 * Support ElasticSearch 8 and add it into E2E tests.
 * Disable indexing for field `alarm_record.tags_raw_data` of binary type in ElasticSearch storage.
+* Fix Zipkin receiver wrong condition for decoding `gzip`. 
 
 #### UI
 

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanProcessor.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanProcessor.java
@@ -58,7 +58,7 @@ public class SpanProcessor {
     private InputStream getInputStream(HttpServletRequest request) throws IOException {
         InputStream requestInStream;
 
-        String headEncoding = request.getHeader("accept-encoding");
+        String headEncoding = request.getHeader("Content-Encoding");
         if (headEncoding != null && (headEncoding.indexOf("gzip") != -1)) {
             requestInStream = new GZIPInputStream(request.getInputStream());
         } else {


### PR DESCRIPTION
Zipkin receiver used `accept-encoding` to identify the agent report is a  gzip content, fix it to  `Content-Encoding`.

### Fix Zipkin receiver wrong condition for decoding `gzip`
- [ ] Add a unit test to verify that the fix works.
- [X] Explain briefly why the bug exists and how to fix it.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #8267.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
