### PR TITLE
sync ui: fix the tabs and on-demand logs widget

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -112,6 +112,7 @@
 * Add Spanish language to UI.
 * Sort spans with startTime or spanId in a segment.
 * Visualize a on-demand log widget.
+* Fix activate the correct tab index after renaming a Tabs name.
 
 #### Documentation
 


### PR DESCRIPTION

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).

Fixes the tabs and on-demand logs widget.

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
