### PR TITLE
Sync ui to remove the `duration` when query eBPF Profiling scheduler

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -72,6 +72,7 @@
 * Fix jump to endpoint-relation dashboard template.
 * Fix set graph options.
 * Remove the `Layer` filed from the Instance and Process.
+* Fix date time picker display when set hour to `0`.
 
 #### Documentation
 


### PR DESCRIPTION
It's a new feature in 9.1.0, so don't need to update the changelog. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).
