### PR TITLE
Fix: set tag autocomplete query time range unit to the day

### DIFF
--- a/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/TagAutoCompleteQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-influxdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/influxdb/query/TagAutoCompleteQueryDAO.java
@@ -104,13 +104,13 @@ public class TagAutoCompleteQueryDAO implements ITagAutoCompleteQueryDAO {
                                                 final WhereQueryImpl<SelectQueryImpl> query) {
         query.and(eq(TagAutocompleteData.TAG_TYPE, tagType.name()));
 
-        long startMinTB = startSecondTB / 100;
-        long endMinTB = endSecondTB / 100;
-        if (startMinTB > 0) {
-            query.and(gte(TagAutocompleteData.TIME_BUCKET, startMinTB));
+        long startTB = startSecondTB / 1000000 * 10000;
+        long endTB = endSecondTB / 1000000 * 10000 + 9999;
+        if (startTB > 0) {
+            query.and(gte(TagAutocompleteData.TIME_BUCKET, startTB));
         }
-        if (endMinTB > 0) {
-            query.and(lte(TagAutocompleteData.TIME_BUCKET, endMinTB));
+        if (endTB > 0) {
+            query.and(lte(TagAutocompleteData.TIME_BUCKET, endTB));
         }
     }
 }

--- a/oap-server/server-storage-plugin/storage-iotdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/iotdb/query/IoTDBTagAutoCompleteQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-iotdb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/iotdb/query/IoTDBTagAutoCompleteQueryDAO.java
@@ -54,7 +54,7 @@ public class IoTDBTagAutoCompleteQueryDAO implements ITagAutoCompleteQueryDAO {
         Map<String, String> indexAndValueMap = new HashMap<>();
         indexAndValueMap.put(IoTDBIndexes.AUTOCOMPLETE_TAG_TYPE, tagType.name());
         IoTDBUtils.addQueryIndexValue(TagAutocompleteData.INDEX_NAME, query, indexAndValueMap);
-        appendTagAutocompleteCondition(tagType, startSecondTB, endSecondTB, query);
+        appendTagAutocompleteCondition(startSecondTB, endSecondTB, query);
         query.append(IoTDBClient.ALIGN_BY_DEVICE);
 
         SessionPool sessionPool = client.getSessionPool();
@@ -93,7 +93,7 @@ public class IoTDBTagAutoCompleteQueryDAO implements ITagAutoCompleteQueryDAO {
         indexAndValueMap.put(IoTDBIndexes.AUTOCOMPLETE_TAG_KEY, tagKey);
         indexAndValueMap.put(IoTDBIndexes.AUTOCOMPLETE_TAG_TYPE, tagType.name());
         IoTDBUtils.addQueryIndexValue(TagAutocompleteData.INDEX_NAME, query, indexAndValueMap);
-        appendTagAutocompleteCondition(tagType, startSecondTB, endSecondTB, query);
+        appendTagAutocompleteCondition(startSecondTB, endSecondTB, query);
         query.append(" limit ").append(limit).append(IoTDBClient.ALIGN_BY_DEVICE);
         List<? super StorageData> storageDataList = client.filterQuery(TagAutocompleteData.INDEX_NAME,
                                                                        query.toString(),
@@ -109,22 +109,21 @@ public class IoTDBTagAutoCompleteQueryDAO implements ITagAutoCompleteQueryDAO {
         return tagValues;
     }
 
-    private void appendTagAutocompleteCondition(final TagType tagType,
-                                                final long startSecondTB,
+    private void appendTagAutocompleteCondition(final long startSecondTB,
                                                 final long endSecondTB,
                                                 final StringBuilder query) {
-        long startMinTB = startSecondTB / 100;
-        long endMinTB = endSecondTB / 100;
+        long startTB = startSecondTB / 1000000 * 10000;
+        long endTB = endSecondTB / 1000000 * 10000 + 9999;
 
         StringBuilder where = new StringBuilder();
-        if (startMinTB > 0) {
-            where.append(IoTDBClient.TIME).append(" >= ").append(TimeBucket.getTimestamp(startMinTB));
+        if (startTB > 0) {
+            where.append(IoTDBClient.TIME).append(" >= ").append(TimeBucket.getTimestamp(startTB));
         }
-        if (endMinTB > 0) {
+        if (endTB > 0) {
             if (where.length() > 0) {
                 where.append(" and ");
             }
-            where.append(IoTDBClient.TIME).append(" <= ").append(TimeBucket.getTimestamp(endMinTB));
+            where.append(IoTDBClient.TIME).append(" <= ").append(TimeBucket.getTimestamp(endTB));
         }
         if (where.length() > 0) {
             query.append(" where ").append(where);

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TagAutoCompleteQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TagAutoCompleteQueryDAO.java
@@ -94,17 +94,17 @@ public class H2TagAutoCompleteQueryDAO implements ITagAutoCompleteQueryDAO {
         sql.append(TagAutocompleteData.TAG_TYPE).append(" = ?");
         condition.add(tagType.name());
 
-        long startMinTB = startSecondTB / 100;
-        long endMinTB = endSecondTB / 100;
-        if (startMinTB > 0) {
+        long startTB = startSecondTB / 1000000 * 10000;
+        long endTB = endSecondTB / 1000000 * 10000 + 9999;
+        if (startTB > 0) {
             sql.append(" and ");
             sql.append(TagAutocompleteData.TIME_BUCKET).append(">=?");
-            condition.add(startMinTB);
+            condition.add(startTB);
         }
-        if (endMinTB > 0) {
+        if (endTB > 0) {
             sql.append(" and ");
             sql.append(TagAutocompleteData.TIME_BUCKET).append("<=?");
-            condition.add(endMinTB);
+            condition.add(endTB);
         }
     }
 }


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).

Since the same tags are stored by the day.