### PR TITLE
Fix Zipkin receiver: Decode spans error, missing `Layer` for V9 and wrong time bucket for generate Service and Endpoint.

### DIFF
--- a/dist-material/release-docs/LICENSE
+++ b/dist-material/release-docs/LICENSE
@@ -287,7 +287,7 @@ The text of each license is the standard Apache 2.0 license.
     servo 0.10.1: https://github.com/Netflix/servo, Apache 2.0
     validation-api 1.1.0.Final: http://beanvalidation.org/licensing/, Apache 2.0
     HikariCP 3.1.0: https://github.com/brettwooldridge/HikariCP, Apache 2.0
-    zipkin 2.9.1: https://github.com/openzipkin/zipkin, Apache 2.0
+    zipkin 2.23.16: https://github.com/openzipkin/zipkin, Apache 2.0
     sharding-jdbc-core 2.0.3: https://github.com/sharding-sphere/sharding-sphere, Apache 2.0
     kubernetes-client 14.0.0: https://github.com/kubernetes-client/java, Apache 2.0
     proto files from istio/istio: https://github.com/istio/istio  Apache 2.0

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -1,10 +1,11 @@
 ## 9.1.0
 
 #### Project
-
+* Upgrade zipkin to 2.23.16.
 
 #### OAP Server
 * Add component definition(ID=127) for `Apache ShenYu (incubating)`.
+* Fix Zipkin receiver: Decode spans error, missing `Layer` for V9 and wrong time bucket for generate Service and Endpoint.
 
 #### UI
 * General service instance: move `Thread Pool` from JVM to Overview, fix `JVM GC Count` calculation.

--- a/oap-server-bom/pom.xml
+++ b/oap-server-bom/pom.xml
@@ -49,7 +49,7 @@
         <commons-io.version>2.7</commons-io.version>
         <kubernetes.version>14.0.0</kubernetes.version>
         <hikaricp.version>3.1.0</hikaricp.version>
-        <zipkin.version>2.9.1</zipkin.version>
+        <zipkin.version>2.23.16</zipkin.version>
         <jackson-core.version>2.13.2</jackson-core.version>
         <jackson-annotations.version>2.13.2</jackson-annotations.version>
         <jackson-databind.version>2.13.2.2</jackson-databind.version>

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/ZipkinSpanHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/ZipkinSpanHTTPHandler.java
@@ -109,7 +109,7 @@ public class ZipkinSpanHTTPHandler {
         final HistogramMetrics.Timer timer = histogram.createTimer();
         final HttpResponse response = HttpResponse.from(req.aggregate().thenApply(request -> {
             final HttpData httpData = UnzippingBytesRequestConverter.convertRequest(ctx, request);
-            final List<Span> spanList = decoder.decodeList(httpData.byteBuf().array());
+            final List<Span> spanList = decoder.decodeList(httpData.byteBuf().nioBuffer());
             final SpanForward forward = new SpanForward(namingControl, sourceReceiver, config);
             forward.send(spanList);
             return HttpResponse.of(HttpStatus.OK);

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/trace/SpanForward.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/trace/SpanForward.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.receiver.zipkin.trace;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.skywalking.oap.server.core.analysis.Layer;
 import org.apache.skywalking.oap.server.library.util.StringUtil;
 import org.apache.skywalking.oap.server.core.analysis.IDManager;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
@@ -62,7 +63,8 @@ public class SpanForward {
             zipkinSpan.setStartTime(startTime);
             long timeBucket = TimeBucket.getRecordTimeBucket(zipkinSpan.getStartTime());
             zipkinSpan.setTimeBucket(timeBucket);
-
+            long minuteTimeBucket = TimeBucket.getMinuteTimeBucket(zipkinSpan.getStartTime());
+            
             String spanName = span.name();
             if (!StringUtil.isEmpty(spanName)) {
                 final String endpointName = namingControl.formatEndpointName(serviceName, spanName);
@@ -73,7 +75,7 @@ public class SpanForward {
                 EndpointMeta endpointMeta = new EndpointMeta();
                 endpointMeta.setServiceName(serviceName);
                 endpointMeta.setEndpoint(endpointName);
-                endpointMeta.setTimeBucket(timeBucket);
+                endpointMeta.setTimeBucket(minuteTimeBucket);
                 receiver.receive(endpointMeta);
             }
             long latency = span.durationAsLong() / 1000;
@@ -94,7 +96,8 @@ public class SpanForward {
             // No instance name is required in the Zipkin model.
             ServiceMeta serviceMeta = new ServiceMeta();
             serviceMeta.setName(serviceName);
-            serviceMeta.setTimeBucket(timeBucket);
+            serviceMeta.setTimeBucket(minuteTimeBucket);
+            serviceMeta.setLayer(Layer.GENERAL);
             receiver.receive(serviceMeta);
         });
     }

--- a/tools/dependencies/known-oap-backend-dependencies.txt
+++ b/tools/dependencies/known-oap-backend-dependencies.txt
@@ -150,7 +150,7 @@ swagger-annotations-1.6.3.jar
 tsfile-0.12.5.jar
 vavr-0.10.3.jar
 vavr-match-0.10.3.jar
-zipkin-2.9.1.jar
+zipkin-2.23.16.jar
 zookeeper-3.5.7.jar
 zookeeper-jute-3.5.7.jar
 zstd-jni-1.4.3-1.jar


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).

Upgrade Zipkin to `2.23.16` for `SpanBytesDecoder` support `ByteBuffer`.