### PR TITLE
Add TiDB, OpenSearch, Postgres storage optional to Trace and eBPF Profiling E2E Testing

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -408,6 +408,16 @@ jobs:
             config: test/e2e-v2/cases/profiling/trace/es/e2e.yaml
           - name: Trace Profiling MySQL
             config: test/e2e-v2/cases/profiling/trace/mysql/e2e.yaml
+          - name: Trace Profiling Postgres
+            config: test/e2e-v2/cases/profiling/trace/postgres/e2e.yaml
+          - name: Trace Profiling TiDB
+            config: test/e2e-v2/cases/profiling/trace/tidb/e2e.yaml
+          - name: Trace Profiling OpenSearch 1.1.0
+            config: test/e2e-v2/cases/profiling/trace/opensearch/e2e.yaml
+            env: OPENSEARCH_VERSION=1.1.0
+          - name: Trace Profiling OpenSearch 1.2.0
+            config: test/e2e-v2/cases/profiling/trace/opensearch/e2e.yaml
+            env: OPENSEARCH_VERSION=1.2.0
 
           - name: eBPF Profiling BanyanDB
             config: test/e2e-v2/cases/profiling/ebpf/banyandb/e2e.yaml
@@ -417,6 +427,16 @@ jobs:
             config: test/e2e-v2/cases/profiling/ebpf/es/e2e.yaml
           - name: eBPF Profiling MySQL
             config: test/e2e-v2/cases/profiling/ebpf/mysql/e2e.yaml
+          - name: eBPF Profiling Postgres
+            config: test/e2e-v2/cases/profiling/ebpf/postgres/e2e.yaml
+          - name: eBPF Profiling TiDB
+            config: test/e2e-v2/cases/profiling/ebpf/tidb/e2e.yaml
+          - name: eBPF Profiling OpenSearch 1.1.0
+            config: test/e2e-v2/cases/profiling/ebpf/opensearch/e2e.yaml
+            env: OPENSEARCH_VERSION=1.1.0
+          - name: eBPF Profiling OpenSearch 1.2.0
+            config: test/e2e-v2/cases/profiling/ebpf/opensearch/e2e.yaml
+            env: OPENSEARCH_VERSION=1.2.0
 
           - name: Kafka Basic
             config: test/e2e-v2/cases/kafka/simple-so11y/e2e.yaml

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -65,6 +65,7 @@
 * [Breaking Change] Remove `total` field in Trace, Log, Event, Browser log, and alarm list query.
 * Support `OFF_CPU` eBPF Profiling.
 * Fix SumAggregationBuilder#build should use the SumAggregation rather than MaxAggregation.
+* Add TiDB, OpenSearch, Postgres storage optional to Trace and eBPF Profiling E2E testing.
 
 #### UI
 

--- a/test/e2e-v2/cases/profiling/ebpf/opensearch/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/opensearch/docker-compose.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2.1'
+
+services:
+  opensearch:
+    image: opensearchproject/opensearch:${OPENSEARCH_VERSION}
+    expose:
+      - 9200
+    networks:
+      - e2e
+    environment:
+      - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - plugins.security.ssl.http.enabled=false
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9200" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  oap:
+    extends:
+      file: ../docker-compose.yml
+      service: oap
+    networks:
+      - e2e
+    environment:
+      SW_STORAGE: elasticsearch
+      SW_STORAGE_ES_CLUSTER_NODES: opensearch:9200
+      SW_ES_USER: admin
+      SW_ES_PASSWORD: admin
+    depends_on:
+      opensearch:
+        condition: service_healthy
+    ports:
+    - 12800
+
+  sqrt:
+    extends:
+      file: ../docker-compose.yml
+      service: sqrt
+    networks:
+      - e2e
+
+  rover:
+    extends:
+      file: ../docker-compose.yml
+      service: rover
+    networks:
+      - e2e
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e-v2/cases/profiling/ebpf/opensearch/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/opensearch/e2e.yaml
@@ -13,22 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
-- id: {{ notEmpty .id }}
-  serviceid: {{ b64enc "e2e-service-provider" }}.1
-  servicename: ""
-  endpointname: POST:/info
-  starttime: {{ gt .starttime 0 }}
-  duration: 1
-  mindurationthreshold: 0
-  dumpperiod: 10
-  maxsamplingcount: 9
-  logs:
-    {{- contains .logs }}
-    - id: {{ notEmpty .id }}
-      instanceid: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}
-      operationtype: {{ notEmpty .operationtype }}
-      instancename: ""
-      operationtime: {{ gt .operationtime 0 }}
-  {{- end }}
-{{- end }}
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../profiling-cases.yaml

