### PR TITLE
ElasticSearch: scroll id should be updated when scrolling as it may change

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -4,6 +4,8 @@
 
 #### OAP Server
 
+* ElasticSearch: scroll id should be updated when scrolling as it may change
+
 #### Documentation
 
 * Fix invalid links in release docs


### PR DESCRIPTION
This partially reverts #9128 , originally I deleted the scroll id when I scroll one time, later that @mrproliu modified in #9128 to only delete the scroll id after the scroll is done, in #9128 we assumed that the scroll id is not changed but that's not the case, according to https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/search_operations.html 

```
    // When done, get the new scroll_id
    // You must always refresh your _scroll_id!  It can change sometimes
    $scroll_id = $response['_scroll_id'];
```

^^^ found by @wankai123 (thanks 🙇) and it becomes painful due to "It can change sometimes".

SO in this PR I just save the scroll ids and when done delete them all at once.