### PR TITLE
Fix write record data to the wrong index name in ES storage

### DIFF
--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/TimeSeriesUtils.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/TimeSeriesUtils.java
@@ -87,8 +87,6 @@ public class TimeSeriesUtils {
         String tableName = IndexController.INSTANCE.getTableName(model);
         if (model.isRecord() && model.isSuperDataset()) {
             return tableName + Const.LINE + compressTimeBucket(timeBucket / 1000000, SUPER_DATASET_DAY_STEP);
-        } else if (model.isRecord()) {
-            return tableName + Const.LINE + compressTimeBucket(timeBucket / 1000000, DAY_STEP);
         } else {
             switch (model.getDownsampling()) {
                 case None:

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/TimeSeriesUtilsTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/TimeSeriesUtilsTest.java
@@ -38,10 +38,10 @@ public class TimeSeriesUtilsTest {
     @Before
     public void prepare() {
         superDatasetModel = new Model("superDatasetModel", Lists.newArrayList(),
-                                      0, DownSampling.Minute, true, true, "", true, new SQLDatabaseModelExtension()
+                                      0, DownSampling.Second, true, true, "", true, new SQLDatabaseModelExtension()
         );
         normalRecordModel = new Model("normalRecordModel", Lists.newArrayList(),
-                                      0, DownSampling.Minute, true, false, "", true, new SQLDatabaseModelExtension()
+                                      0, DownSampling.Second, true, false, "", true, new SQLDatabaseModelExtension()
         );
         normalMetricsModel = new Model("normalMetricsModel", Lists.newArrayList(),
                                        0, DownSampling.Minute, false, false, "", true, new SQLDatabaseModelExtension()


### PR DESCRIPTION
Continue https://github.com/apache/skywalking/pull/9145, the previous PR simplified the format relate to TTL and installation, but forget to update the data written index name. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).
