### PR TITLE
Use the plugin version defined by the Apache maven parent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Release Notes.
 * Upgrade protoc to 3.19.2.
 * Add Istio 1.13.1 to E2E test matrix for verification.
 * Upgrade Apache parent pom version to 25.
+* Use the plugin version defined by the Apache maven parent.
 
 #### OAP Server
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,15 @@ Release Notes.
 * Add Istio 1.13.1 to E2E test matrix for verification.
 * Upgrade Apache parent pom version to 25.
 * Use the plugin version defined by the Apache maven parent.
+  * Upgrade maven-dependency-plugin to 3.2.0.
+  * Upgrade  maven-assembly-plugin to 3.3.0.
+  * Upgrade  maven-failsafe-plugin to 2.22.2.
+  * Upgrade  maven-surefire-plugin to 2.22.2.
+  * Upgrade  maven-jar-plugin to 3.2.2.
+  * Upgrade  maven-enforcer-plugin to 3.0.0.
+  * Upgrade  maven-compiler-plugin to 3.10.0.
+  * Upgrade  maven-resources-plugin to 3.2.0.
+  * Upgrade  maven-source-plugin to 3.2.1.
 
 #### OAP Server
 

--- a/oap-server/pom.xml
+++ b/oap-server/pom.xml
@@ -51,8 +51,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <maven-docker-plugin.version>0.30.0</maven-docker-plugin.version>
+        
         <kafka-clients.version>2.4.1</kafka-clients.version>
         <spring-kafka-test.version>2.4.6.RELEASE</spring-kafka-test.version>
     </properties>

--- a/oap-server/server-receiver-plugin/receiver-proto/pom.xml
+++ b/oap-server/server-receiver-plugin/receiver-proto/pom.xml
@@ -110,7 +110,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven-dependency-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>unpack</id>

--- a/pom.xml
+++ b/pom.xml
@@ -192,18 +192,7 @@
         <docker.plugin.version>0.4.13</docker.plugin.version>
         <takari-maven-plugin.version>0.6.1</takari-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-        <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
-        <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
-        <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
-        <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
-        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
-        <maven-resource-plugin.version>3.1.0</maven-resource-plugin.version>
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <versions-maven-plugin.version>2.5</versions-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
         <jmh.version>1.21</jmh.version>
         <gmaven-plugin.version>1.5</gmaven-plugin.version>
@@ -329,19 +318,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>${maven-deploy-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>${maven-assembly-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>${maven-failsafe-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>${maven-jar-plugin.version}</version>
                     <configuration>
                         <forceCreation>true</forceCreation>
                     </configuration>
@@ -356,7 +341,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire-plugin.version}</version>
                     <configuration>
                         <excludes>
                             <exclude>IT*.class</exclude>
@@ -381,7 +365,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -405,7 +388,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>${compiler.version}</source>
                     <target>${compiler.version}</target>
@@ -416,12 +398,10 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <source>${compiler.version}</source>
-                    <target>${compiler.version}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven-resource-plugin.version}</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
@@ -436,7 +416,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
Use the plugin version defined by the Apache maven parent
Delete target field in the `java-doc` configuration

These are the upgraded versions:
```
maven-dependency-plugin 2.10 - 3.2.0
maven-assembly-plugin   3.1.0 - 3.3.0
maven-failsafe-plugin   2.22.0 - 2.22.2
maven-surefire-plugin   2.22.0 - 2.22.2
maven-jar-plugin        3.1.0 - 3.2.2
maven-enforcer-plugin   3.0.0-M2 - 3.0.0
maven-compiler-plugin 3.8.0 - 3.10.0
maven-resources-plugin 3.1.0 - 3.2.0
maven-source-plugin    3.0.1 - 3.2.1
```

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
