### PR TITLE
sync ui: remove the total field from queries

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -87,6 +87,8 @@
 * Fix the page doesn't need to be re-rendered when the url changes.
 * Remove unexpected data for exporting dashboards.
 * Fix duration time.
+* Remove the total field from query conditions.
+* Fix minDuration and maxDuration for the trace filter.
 
 #### Documentation
 


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).

* Remove the total field from query conditions.
* Fix `minDuration` and `maxDuration` for the trace filter.

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
