### PR TITLE
Support ElasticSearch template mappings `properties parameters` and `_source` update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,6 +120,7 @@ Release Notes.
 * [Breaking Change] Break all existing 3rd-party storage extensions.
 * Remove hard requirement of BASE64 encoding for binary field.
 * Add complexity limitation for GraphQL query to avoid malicious query.
+* Support ElasticSearch template mappings `properties parameters` and `_source` update.
 
 #### UI
 

--- a/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/response/Mappings.java
+++ b/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/response/Mappings.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -56,5 +57,20 @@ public final class Mappings {
         @Getter
         @Setter
         private Set<String> excludes = new HashSet<>();
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            final Source source = (Source) o;
+            return Objects.equals(excludes, source.excludes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(excludes);
+        }
     }
 }

--- a/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/response/Mappings.java
+++ b/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/response/Mappings.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Objects;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -52,25 +51,11 @@ public final class Mappings {
     @Setter
     private Source source = new Source();
 
+    @EqualsAndHashCode
     public static class Source {
         @JsonProperty("excludes")
         @Getter
         @Setter
         private Set<String> excludes = new HashSet<>();
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o)
-                return true;
-            if (o == null || getClass() != o.getClass())
-                return false;
-            final Source source = (Source) o;
-            return Objects.equals(excludes, source.excludes);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(excludes);
-        }
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexStructures.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexStructures.java
@@ -116,26 +116,12 @@ public class IndexStructures {
             if (this.properties.size() < fields.properties.size()) {
                 return false;
             }
-            boolean isContains = false;
-            isContains = fields.properties.entrySet().stream()
-                                    .allMatch(item -> {
-                                        Object hisItem = this.properties.get(item.getKey());
-                                        if (hisItem != null) {
-                                            return hisItem.toString().equals(item.getValue().toString());
-                                        } else {
-                                            return false;
-                                        }
-                                    });
+            boolean isContains = fields.properties.entrySet().stream()
+                    .allMatch(item -> Objects.equals(properties.get(item.getKey()), item.getValue()));
             if (!isContains) {
                 return false;
             }
-
-            if (fields.source != null && this.source != null) {
-                isContains = this.source.getExcludes().toString().equals(fields.source.getExcludes().toString());
-            } else {
-                return fields.source == null && this.source == null;
-            }
-            return isContains;
+            return Objects.equals(this.source, fields.source);
         }
 
         /**

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexStructures.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexStructures.java
@@ -133,7 +133,7 @@ public class IndexStructures {
             if (fields.source != null && this.source != null) {
                 isContains = this.source.getExcludes().toString().equals(fields.source.getExcludes().toString());
             } else {
-                return false;
+                return fields.source == null && this.source == null;
             }
             return isContains;
         }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexStructuresTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexStructuresTest.java
@@ -21,7 +21,6 @@ package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Set;
 import org.apache.skywalking.library.elasticsearch.response.Mappings;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
 import org.junit.Assert;
@@ -61,8 +60,8 @@ public class IndexStructuresTest {
                             .properties(properties)
                             .source(source)
                             .build());
-        Assert.assertEquals(structuresSource.getMapping("test").getProperties(), properties);
-        Assert.assertEquals(structuresSource.getMapping("test").getSource().getExcludes(), source.getExcludes());
+        Assert.assertEquals(properties, structuresSource.getMapping("test").getProperties());
+        Assert.assertEquals(source.getExcludes(), structuresSource.getMapping("test").getSource().getExcludes());
     }
 
     @Test
@@ -103,8 +102,8 @@ public class IndexStructuresTest {
                             .properties(properties)
                             .source(source)
                             .build());
-        Assert.assertEquals(structuresSource.getMapping("test").getProperties(), properties);
-        Assert.assertEquals(structuresSource.getMapping("test").getSource().getExcludes(), source.getExcludes());
+        Assert.assertEquals(properties, structuresSource.getMapping("test").getProperties());
+        Assert.assertEquals(source.getExcludes(), structuresSource.getMapping("test").getSource().getExcludes());
 
         Mappings.Source source2 = new Mappings.Source();
         source.getExcludes().addAll(Arrays.asList("b", "c", "d", "e"));
@@ -114,9 +113,8 @@ public class IndexStructuresTest {
                             .properties(properties2)
                             .source(source2)
                             .build());
-        Set<String> excludes = new HashSet<>(Arrays.asList("a", "b", "c", "d", "e"));
-        Assert.assertEquals(structuresSource.getMapping("test").getProperties(), res);
-        Assert.assertEquals(structuresSource.getMapping("test").getSource().getExcludes(), excludes);
+        Assert.assertEquals(res, structuresSource.getMapping("test").getProperties());
+        Assert.assertEquals(new HashSet<>(), structuresSource.getMapping("test").getSource().getExcludes());
     }
 
     @Test

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MockEsInstallTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MockEsInstallTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.skywalking.library.elasticsearch.response.Mappings;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
+
+@RunWith(Parameterized.class)
+public class MockEsInstallTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+    @Parameterized.Parameter
+    public String name;
+
+    @Parameterized.Parameter(1)
+    public Mappings hisMappings;
+
+    @Parameterized.Parameter(2)
+    public Mappings newMappings;
+
+    @Parameterized.Parameter(3)
+    public Set<String> excludes;
+
+    @Parameterized.Parameter(4)
+    public Set<String> newExcludes;
+
+    @Parameterized.Parameter(5)
+    public String combineResult;
+
+    @Parameterized.Parameter(6)
+    public String diffResult;
+
+    @Parameterized.Parameter(7)
+    public boolean contains;
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {
+                "contains_properties_true",
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("a", ImmutableMap.of("type", "keyword"),
+                                            "b", ImmutableMap.of("type", "keyword")
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("b", ImmutableMap.of("type", "keyword"))))
+                        .source(new Mappings.Source())
+                    .build(),
+                null,
+                null,
+                "{\"properties\":{\"a\":{\"type\":\"keyword\"},\"b\":{\"type\":\"keyword\"}},\"_source\":{\"excludes\":[]}}",
+                "{\"properties\":{},\"_source\":null}",
+                true
+            },
+            {
+                "contains_source_true",
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("a", ImmutableMap.of("type", "keyword"),
+                                            "b", ImmutableMap.of("type", "keyword")
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("b", ImmutableMap.of("type", "keyword"))))
+                        .source(new Mappings.Source())
+                    .build(),
+                new HashSet<>(ImmutableSet.of("b")),
+                new HashSet<>(ImmutableSet.of("b")),
+                "{\"properties\":{\"a\":{\"type\":\"keyword\"},\"b\":{\"type\":\"keyword\"}},\"_source\":{\"excludes\":[\"b\"]}}",
+                "{\"properties\":{},\"_source\":null}",
+                true
+            },
+            {
+                "contains_source_false",
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("a", ImmutableMap.of("type", "keyword"),
+                                            "b", ImmutableMap.of("type", "keyword")
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("b", ImmutableMap.of("type", "keyword"))))
+                        .source(new Mappings.Source())
+                    .build(),
+                new HashSet<>(ImmutableSet.of("a", "b")),
+                new HashSet<>(ImmutableSet.of("b")),
+                "{\"properties\":{\"a\":{\"type\":\"keyword\"},\"b\":{\"type\":\"keyword\"}},\"_source\":{\"excludes\":[\"b\"]}}",
+                "{\"properties\":{},\"_source\":null}",
+                false
+            },
+            {
+                "contains_source_false",
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("a", ImmutableMap.of("type", "keyword"),
+                                            "b", ImmutableMap.of("type", "keyword")
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("b", ImmutableMap.of("type", "keyword"))))
+                        .source(new Mappings.Source())
+                    .build(),
+                new HashSet<>(ImmutableSet.of("a", "b")),
+                null,
+                "{\"properties\":{\"a\":{\"type\":\"keyword\"},\"b\":{\"type\":\"keyword\"}},\"_source\":{\"excludes\":[]}}",
+                "{\"properties\":{},\"_source\":null}",
+                false
+            },
+            {
+                "combineAndUpdate_properties",
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("a", ImmutableMap.of("type", "keyword"),
+                                            "b", ImmutableMap.of("type", "keyword")
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("b", ImmutableMap.of("type", "keyword", "index", false),
+                                            "c", ImmutableMap.of("type", "keyword")
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                null,
+                null,
+                "{\"properties\":{\"a\":{\"type\":\"keyword\"},\"b\":{\"type\":\"keyword\",\"index\":false},\"c\":{\"type\":\"keyword\"}},\"" +
+                    "_source\":{\"excludes\":[]}}",
+                "{\"properties\":{\"c\":{\"type\":\"keyword\"}},\"_source\":null}",
+                false
+            },
+            {
+                "combineAndUpdate_properties",
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("a", ImmutableMap.of("type", "keyword"),
+                                            "b", ImmutableMap.of("type", "keyword", "index", false)
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("b", ImmutableMap.of("type", "keyword"),
+                                            "c", ImmutableMap.of("type", "keyword", "index", false)
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                null,
+                null,
+                "{\"properties\":{\"a\":{\"type\":\"keyword\"},\"b\":{\"type\":\"keyword\"},\"c\":{\"type\":\"keyword\",\"index\":false}},\"" +
+                    "_source\":{\"excludes\":[]}}",
+                "{\"properties\":{\"c\":{\"type\":\"keyword\",\"index\":false}},\"_source\":null}",
+                false
+            },
+            {
+                "update_source",
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("a", ImmutableMap.of("type", "keyword"),
+                                            "b", ImmutableMap.of("type", "keyword", "index", false)
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                Mappings.builder()
+                        .type(ElasticSearchClient.TYPE)
+                        .properties(new HashMap<>(
+                            ImmutableMap.of("b", ImmutableMap.of("type", "keyword"),
+                                            "c", ImmutableMap.of("type", "keyword", "index", false)
+                            )))
+                        .source(new Mappings.Source())
+                    .build(),
+                new HashSet<>(ImmutableSet.of("a")),
+                new HashSet<>(ImmutableSet.of("b")),
+                "{\"properties\":{\"a\":{\"type\":\"keyword\"},\"b\":{\"type\":\"keyword\"},\"c\":{\"type\":\"keyword\",\"index\":false}},\"" +
+                    "_source\":{\"excludes\":[\"b\"]}}",
+                "{\"properties\":{\"c\":{\"type\":\"keyword\",\"index\":false}},\"_source\":null}",
+                false
+            }
+        });
+    }
+
+    @Before
+    public void init() {
+        if (this.excludes != null) {
+            this.hisMappings.getSource().setExcludes(this.excludes);
+        }
+        if (this.newExcludes != null) {
+            this.newMappings.getSource().setExcludes(this.newExcludes);
+        }
+    }
+
+    @Test
+    public void mockEsInstallTest() throws JsonProcessingException {
+        IndexStructures structures = new IndexStructures();
+        //clone it since the items will be changed after combine
+        Mappings hisMappingsClone = cloneMappings(this.hisMappings);
+        //put the current mappings
+        structures.putStructure(this.name, this.hisMappings);
+        //if current mappings already contains new mappings items
+        Assert.assertEquals(this.contains, structures.containsStructure(this.name, this.newMappings));
+
+        //put the new mappings and combine
+        structures.putStructure(this.name, this.newMappings);
+        Mappings mappings = structures.getMapping(this.name);
+        Assert.assertEquals(this.combineResult, mapper.writeValueAsString(mappings));
+
+        //diff the hisMapping and new, if has new item will update current index
+        structures.putStructure(this.name, this.newMappings);
+        Mappings diff = structures.diffStructure(this.name, hisMappingsClone);
+        Assert.assertEquals(this.diffResult, mapper.writeValueAsString(diff));
+    }
+
+    private Mappings cloneMappings(Mappings mappings) {
+        Mappings.Source source = new Mappings.Source();
+        source.setExcludes(new HashSet<>(mappings.getSource().getExcludes()));
+        return Mappings.builder()
+                       .type(mappings.getType())
+                       .properties(new HashMap<>(mappings.getProperties()))
+                       .source(source)
+                       .build();
+    }
+}


### PR DESCRIPTION
### Support ElasticSearch template mappings `properties parameters` and `_source` update
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [X] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/CHANGES.md).

Previous logic can't update the mappings `properties parameters` and `_source` only support adding a new property.
### Now
1. As the OAP core merges the index of metrics, properties would not be deleted still.
2. Would not update the current index to avoid conflict, a new index follows the new template to create.