### PR TITLE
Update frontend-maven-plugin to 1.12 and npm to 16.14.0 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Release Notes.
   * Upgrade  maven-resources-plugin to 3.2.0.
   * Upgrade  maven-source-plugin to 3.2.1.
 * Update codeStyle.xml to fix incompatibility on M1's IntelliJ IDEA 2021.3.2.
+* Update frontend-maven-plugin to 1.12 and npm to 16.14.0 for booster UI build.
 
 #### OAP Server
 

--- a/apm-webapp/pom.xml
+++ b/apm-webapp/pom.xml
@@ -35,7 +35,7 @@
         <gson.version>2.8.2</gson.version>
         <apache-httpclient.version>4.5.3</apache-httpclient.version>
         <spring-cloud-dependencies.version>2020.0.3</spring-cloud-dependencies.version>
-        <frontend-maven-plugin.version>1.11.0</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
         <logback-classic.version>1.2.3</logback-classic.version>
         <jackson-version>2.12.2</jackson-version>
         <yaml.version>1.28</yaml.version>
@@ -147,7 +147,7 @@
                 <version>${frontend-maven-plugin.version}</version>
                 <configuration>
                     <workingDirectory>${ui.path}</workingDirectory>
-                    <nodeVersion>v14.19.0</nodeVersion>
+                    <nodeVersion>v16.14.0</nodeVersion>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

`skywalking-ui/node` folder is generated due to frontend-maven-plugin downloads npm from compiling, and npm v16 has a different package-lock.json format, so every time in the main repo compiling, `skywalking-ui` submodule shows 4 files in changes.
Update frontend-maven-plugin to 1.12 and npm to 16.14.0 for booster UI build, and with merged https://github.com/apache/skywalking-booster-ui/pull/26, we don't have to face unexpected changes in local git.