### PR TITLE
[Critical] Fix the priority mechanism of DataCarrier's MultipleChannelsConsumer failure.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -6,6 +6,9 @@
 
 #### OAP Server
 
+* [Critical] Fix the priority mechanism of DataCarrier's MultipleChannelsConsumer failure. This critical bug could stop
+  message consuming if the data are pushed into queue in small pieces but continuously.
+  (Notice, this could cause gRPC/HTTP thread pool blocking, and start rejecting telemetry data reporting.)
 * Add component definition(ID=127) for `Apache ShenYu (incubating)`.
 * Fix Zipkin receiver: Decode spans error, missing `Layer` for V9 and wrong time bucket for generate Service and
   Endpoint.
@@ -13,8 +16,8 @@
 * Support BanyanDB global index for entities. Log and Segment record entities declare this new feature.
 * Remove unnecessary analyzer settings in columns of templates. Many were added due to analyzer's default value.
 * Simplify the Kafka Fetch configuration in cluster mode.
-* [Breaking Change] Update the eBPF Profiling task to the service level,
-  please delete index/table: `ebpf_profiling_task`, `process_traffic`.
+* [Breaking Change] Update the eBPF Profiling task to the service level, please delete
+  index/table: `ebpf_profiling_task`, `process_traffic`.
 * Fix event can't split service ID into 2 parts.
 * Fix OAP Self-Observability metric `GC Time` calculation.
 * Set `SW_QUERY_MAX_QUERY_COMPLEXITY` default value to `1000`

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/buffer/Channels.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/buffer/Channels.java
@@ -86,7 +86,7 @@ public class Channels<T> {
     /**
      * @return the whole size of slots in the whole channels.
      */
-    public long size() {
+    public long capacity() {
         return size;
     }
 

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/buffer/Channels.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/buffer/Channels.java
@@ -77,14 +77,14 @@ public class Channels<T> {
     }
 
     /**
-     * get channelSize
+     * @return the number of channels
      */
     public int getChannelSize() {
         return this.bufferChannels.length;
     }
 
     /**
-     * @return the whole size of channels.
+     * @return the whole size of slots in the whole channels.
      */
     public long size() {
         return size;

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/buffer/Channels.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/buffer/Channels.java
@@ -83,6 +83,9 @@ public class Channels<T> {
         return this.bufferChannels.length;
     }
 
+    /**
+     * @return the whole size of channels.
+     */
     public long size() {
         return size;
     }

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
@@ -78,7 +78,7 @@ public class MultipleChannelsConsumer extends Thread {
         newList.addAll(consumeTargets);
         newList.add(group);
         consumeTargets = newList;
-        size += channels.size();
+        size += channels.capacity();
     }
 
     public long size() {
@@ -100,7 +100,7 @@ public class MultipleChannelsConsumer extends Thread {
          *
          * if 'size of last fetched data' > 0
          *
-         * priority = 'size of last fetched data' * 100 / {@link Channels#size()} * {@link Channels#getChannelSize()}
+         * priority = 'size of last fetched data' * 100 / {@link Channels#capacity()} 
          *
          * else
          *
@@ -149,7 +149,7 @@ public class MultipleChannelsConsumer extends Thread {
                 }
 
                 if (!consumeList.isEmpty()) {
-                    priority = (priority + (int) (consumeList.size() * 100 / channels.size())) / 2;
+                    priority = (priority + (int) (consumeList.size() * 100 / channels.capacity())) / 2;
                     try {
                         consumer.consume(consumeList);
                     } catch (Throwable t) {

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
@@ -135,7 +135,9 @@ public class MultipleChannelsConsumer extends Thread {
          */
         private boolean consume(List consumeList) {
             try {
-                log.debug("consumer {}, priority {}", consumer.getClass().getName(), priority);
+                if (log.isTraceEnabled()) {
+                    log.trace("consumer {}, priority {}", consumer.getClass().getName(), priority);
+                }
                 if (priority < 50) {
                     priority += 10;
                     return false;
@@ -172,7 +174,9 @@ public class MultipleChannelsConsumer extends Thread {
                 consumer.nothingToConsume();
                 return false;
             } finally {
-                log.debug("consumer {}, new priority {}", consumer.getClass().getName(), priority);
+                if (log.isTraceEnabled()) {
+                    log.trace("consumer {}, new priority {}", consumer.getClass().getName(), priority);
+                }
                 consumer.onExit();
             }
         }

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.oap.server.library.datacarrier.consumer;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.library.datacarrier.buffer.Channels;
 import org.apache.skywalking.oap.server.library.datacarrier.buffer.QueueBuffer;
 
@@ -48,8 +49,8 @@ public class MultipleChannelsConsumer extends Thread {
         while (running) {
             boolean hasData = false;
             for (Group target : consumeTargets) {
-                boolean consume = target.consume(consumeList);
-                hasData = hasData || consume;
+                boolean consumed = target.consume(consumeList);
+                hasData = hasData || consumed;
             }
 
             if (!hasData) {
@@ -88,6 +89,7 @@ public class MultipleChannelsConsumer extends Thread {
         running = false;
     }
 
+    @Slf4j
     private static class Group {
         private Channels channels;
         private IConsumer consumer;
@@ -133,6 +135,7 @@ public class MultipleChannelsConsumer extends Thread {
          */
         private boolean consume(List consumeList) {
             try {
+                log.debug("consumer {}, priority {}", consumer.getClass().getName(), priority);
                 if (priority < 50) {
                     priority += 10;
                     return false;
@@ -169,6 +172,7 @@ public class MultipleChannelsConsumer extends Thread {
                 consumer.nothingToConsume();
                 return false;
             } finally {
+                log.debug("consumer {}, new priority {}", consumer.getClass().getName(), priority);
                 consumer.onExit();
             }
         }

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
@@ -147,7 +147,7 @@ public class MultipleChannelsConsumer extends Thread {
                 }
 
                 if (!consumeList.isEmpty()) {
-                    priority = (priority + (int) (consumeList.size() * 100 / channels.getChannelSize() * channels.size())) / 2;
+                    priority = (priority + (int) (consumeList.size() * 100 / channels.size())) / 2;
                     try {
                         consumer.consume(consumeList);
                     } catch (Throwable t) {


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).

@kezhenxu94 Reported this bug to us, and noticed https://github.com/apache/skywalking/pull/8664 applied into the mainstream, the OAP server could report gRPC thread pool is full, rejecting the task, even the traffic is very low, and ElasticSearch is healthy, once #8664 is reverted, the error is gone in the same test scenario.

I did some research about my last change, and found out this bug only could occur when traffic is low.
I was using `channels.getChannelSize() * channels.size()`, and I thought it is the size, and actually `channels.size()` is the size already. So with this wrong usage, the priority is always very low, and hard(maybe never?) to reach over 50. Then the queue is full with a very low priority, not consuming anymore.

The fix is easy, make the priority back to expected value.