--- a/test/e2e-v2/cases/profiling/ebpf/postgres/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/postgres/docker-compose.yml
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2.1'
+
+services:
+  postgres:
+    image: postgres:13
+    networks:
+      - e2e
+    expose:
+      - 5432
+    environment:
+      - POSTGRES_PASSWORD=123456
+      - POSTGRES_DB=skywalking
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/5432" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  oap:
+    extends:
+      file: ../docker-compose.yml
+      service: oap
+    networks:
+      - e2e
+    environment:
+      SW_STORAGE: postgresql
+      SW_JDBC_URL: "jdbc:postgresql://postgres:5432/skywalking"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+    - 12800
+
+  sqrt:
+    extends:
+      file: ../docker-compose.yml
+      service: sqrt
+    networks:
+      - e2e
+
+  rover:
+    extends:
+      file: ../docker-compose.yml
+      service: rover
+    networks:
+      - e2e
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e-v2/cases/profiling/ebpf/postgres/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/postgres/e2e.yaml
@@ -13,26 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-spans:
-{{- contains .spans }}
-- spanid: 0
-  parentspanid: -1
-  servicecode: e2e-service-provider
-  serviceinstancename: ""
-  starttime: {{ gt .starttime 0 }}
-  endtime: {{ gt .endtime 0 }}
-  endpointname: POST:/info
-  type: Entry
-  peer: ""
-  component: Tomcat
-  iserror: false
-  layer: Http
-  tags:
-    {{- contains .tags }}
-    - key: url
-      value: {{ notEmpty .value }}
-    - key: http.method
-      value: POST
-    {{- end }}
-  logs: []
-{{- end }}
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../profiling-cases.yaml

--- a/test/e2e-v2/cases/profiling/ebpf/tidb/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/tidb/docker-compose.yml
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2.1'
+
+services:
+  tidb:
+    image: pingcap/tidb:v4.0.12
+    expose:
+      - 4000
+    volumes:
+      - ../../../storage/tidb/tidbconfig/tidb.toml:/tidb.toml:ro
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD", "sh", "-c", "nc -zn 127.0.0.1 4000" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    networks:
+      - e2e
+
+  oap:
+    extends:
+      file: ../docker-compose.yml
+      service: oap
+    networks:
+      - e2e
+    environment:
+      SW_STORAGE: tidb
+      SW_JDBC_URL: "jdbc:mysql://tidb:4000/test"
+      SW_DATA_SOURCE_PASSWORD: ""
+    entrypoint: ['sh', '-c', '/download-mysql.sh && /skywalking/docker-entrypoint.sh']
+    depends_on:
+      tidb:
+        condition: service_healthy
+    ports:
+    - 12800
+
+  sqrt:
+    extends:
+      file: ../docker-compose.yml
+      service: sqrt
+    networks:
+      - e2e
+
+  rover:
+    extends:
+      file: ../docker-compose.yml
+      service: rover
+    networks:
+      - e2e
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e-v2/cases/profiling/ebpf/tidb/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/tidb/e2e.yaml
@@ -13,16 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-tip: null
-trees:
-  {{- contains .trees }}
-  - elements:
-    {{- contains .elements }}
-    - id: "{{ notEmpty .id }}"
-      parentid: "{{ notEmpty .parentid }}"
-      codesignature: "java.lang.Thread.sleep:-2"
-      duration: {{ gt .duration 0 }}
-      durationchildexcluded: {{ gt .durationchildexcluded 0 }}
-      count: {{ gt .count 0 }}
-    {{- end }}
-  {{- end }}
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../profiling-cases.yaml

--- a/test/e2e-v2/cases/profiling/trace/opensearch/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/opensearch/docker-compose.yml
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2.1'
+
+services:
+  opensearch:
+    image: opensearchproject/opensearch:${OPENSEARCH_VERSION}
+    expose:
+      - 9200
+    networks:
+      - e2e
+    environment:
+      - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - plugins.security.ssl.http.enabled=false
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9200" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  provider:
+    extends:
+      file: ../../../../script/docker-compose/base-compose.yml
+      service: provider
+    depends_on:
+      oap:
+        condition: service_healthy
+    ports:
+      - 9090
+
+  oap:
+    extends:
+      file: ../../../../script/docker-compose/base-compose.yml
+      service: oap
+    environment:
+      SW_STORAGE: elasticsearch
+      SW_STORAGE_ES_CLUSTER_NODES: opensearch:9200
+      SW_ES_USER: admin
+      SW_ES_PASSWORD: admin
+    depends_on:
+      opensearch:
+        condition: service_healthy
+    ports:
+      - 12800
+
+networks:
+  e2e:

--- a/test/e2e-v2/cases/profiling/trace/opensearch/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/trace/opensearch/e2e.yaml
@@ -13,15 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
-- segmentid: {{ notEmpty .segmentid }}
-  endpointnames:
-    - POST:/info
-  duration: {{ gt .duration 0 }}
-  start: "{{ notEmpty .start }}"
-  iserror: false
-  traceids:
-  {{- contains .traceids }}
-    - {{ notEmpty . }}
-  {{- end }}
-{{- end }}
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 20
+    interval: 3s
+  cases:
+    - includes:
+        - ../profiling-cases.yaml

