### PR TITLE
Sync ui: associate the event widget with the trace and log widget

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -57,6 +57,7 @@
 * Refactor the tags component to support searching for tag keys and values.
 * Implement the log widget and the trace widget associate with each other, remove log tables on the trace widget.
 * Add log widget to general service root.
+* Associate the event widget with the trace and log widget.
 
 #### Documentation
 


### PR DESCRIPTION

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

Associate the event widget with the trace and log widget.

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
