### PR TITLE
Remove unnecessary time range check in eBPF profiling analysis

### DIFF
--- a/docs/en/setup/backend/configuration-vocabulary.md
+++ b/docs/en/setup/backend/configuration-vocabulary.md
@@ -45,7 +45,6 @@ core|default|role|Option values: `Mixed/Receiver/Aggregator`. **Receiver** mode 
 | - | - | maxSizeOfAnalyzeProfileSnapshot| The maximum number of snapshots analyzed by the OAP. | - | 12000                                                                   |
 | - | - | prepareThreads| The number of threads used to prepare metrics data to the storage. | SW_CORE_PREPARE_THREADS | 2                                                                       |
 | - | - | enableEndpointNameGroupingByOpenapi | Automatically groups endpoints by the given OpenAPI definitions. | SW_CORE_ENABLE_ENDPOINT_NAME_GROUPING_BY_OPAENAPI | true                                                                    |
-| - | - | maxDurationOfAnalyzeEBPFProfiling| The maximum duration(in minute) of analyze the eBPF profiling data. | - | 10                                                                      |
 | - | - | maxDurationOfQueryEBPFProfilingData| The maximum duration(in second) of query the eBPF profiling data from database. | - | 30                                                                      |
 | - | - | maxThreadCountOfQueryEBPFProfilingData| The maximum thread count of query the eBPF profiling data from database. | - | System CPU core size                                                    |
 |cluster|standalone| - | Standalone is not suitable for running on a single node running. No configuration available. | - | -                                                                       |

--- a/oap-server/microbench/src/main/java/org/apache/skywalking/oap/server/microbench/core/profiling/ebpf/EBPFProfilingAnalyzerBenchmark.java
+++ b/oap-server/microbench/src/main/java/org/apache/skywalking/oap/server/microbench/core/profiling/ebpf/EBPFProfilingAnalyzerBenchmark.java
@@ -134,7 +134,7 @@ public class EBPFProfilingAnalyzerBenchmark extends AbstractMicrobenchmark {
         }
 
         public void analyze() {
-            new EBPFProfilingAnalyzer(null, 100, 100, 5).generateTrees(new EBPFProfilingAnalyzation(), stackStream.parallelStream());
+            new EBPFProfilingAnalyzer(null, 100, 5).generateTrees(new EBPFProfilingAnalyzation(), stackStream.parallelStream());
         }
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleConfig.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleConfig.java
@@ -103,10 +103,6 @@ public class CoreModuleConfig extends ModuleConfig {
      */
     private int maxSizeOfAnalyzeProfileSnapshot = 12000;
     /**
-     * Analyze eBPF profiling data max duration(minute)
-     */
-    private int maxDurationOfAnalyzeEBPFProfiling = 10;
-    /**
      * Query the eBPF Profiling data max duration(second) from database.
      */
     private int maxDurationOfQueryEBPFProfilingData = 30;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/EBPFProfilingQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/EBPFProfilingQueryService.java
@@ -123,8 +123,8 @@ public class EBPFProfilingQueryService implements Service {
 
     private EBPFProfilingAnalyzer getProfilingAnalyzer() {
         if (profilingAnalyzer == null) {
-            this.profilingAnalyzer = new EBPFProfilingAnalyzer(moduleManager, config.getMaxDurationOfAnalyzeEBPFProfiling(),
-                    config.getMaxDurationOfQueryEBPFProfilingData(), config.getMaxThreadCountOfQueryEBPFProfilingData());
+            this.profilingAnalyzer = new EBPFProfilingAnalyzer(moduleManager, config.getMaxDurationOfQueryEBPFProfilingData(),
+                    config.getMaxThreadCountOfQueryEBPFProfilingData());
         }
         return profilingAnalyzer;
     }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/profiling/ebpf/analyze/EBPFProfilingAnalyzeContext.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/profiling/ebpf/analyze/EBPFProfilingAnalyzeContext.java
@@ -109,7 +109,7 @@ public class EBPFProfilingAnalyzeContext {
 
     private class Analyzer extends EBPFProfilingAnalyzer implements IEBPFProfilingDataDAO {
         public Analyzer() {
-            super(null, 100, 100, 5);
+            super(null, 100, 5);
         }
 
         @Override


### PR DESCRIPTION
Currently, the eBPF profiling analysis has the max schedule time range check, but it's not necessary. So I remove it, I think we limit the query data timeout(the 30s) is enough. So delete it. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).
