### PR TITLE
Fix the pod match error when the service has multiple selector in kubernates environment.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -44,6 +44,7 @@
 * Clean up scroll contexts after used.
 * Support autocomplete tags in logs query.
 * Enhance Deprecated MetricQuery(v1) getValues querying to asynchronous concurrency query
+* Fix the pod match error when the service has multiple selector in kubernetes environment.
 
 #### UI
 

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/k8s/K8sInfoRegistry.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/k8s/K8sInfoRegistry.java
@@ -223,10 +223,10 @@ public class K8sInfoRegistry {
         Objects.requireNonNull(o);
         Objects.requireNonNull(c);
         for (final Object value : o) {
-            if (c.contains(value)) {
-                return true;
+            if (!c.contains(value)) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
When OAP received the metrics from OTEL and bound it to the K8S_SERVICE entity, I found that when the Service has multiple selectors, the matching rules between service and pod are incorrect.

The current match rule is that as long as any selector in the service matches the label in the pod, it is considered a match and should be changed to match all.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).
