### PR TITLE
Fix the problem that MQ has the wrong layer type(#9080)

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -57,6 +57,7 @@
 * Remove `Layer` concept form `Process`.
 * Update to list all eBPF profiling schedulers without duration.
 * Storage(ElasticSearch): add search options to tolerate inexisting indices.
+* Fix the problem that `MQ` has the wrong `Layer` type
 
 #### UI
 

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/RPCAnalysisListener.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/RPCAnalysisListener.java
@@ -393,7 +393,7 @@ public class RPCAnalysisListener extends CommonAnalysisListener implements Entry
                 }
                 return Layer.GENERAL;
             case MQ:
-                return Layer.MQ;
+                return Layer.VIRTUAL_MQ;
             case Cache:
                 return Layer.CACHE;
             case UNRECOGNIZED:


### PR DESCRIPTION
### Fix <bug description or the bug issue number or bug issue link>
- [x] Add a unit test to verify that the fix works.
Before:
<img width="554" alt="image" src="https://user-images.githubusercontent.com/29882506/168785834-68c5d217-9040-4ad4-915d-0e7c8f457815.png">

After:
<img width="554" alt="image" src="https://user-images.githubusercontent.com/29882506/168802562-f2cf947d-44dc-4c49-aa01-499626771b34.png">

- [x] Explain briefly why the bug exists and how to fix it.
>  when OAP analysises service relations from segments, the source layer type of the service agent_test_3 is set `LAYER.VIRTUAL_MQ`, however, the target layer type of the service agent_test_2 is set `LAYER.MQ`. it result in the same kafka service id of the two spans are different, then, it causes the wrong topology.
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #9080.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).
