### PR TITLE
Fixes Banynadb race condition

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -25,7 +25,7 @@
 * Support the `NETWORK` type of eBPF Profiling task.
 * Support `sumHistogram` in `MAL`.
 * [Breaking Change] Make the eBPF Profiling task support to the service instance level, index/table `ebpf_profiling_task` is required to be re-created when bump up from previous releases.
-* Fix race condition in Banyandb storage module
+* Fix race condition in Banyandb storage
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -25,6 +25,7 @@
 * Support the `NETWORK` type of eBPF Profiling task.
 * Support `sumHistogram` in `MAL`.
 * [Breaking Change] Make the eBPF Profiling task support to the service instance level, index/table `ebpf_profiling_task` is required to be re-created when bump up from previous releases.
+* Fix race condition in Banyandb storage module
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBBatchDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBBatchDAO.java
@@ -31,9 +31,10 @@ import org.apache.skywalking.oap.server.storage.plugin.banyandb.stream.BanyanDBS
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BanyanDBBatchDAO extends AbstractDAO<BanyanDBStorageClient> implements IBatchDAO {
+    private static final Object STREAM_SYNCHRONIZER = new Object();
+    private static final Object MEASURE_SYNCHRONIZER = new Object();
     private StreamBulkWriteProcessor streamBulkWriteProcessor;
 
     private MeasureBulkWriteProcessor measureBulkWriteProcessor;
@@ -44,8 +45,6 @@ public class BanyanDBBatchDAO extends AbstractDAO<BanyanDBStorageClient> impleme
 
     private final int concurrency;
 
-    private final AtomicBoolean initialized = new AtomicBoolean(false);
-
     public BanyanDBBatchDAO(BanyanDBStorageClient client, int maxBulkSize, int flushInterval, int concurrency) {
         super(client);
         this.maxBulkSize = maxBulkSize;
@@ -55,37 +54,46 @@ public class BanyanDBBatchDAO extends AbstractDAO<BanyanDBStorageClient> impleme
 
     @Override
     public void insert(InsertRequest insertRequest) {
-        if (initialized.compareAndSet(false, true)) {
-            this.streamBulkWriteProcessor = getClient().createStreamBulkProcessor(maxBulkSize, flushInterval, concurrency);
-            this.measureBulkWriteProcessor = getClient().createMeasureBulkProcessor(maxBulkSize, flushInterval, concurrency);
-        }
         if (insertRequest instanceof BanyanDBStreamInsertRequest) {
-            this.streamBulkWriteProcessor.add(((BanyanDBStreamInsertRequest) insertRequest).getStreamWrite());
+            getStreamBulkWriteProcessor().add(((BanyanDBStreamInsertRequest) insertRequest).getStreamWrite());
         } else if (insertRequest instanceof BanyanDBMeasureInsertRequest) {
-            this.measureBulkWriteProcessor.add(((BanyanDBMeasureInsertRequest) insertRequest).getMeasureWrite());
+            getMeasureBulkWriteProcessor().add(((BanyanDBMeasureInsertRequest) insertRequest).getMeasureWrite());
         }
     }
 
     @Override
     public CompletableFuture<Void> flush(List<PrepareRequest> prepareRequests) {
-        if (initialized.compareAndSet(false, true)) {
-            this.streamBulkWriteProcessor = getClient().createStreamBulkProcessor(maxBulkSize, flushInterval, concurrency);
-            this.measureBulkWriteProcessor = getClient().createMeasureBulkProcessor(maxBulkSize, flushInterval, concurrency);
-        }
-
         if (CollectionUtils.isNotEmpty(prepareRequests)) {
             for (final PrepareRequest r : prepareRequests) {
                 if (r instanceof BanyanDBStreamInsertRequest) {
                     // TODO: return CompletableFuture<Void>
-                    this.streamBulkWriteProcessor.add(((BanyanDBStreamInsertRequest) r).getStreamWrite());
+                    getStreamBulkWriteProcessor().add(((BanyanDBStreamInsertRequest) r).getStreamWrite());
                 } else if (r instanceof BanyanDBMeasureInsertRequest) {
-                    this.measureBulkWriteProcessor.add(((BanyanDBMeasureInsertRequest) r).getMeasureWrite());
+                    getMeasureBulkWriteProcessor().add(((BanyanDBMeasureInsertRequest) r).getMeasureWrite());
                 } else if (r instanceof BanyanDBMeasureUpdateRequest) {
-                    this.measureBulkWriteProcessor.add(((BanyanDBMeasureUpdateRequest) r).getMeasureWrite());
+                    getMeasureBulkWriteProcessor().add(((BanyanDBMeasureUpdateRequest) r).getMeasureWrite());
                 }
             }
         }
 
         return CompletableFuture.completedFuture(null);
+    }
+
+    private StreamBulkWriteProcessor getStreamBulkWriteProcessor() {
+        if (streamBulkWriteProcessor == null) {
+            synchronized (STREAM_SYNCHRONIZER) {
+                this.streamBulkWriteProcessor = getClient().createStreamBulkProcessor(maxBulkSize, flushInterval, concurrency);
+            }
+        }
+        return streamBulkWriteProcessor;
+    }
+
+    private MeasureBulkWriteProcessor getMeasureBulkWriteProcessor() {
+        if (measureBulkWriteProcessor == null) {
+            synchronized (MEASURE_SYNCHRONIZER) {
+                this.measureBulkWriteProcessor = getClient().createMeasureBulkProcessor(maxBulkSize, flushInterval, concurrency);
+            }
+        }
+        return measureBulkWriteProcessor;
     }
 }

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBBatchDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBBatchDAO.java
@@ -82,7 +82,9 @@ public class BanyanDBBatchDAO extends AbstractDAO<BanyanDBStorageClient> impleme
     private StreamBulkWriteProcessor getStreamBulkWriteProcessor() {
         if (streamBulkWriteProcessor == null) {
             synchronized (STREAM_SYNCHRONIZER) {
-                this.streamBulkWriteProcessor = getClient().createStreamBulkProcessor(maxBulkSize, flushInterval, concurrency);
+                if (streamBulkWriteProcessor == null) {
+                    this.streamBulkWriteProcessor = getClient().createStreamBulkProcessor(maxBulkSize, flushInterval, concurrency);
+                }
             }
         }
         return streamBulkWriteProcessor;
@@ -91,7 +93,9 @@ public class BanyanDBBatchDAO extends AbstractDAO<BanyanDBStorageClient> impleme
     private MeasureBulkWriteProcessor getMeasureBulkWriteProcessor() {
         if (measureBulkWriteProcessor == null) {
             synchronized (MEASURE_SYNCHRONIZER) {
-                this.measureBulkWriteProcessor = getClient().createMeasureBulkProcessor(maxBulkSize, flushInterval, concurrency);
+                if (measureBulkWriteProcessor == null) {
+                    this.measureBulkWriteProcessor = getClient().createMeasureBulkProcessor(maxBulkSize, flushInterval, concurrency);
+                }
             }
         }
         return measureBulkWriteProcessor;


### PR DESCRIPTION
### Fix #9359

The issue exists because BanyanDBBatchDAO is used by multiple threads but `initialized.compareAndSet(false, true)` is set before the values it's supposed to initialize are actually initialized.

My method of multithreaded protection probably isn't the best, but it works. Let me know if I should use another method.