--- a/test/e2e-v2/cases/profiling/trace/postgres/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/postgres/docker-compose.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2.1'
+
+services:
+  postgres:
+    image: postgres:13
+    networks:
+      - e2e
+    expose:
+      - 5432
+    environment:
+      - POSTGRES_PASSWORD=123456
+      - POSTGRES_DB=skywalking
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/5432" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  provider:
+    extends:
+      file: ../../../../script/docker-compose/base-compose.yml
+      service: provider
+    depends_on:
+      oap:
+        condition: service_healthy
+    ports:
+    - 9090
+
+  oap:
+    extends:
+      file: ../../../../script/docker-compose/base-compose.yml
+      service: oap
+    environment:
+      SW_STORAGE: postgresql
+      SW_JDBC_URL: "jdbc:postgresql://postgres:5432/skywalking"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+    - 12800
+
+networks:
+  e2e:

--- a/test/e2e-v2/cases/profiling/trace/postgres/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/trace/postgres/e2e.yaml
@@ -13,5 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-id: {{ notEmpty .id }}
-errorreason: null
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 20
+    interval: 3s
+  cases:
+    - includes:
+        - ../profiling-cases.yaml

--- a/test/e2e-v2/cases/profiling/trace/tidb/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/tidb/docker-compose.yml
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2.1'
+
+services:
+  tidb:
+    image: pingcap/tidb:v4.0.12
+    expose:
+      - 4000
+    volumes:
+      - ../../../storage/tidb/tidbconfig/tidb.toml:/tidb.toml:ro
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD", "sh", "-c", "nc -zn 127.0.0.1 4000" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    networks:
+      - e2e
+
+  provider:
+    extends:
+      file: ../../../../script/docker-compose/base-compose.yml
+      service: provider
+    depends_on:
+      oap:
+        condition: service_healthy
+    ports:
+      - 9090
+
+  oap:
+    extends:
+      file: ../../../../script/docker-compose/base-compose.yml
+      service: oap
+    environment:
+      SW_STORAGE: tidb
+      SW_JDBC_URL: "jdbc:mysql://tidb:4000/test"
+      SW_DATA_SOURCE_PASSWORD: ""
+    entrypoint: ['sh', '-c', '/download-mysql.sh && /skywalking/docker-entrypoint.sh']
+    depends_on:
+      tidb:
+        condition: service_healthy
+    ports:
+      - 12800
+
+networks:
+  e2e:

--- a/test/e2e-v2/cases/profiling/trace/tidb/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/trace/tidb/e2e.yaml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 20
+    interval: 3s
+  cases:
+    - includes:
+        - ../profiling-cases.yaml

--- a/test/e2e-v2/cases/storage/storage-cases.yaml
+++ b/test/e2e-v2/cases/storage/storage-cases.yaml
@@ -56,47 +56,6 @@ cases:
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql event list
     expected: expected/event-list.yml
 
-  # native profile: create task
-  - query: |
-      swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql \
-        profiling trace create --service-name=e2e-service-provider \
-          --endpoint-name=POST:/info \
-          --start-time=$((($(date +%s)+5)*1000)) \
-          --duration=1 --min-duration-threshold=0 \
-          --dump-period=10 --max-sampling-count=9
-    expected: expected/profile-create.yml
-  # native profile: sleep to wait agent notices and query profile list
-  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace list -service-name=e2e-service-provider --endpoint-name=POST:/info
-    expected: expected/profile-list.yml
-
-  # native profile: sleep to wait segment report and query profiled segment list
-  - query: |
-      swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace segment-list --task-id=$( \
-        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace list --service-name=e2e-service-provider --endpoint-name=POST:/info | yq e '.[0].id' - \
-      )
-    expected: expected/profile-segment-list.yml
-
-  # native profile: query profiled segment
-  - query: |
-      swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace profiled-segment --segment-id=$( \
-        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace segment-list --task-id=$( \
-          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace list --service-name=e2e-service-provider --endpoint-name=POST:/info | yq e '.[0].id' - \
-        ) | yq e '.[0].segmentid' - \
-      )
-    expected: expected/profile-segment-detail.yml
-
-  # native profile: query profiled segment analyze
-  - query: |
-      segmentid=$( \
-        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace segment-list --task-id=$( \
-          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace list --service-name=e2e-service-provider --endpoint-name=POST:/info | yq e '.[0].id' - \
-        ) | yq e '.[0].segmentid' - \
-      );
-      start=$(swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace profiled-segment --segment-id=$segmentid|yq e '.spans.[0].starttime' -);
-      end=$(swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace profiled-segment --segment-id=$segmentid|yq e '.spans.[0].endtime' -);
-      swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql profiling trace analysis --segment-id=$segmentid --time-ranges=$(echo $start"-"$end)
-    expected: expected/profile-segment-analyze.yml
-
   - query: |
       curl -s -XPOST http://${provider_host}:${provider_9090}/users -d '{"id":"123","name":"SinglesBar"}' -H "Content-Type: application/json" > /dev/null;
       sleep 5;


### PR DESCRIPTION
1. Add storage testing into trace and eBPF Profiling E2E Testing.
2. Remove duplicate checking in storage E2E testing. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).
