### PR TITLE
Fix saving Process Traffic error when cluster mode

### DIFF
--- a/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/EBPFProcessServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/EBPFProcessServiceHandler.java
@@ -35,6 +35,7 @@ import org.apache.skywalking.apm.network.ebpf.profiling.process.v3.EBPFProcessPr
 import org.apache.skywalking.apm.network.ebpf.profiling.process.v3.EBPFProcessReportList;
 import org.apache.skywalking.apm.network.ebpf.profiling.process.v3.EBPFProcessServiceGrpc;
 import org.apache.skywalking.apm.network.ebpf.profiling.process.v3.EBPFReportProcessDownstream;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.DownSampling;
 import org.apache.skywalking.oap.server.core.analysis.IDManager;
@@ -118,6 +119,7 @@ public class EBPFProcessServiceHandler extends EBPFProcessServiceGrpc.EBPFProces
             processUpdate.setName(entity.getProcessName());
             processUpdate.setLabels(entity.getLabelsList());
             processUpdate.setTimeBucket(timeBucket);
+            processUpdate.setAgentId(Const.EMPTY_STRING);
             sourceReceiver.receive(processUpdate);
 
             // instance


### PR DESCRIPTION
When receiving the process keepalive protocol in cluster mode, It will throw an exception when balancing the process traffic data. Because the gRPC could not be added a null value(`ProcessTraffic#agentID`) into the data. So I update the agent id to the `Const#EMPTY_STRING` to fix it. 

The Process traffic is new in the current milestone, so I don't need to update the changelog.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).
