### PR TITLE
Update the way to count the process traffic 

### DIFF
--- a/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/MetadataQuery.java
+++ b/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/MetadataQuery.java
@@ -175,7 +175,7 @@ public class MetadataQuery implements IMetadataQueryDAO {
     @Override
     public long getProcessesCount(String serviceId, String instanceId, String agentId, final ProfilingSupportStatus profilingSupportStatus,
                                   final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException {
-        final SelectQueryImpl query = select().count(ProcessTraffic.PROPERTIES).from(client.getDatabase(), ProcessTraffic.INDEX_NAME);
+        final SelectQueryImpl query = select().count(ID_COLUMN).from(client.getDatabase(), ProcessTraffic.INDEX_NAME);
         appendProcessWhereQuery(query, serviceId, instanceId, agentId, profilingSupportStatus,
                 lastPingStartTimeBucket, lastPingEndTimeBucket);
 

--- a/oap-server/server-storage-plugin/storage-iotdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/iotdb/query/IoTDBMetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-iotdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/iotdb/query/IoTDBMetadataQueryDAO.java
@@ -180,7 +180,7 @@ public class IoTDBMetadataQueryDAO implements IMetadataQueryDAO {
                                   final ProfilingSupportStatus profilingSupportStatus, final long lastPingStartTimeBucket,
                                   final long lastPingEndTimeBucket) throws IOException {
         StringBuilder query = new StringBuilder();
-        query.append("select count(" + ProcessTraffic.PROPERTIES + ") from ");
+        query.append("select count(*) from ");
         appendProcessFromQuery(query, serviceId, instanceId, agentId, profilingSupportStatus,
                 lastPingStartTimeBucket, lastPingEndTimeBucket);
 


### PR DESCRIPTION
Update the way to count the process traffic to avoid counting by the `properties` field. This feature is a new addition to this milestone, so is no need to modify the changelog.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).
