### PR TITLE
Add `VIRTUAL` detect type to Process for Network Profiling

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -11,6 +11,7 @@
 * Mesh: fix only last rule works when multiple rules are defined in metadata-service-mapping.yaml.
 * Support sending alarm messages to PagerDuty.
 * Support Zipkin kafka collector.
+* Add `VIRTUAL` detect type to Process for Network Profiling.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/process/ProcessDetectType.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/process/ProcessDetectType.java
@@ -43,7 +43,13 @@ public enum ProcessDetectType {
     /**
      * Detect by kubernetes platform
      */
-    KUBERNETES(2)
+    KUBERNETES(2),
+
+    /**
+     * Detect by Network Profiling for build the Topology only.
+     * This type of process should not be profileable.
+     */
+    VIRTUAL(3),
     ;
 
     private final int value;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/EBPFProfilingQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/EBPFProfilingQueryService.java
@@ -154,7 +154,7 @@ public class EBPFProfilingQueryService implements Service {
         final long endTimestamp = System.currentTimeMillis();
         final long startTimestamp = endTimestamp - TimeUnit.MINUTES.toMillis(10);
         final long processesCount = getMetadataQueryDAO().getProcessesCount(serviceId, null, null,
-                ProfilingSupportStatus.SUPPORT_EBPF_PROFILING, TimeBucket.getTimeBucket(startTimestamp, DownSampling.Minute),
+                ProfilingSupportStatus.SUPPORT_EBPF_PROFILING, true, TimeBucket.getTimeBucket(startTimestamp, DownSampling.Minute),
                 TimeBucket.getTimeBucket(endTimestamp, DownSampling.Minute));
         if (processesCount <= 0) {
             prepare.setCouldProfiling(false);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetadataQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetadataQueryService.java
@@ -104,7 +104,7 @@ public class MetadataQueryService implements org.apache.skywalking.oap.server.li
     }
 
     public List<Process> listProcesses(final Duration duration, final String instanceId) throws IOException {
-        return getMetadataQueryDAO().listProcesses(null, instanceId, null, null,
+        return getMetadataQueryDAO().listProcesses(null, instanceId, null, null, true,
                 duration.getStartTimeBucket(), duration.getEndTimeBucket());
     }
 
@@ -122,7 +122,7 @@ public class MetadataQueryService implements org.apache.skywalking.oap.server.li
         final long endTimestamp = System.currentTimeMillis();
         final long startTimestamp = endTimestamp - TimeUnit.MINUTES.toMillis(10);
         final List<Process> processes = getMetadataQueryDAO().listProcesses(serviceId, null, null,
-                ProfilingSupportStatus.SUPPORT_EBPF_PROFILING, TimeBucket.getTimeBucket(startTimestamp, DownSampling.Minute),
+                ProfilingSupportStatus.SUPPORT_EBPF_PROFILING, true, TimeBucket.getTimeBucket(startTimestamp, DownSampling.Minute),
                 TimeBucket.getTimeBucket(endTimestamp, DownSampling.Minute));
         return CollectionUtils.isEmpty(processes) ?
                 0L :

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IMetadataQueryDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IMetadataQueryDAO.java
@@ -67,8 +67,8 @@ public interface IMetadataQueryDAO extends DAO {
      * @return list of processes matching the given conditions.
      */
     List<Process> listProcesses(final String serviceId, final String instanceId, final String agentId,
-                                final ProfilingSupportStatus profilingSupportStatus, final long lastPingStartTimeBucket,
-                                final long lastPingEndTimeBucket) throws IOException;
+                                final ProfilingSupportStatus profilingSupportStatus, final boolean excludeVirtual,
+                                final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException;
 
     /**
      * get the count of processes
@@ -78,8 +78,8 @@ public interface IMetadataQueryDAO extends DAO {
      * @return the size of processes
      */
     long getProcessesCount(final String serviceId, final String instanceId, final String agentId,
-                           final ProfilingSupportStatus profilingSupportStatus, final long lastPingStartTimeBucket,
-                           final long lastPingEndTimeBucket) throws IOException;
+                           final ProfilingSupportStatus profilingSupportStatus, final boolean excludeVirtual,
+                           final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException;
 
     /**
      * @param processId the id of the process.

--- a/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/EBPFProfilingServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/EBPFProfilingServiceHandler.java
@@ -83,7 +83,7 @@ public class EBPFProfilingServiceHandler extends EBPFProfilingServiceGrpc.EBPFPr
         try {
             // find exists process from agent
             final List<Process> processes = metadataQueryDAO.listProcesses(null, null, agentId,
-                    ProfilingSupportStatus.SUPPORT_EBPF_PROFILING, 0, 0);
+                    ProfilingSupportStatus.SUPPORT_EBPF_PROFILING, true, 0, 0);
             if (CollectionUtils.isEmpty(processes)) {
                 responseObserver.onNext(Commands.newBuilder().build());
                 responseObserver.onCompleted();

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetadataQueryDAO.java
@@ -201,7 +201,7 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
     }
 
     @Override
-    public List<Process> listProcesses(String serviceId, String instanceId, String agentId, ProfilingSupportStatus profilingSupportStatus, long lastPingStartTimeBucket, long lastPingEndTimeBucket) throws IOException {
+    public List<Process> listProcesses(String serviceId, String instanceId, String agentId, ProfilingSupportStatus profilingSupportStatus, boolean excludeVirtual, long lastPingStartTimeBucket, long lastPingEndTimeBucket) throws IOException {
         MeasureQueryResponse resp = query(ProcessTraffic.INDEX_NAME,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
@@ -216,6 +216,9 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                         }
                         if (StringUtil.isNotEmpty(agentId)) {
                             query.and(eq(ProcessTraffic.AGENT_ID, agentId));
+                        }
+                        if (excludeVirtual) {
+                            query.and(ne(ProcessTraffic.DETECT_TYPE, ProcessDetectType.VIRTUAL.value()));
                         }
                         if (lastPingStartTimeBucket > 0) {
                             query.and(gte(ProcessTraffic.LAST_PING_TIME_BUCKET, lastPingStartTimeBucket));
@@ -239,7 +242,7 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
     }
 
     @Override
-    public long getProcessesCount(String serviceId, String instanceId, String agentId, ProfilingSupportStatus profilingSupportStatus, long lastPingStartTimeBucket, long lastPingEndTimeBucket) throws IOException {
+    public long getProcessesCount(String serviceId, String instanceId, String agentId, ProfilingSupportStatus profilingSupportStatus, boolean excludeVirtual, long lastPingStartTimeBucket, long lastPingEndTimeBucket) throws IOException {
         MeasureQueryResponse resp = query(ProcessTraffic.INDEX_NAME,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
@@ -254,6 +257,9 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                         }
                         if (StringUtil.isNotEmpty(agentId)) {
                             query.and(eq(ProcessTraffic.AGENT_ID, instanceId));
+                        }
+                        if (excludeVirtual) {
+                            query.and(ne(ProcessTraffic.DETECT_TYPE, ProcessDetectType.VIRTUAL.value()));
                         }
                         if (lastPingStartTimeBucket > 0) {
                             query.and(gte(ProcessTraffic.LAST_PING_TIME_BUCKET, lastPingStartTimeBucket));

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/stream/AbstractBanyanDBDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/stream/AbstractBanyanDBDAO.java
@@ -122,5 +122,9 @@ public abstract class AbstractBanyanDBDAO extends AbstractDAO<BanyanDBStorageCli
         protected PairQueryCondition<String> eq(String name, String value) {
             return PairQueryCondition.StringQueryCondition.eq(name, value);
         }
+
+        protected PairQueryCondition<Long> ne(String name, long value) {
+            return PairQueryCondition.LongQueryCondition.ne(name, value);
+        }
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
@@ -215,13 +215,13 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
 
     @Override
     public List<Process> listProcesses(String serviceId, String instanceId, String agentId, final ProfilingSupportStatus profilingSupportStatus,
-                                       final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException {
+                                       boolean excludeVirtual, final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException {
         final String index =
             IndexController.LogicIndicesRegister.getPhysicalTableName(ProcessTraffic.INDEX_NAME);
 
         final BoolQueryBuilder query = Query.bool();
         final SearchBuilder search = Search.builder().query(query).size(queryMaxSize);
-        appendProcessWhereQuery(query, serviceId, instanceId, agentId, profilingSupportStatus,
+        appendProcessWhereQuery(query, serviceId, instanceId, agentId, profilingSupportStatus, excludeVirtual,
                 lastPingStartTimeBucket, lastPingEndTimeBucket);
         final SearchResponse results = getClient().search(index, search.build());
 
@@ -230,13 +230,13 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
 
     @Override
     public long getProcessesCount(String serviceId, String instanceId, String agentId, final ProfilingSupportStatus profilingSupportStatus,
-                                  final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException {
+                                  boolean excludeVirtual, final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException {
         final String index =
                 IndexController.LogicIndicesRegister.getPhysicalTableName(ProcessTraffic.INDEX_NAME);
 
         final BoolQueryBuilder query = Query.bool();
         final SearchBuilder search = Search.builder().query(query).size(0);
-        appendProcessWhereQuery(query, serviceId, instanceId, agentId, profilingSupportStatus,
+        appendProcessWhereQuery(query, serviceId, instanceId, agentId, profilingSupportStatus, excludeVirtual,
                 lastPingStartTimeBucket, lastPingEndTimeBucket);
         final SearchResponse results = getClient().search(index, search.build());
 
@@ -244,8 +244,8 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
     }
 
     private void appendProcessWhereQuery(BoolQueryBuilder query, String serviceId, String instanceId, String agentId,
-                                         final ProfilingSupportStatus profilingSupportStatus, final long lastPingStartTimeBucket,
-                                         final long lastPingEndTimeBucket) {
+                                         final ProfilingSupportStatus profilingSupportStatus, final boolean excludeVirtual,
+                                         final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) {
         if (StringUtil.isNotEmpty(serviceId)) {
             query.must(Query.term(ProcessTraffic.SERVICE_ID, serviceId));
         }
@@ -254,6 +254,9 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         }
         if (StringUtil.isNotEmpty(agentId)) {
             query.must(Query.term(ProcessTraffic.AGENT_ID, agentId));
+        }
+        if (excludeVirtual) {
+            query.mustNot(Query.term(ProcessTraffic.DETECT_TYPE, ProcessDetectType.VIRTUAL.value()));
         }
         if (profilingSupportStatus != null) {
             query.must(Query.term(ProcessTraffic.PROFILING_SUPPORT_STATUS, profilingSupportStatus.value()));

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
@@ -233,11 +233,11 @@ public class H2MetadataQueryDAO implements IMetadataQueryDAO {
 
     @Override
     public List<Process> listProcesses(String serviceId, String instanceId, String agentId, final ProfilingSupportStatus profilingSupportStatus,
-                                       final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException {
+                                       boolean excludeVirtual, final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException {
         StringBuilder sql = new StringBuilder();
         List<Object> condition = new ArrayList<>(3);
         sql.append("select * from ").append(ProcessTraffic.INDEX_NAME);
-        appendProcessWhereQuery(sql, condition, serviceId, instanceId, agentId, profilingSupportStatus,
+        appendProcessWhereQuery(sql, condition, serviceId, instanceId, agentId, profilingSupportStatus, excludeVirtual,
                 lastPingStartTimeBucket, lastPingEndTimeBucket);
         sql.append(" limit ").append(metadataQueryMaxSize);
 
@@ -253,11 +253,11 @@ public class H2MetadataQueryDAO implements IMetadataQueryDAO {
 
     @Override
     public long getProcessesCount(String serviceId, String instanceId, String agentId, final ProfilingSupportStatus profilingSupportStatus,
-                                  final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException {
+                                  boolean excludeVirtual, final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) throws IOException {
         StringBuilder sql = new StringBuilder();
         List<Object> condition = new ArrayList<>(3);
         sql.append("select count(1) total from ").append(ProcessTraffic.INDEX_NAME);
-        appendProcessWhereQuery(sql, condition, serviceId, instanceId, agentId, profilingSupportStatus,
+        appendProcessWhereQuery(sql, condition, serviceId, instanceId, agentId, profilingSupportStatus, excludeVirtual,
                 lastPingStartTimeBucket, lastPingEndTimeBucket);
 
         try (Connection connection = h2Client.getConnection()) {
@@ -274,7 +274,7 @@ public class H2MetadataQueryDAO implements IMetadataQueryDAO {
     }
 
     private void appendProcessWhereQuery(StringBuilder sql, List<Object> condition, String serviceId, String instanceId,
-                                         String agentId, final ProfilingSupportStatus profilingSupportStatus,
+                                         String agentId, final ProfilingSupportStatus profilingSupportStatus, boolean excludeVirtual,
                                          final long lastPingStartTimeBucket, final long lastPingEndTimeBucket) {
         if (StringUtil.isNotEmpty(serviceId) || StringUtil.isNotEmpty(instanceId) || StringUtil.isNotEmpty(agentId)) {
             sql.append(" where ");
@@ -297,6 +297,13 @@ public class H2MetadataQueryDAO implements IMetadataQueryDAO {
             }
             sql.append(ProcessTraffic.AGENT_ID).append("=?");
             condition.add(agentId);
+        }
+        if (excludeVirtual) {
+            if (!condition.isEmpty()) {
+                sql.append(" and ");
+            }
+            sql.append(ProcessTraffic.DETECT_TYPE).append("!=?");
+            condition.add(ProcessDetectType.VIRTUAL.value());
         }
         if (profilingSupportStatus != null) {
             if (!condition.isEmpty()) {


### PR DESCRIPTION
When querying Process, exclude all Virtual type data, this part of the data will only be useful in Network Profiling.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
