### PR TITLE
fix: id is too long, must be no longer than 512 bytes

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -1,3 +1,4 @@
+
 ## 9.2.0
 
 #### Project
@@ -11,5 +12,6 @@
 #### Documentation
 
 * Fix invalid links in release docs
+* Fix elasticsearch doc id  is too long, must be no longer than 512 bytes
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/136?closed=1)

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexController.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexController.java
@@ -33,6 +33,7 @@ import org.apache.skywalking.oap.server.core.storage.model.Model;
 @Slf4j
 public enum IndexController {
     INSTANCE;
+    public static final int DOC_ID_MAX_LENGTH = 500;
 
     public String getTableName(Model model) {
         return isMetricModel(model) ? model.getAggregationFunctionName() : model.getName();
@@ -43,17 +44,30 @@ public enum IndexController {
      * to avoid conflicts.
      */
     public String generateDocId(Model model, String originalID) {
+        String docId = originalID;
         if (!isMetricModel(model)) {
-            return originalID;
+            if (docId.length() > DOC_ID_MAX_LENGTH) {
+                docId = docId.substring(0, DOC_ID_MAX_LENGTH);
+            }
+            return docId;
         }
-        return this.generateDocId(model.getName(), originalID);
+        docId = this.generateDocId(model.getName(), originalID);
+        if (docId.length() > DOC_ID_MAX_LENGTH) {
+            docId = docId.substring(0, DOC_ID_MAX_LENGTH);
+        }
+        return docId;
+
     }
 
     /**
      * Generate the index doc ID.
      */
     public String generateDocId(String logicTableName, String originalID) {
-        return logicTableName + Const.ID_CONNECTOR + originalID;
+        String docId = logicTableName + Const.ID_CONNECTOR + originalID;
+        if (docId.length() > DOC_ID_MAX_LENGTH) {
+            docId = docId.substring(0, DOC_ID_MAX_LENGTH);
+        }
+        return docId;
     }
 
     /**


### PR DESCRIPTION

### Fix https://github.com/apache/skywalking/issues/8878 <ElasticSearch doc id is too long, must be no longer than 512 bytes>

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/changelog/docs/en/changes/changes.md).

```
index:sw89_metrics-percent-20220607, docId:endpoint_relation_sla_202206071458_VXNlcg==.0.581-VXNlcg==-cHJvZC1zZWN1cml0eS1jZW50ZXItd2Vi.1.581-e0dFVH0vYXBpL2F1dGh6L2F1dGh6L2xpc3Qve3Jlc291cmNlVHlwZX0=, exception:java.lang.RuntimeException: {"error":{"root_cause":[{"type":"action_request_validation_exception","reason":"Validation Failed: 1: id is too long, must be no longer than 512 bytes but was: 514;"}],"type":"action_request_validation_exception","reason":"Validation Failed: 1: id is too long, must be no longer than 512 bytes but was: 514;"},"status":400}, cost:150ms
```
 By the way, how to become skywaling commiter, I want to contribute my part to skywalking！