### PR TITLE
Chore: Unify module name `receiver_zipkin` to `receiver-zipkin`, remove `receiver_jaeger` from `application.yaml`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,7 @@ Release Notes.
 * Disable indexing for field `alarm_record.tags_raw_data` of binary type in ElasticSearch storage.
 * Fix Zipkin receiver wrong condition for decoding `gzip`. 
 * Add a new sampler (`possibility`) in LAL.
+* Unify module name `receiver_zipkin` to `receiver-zipkin`, remove `receiver_jaeger` from `application.yaml`. 
 
 #### UI
 

--- a/docs/en/setup/backend/configuration-vocabulary.md
+++ b/docs/en/setup/backend/configuration-vocabulary.md
@@ -200,7 +200,7 @@ core|default|role|Option values: `Mixed/Receiver/Aggregator`. **Receiver** mode 
 | receiver-otel | default | A receiver for analyzing metrics data from OpenTelemetry. | - | - |
 | - | - | enabledHandlers| Enabled handlers for otel. | SW_OTEL_RECEIVER_ENABLED_HANDLERS | - |
 | - | - | enabledOcRules| Enabled metric rules for OC handler. | SW_OTEL_RECEIVER_ENABLED_OC_RULES | - |
-| receiver_zipkin |default|  A receiver for Zipkin traces. | - | - |
+| receiver-zipkin |default|  A receiver for Zipkin traces. | - | - |
 | - | - | restHost| Binding IP of RESTful services. |SW_RECEIVER_ZIPKIN_HOST|0.0.0.0|
 | - | - | restPort | Binding port of RESTful services. | SW_RECEIVER_ZIPKIN_PORT|9411|
 | - | - | restContextPath| Web context path of RESTful services. | SW_RECEIVER_ZIPKIN_CONTEXT_PATH|/|

--- a/docs/en/setup/backend/zipkin-trace.md
+++ b/docs/en/setup/backend/zipkin-trace.md
@@ -6,7 +6,7 @@ dependency from Zipkin's trace.
 
 Use the following config to activate it.
 ```yaml
-receiver_zipkin:
+receiver-zipkin:
   selector: ${SW_RECEIVER_ZIPKIN:-}
   default:
     host: ${SW_RECEIVER_ZIPKIN_HOST:0.0.0.0}

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/ZipkinReceiverModule.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/ZipkinReceiverModule.java
@@ -28,7 +28,7 @@ import org.apache.skywalking.oap.server.library.module.ModuleDefine;
  * zipkin backend.
  */
 public class ZipkinReceiverModule extends ModuleDefine {
-    public static final String NAME = "receiver_zipkin";
+    public static final String NAME = "receiver-zipkin";
 
     public ZipkinReceiverModule() {
         super(NAME);

--- a/oap-server/server-starter/src/main/resources/application.yml
+++ b/oap-server/server-starter/src/main/resources/application.yml
@@ -383,7 +383,7 @@ receiver-otel:
     enabledHandlers: ${SW_OTEL_RECEIVER_ENABLED_HANDLERS:"oc"}
     enabledOcRules: ${SW_OTEL_RECEIVER_ENABLED_OC_RULES:"istio-controlplane"}
 
-receiver_zipkin:
+receiver-zipkin:
   selector: ${SW_RECEIVER_ZIPKIN:-}
   default:
     host: ${SW_RECEIVER_ZIPKIN_HOST:0.0.0.0}
@@ -395,12 +395,6 @@ receiver_zipkin:
     jettyAcceptorPriorityDelta: ${SW_RECEIVER_ZIPKIN_JETTY_DELTA:0}
     jettyAcceptQueueSize: ${SW_RECEIVER_ZIPKIN_QUEUE_SIZE:0}
     instanceNameRule: ${SW_RECEIVER_ZIPKIN_INSTANCE_NAME_RULE:[spring.instance_id,node_id]}
-
-receiver_jaeger:
-  selector: ${SW_RECEIVER_JAEGER:-}
-  default:
-    gRPCHost: ${SW_RECEIVER_JAEGER_HOST:0.0.0.0}
-    gRPCPort: ${SW_RECEIVER_JAEGER_PORT:14250}
 
 receiver-browser:
   selector: ${SW_RECEIVER_BROWSER:default}

--- a/oap-server/server-starter/src/test/java/org/apache/skywalking/oap/server/starter/config/ApplicationConfigLoaderTestCase.java
+++ b/oap-server/server-starter/src/test/java/org/apache/skywalking/oap/server/starter/config/ApplicationConfigLoaderTestCase.java
@@ -55,7 +55,7 @@ public class ApplicationConfigLoaderTestCase {
 
     @Test
     public void testLoadListTypeConfig() {
-        Properties providerConfig = applicationConfiguration.getModuleConfiguration("receiver_zipkin")
+        Properties providerConfig = applicationConfiguration.getModuleConfiguration("receiver-zipkin")
                 .getProviderConfiguration("default");
         List<String> instanceNameRule = (List<String>) providerConfig.get("instanceNameRule");
         assertEquals(2, instanceNameRule.size());
@@ -63,7 +63,7 @@ public class ApplicationConfigLoaderTestCase {
 
     @Test
     public void testLoadStringTypeConfig() {
-        Properties providerConfig = applicationConfiguration.getModuleConfiguration("receiver_zipkin")
+        Properties providerConfig = applicationConfiguration.getModuleConfiguration("receiver-zipkin")
                 .getProviderConfiguration("default");
         String host = (String) providerConfig.get("host");
         assertEquals("0.0.0.0", host);
@@ -71,7 +71,7 @@ public class ApplicationConfigLoaderTestCase {
 
     @Test
     public void testLoadIntegerTypeConfig() {
-        Properties providerConfig = applicationConfiguration.getModuleConfiguration("receiver_zipkin")
+        Properties providerConfig = applicationConfiguration.getModuleConfiguration("receiver-zipkin")
                 .getProviderConfiguration("default");
         Integer port = (Integer) providerConfig.get("port");
         assertEquals(Integer.valueOf(9411), port);


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).
