### PR TITLE
Upgrade Apache Parent version to 25

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Release Notes.
 * Add E2E test under Java 17.
 * Upgrade protoc to 3.19.2.
 * Add Istio 1.13.1 to E2E test matrix for verification.
+* Upgrade Apache parent pom version to 25.
 
 #### OAP Server
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>21</version>
+        <version>25</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,13 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>${compiler.version}</source>
+                    <target>${compiler.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>${maven-resource-plugin.version}</version>
                 <configuration>


### PR DESCRIPTION
1: We can see the difference in several versions here. https://maven.apache.org/pom-archives/asf-LATEST/#history
2: The docs plugin is set to default to Java 1.7, so I modified it.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).