### PR TITLE
Add VIRTUAL_CACHE layer to fix Cache server icon in topology

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -28,7 +28,7 @@
 * Fix race condition in Banyandb storage
 * Support `SUM_PER_MIN` downsampling in `MAL`.
 * Support `sumHistogramPercentile` in `MAL`.
-* Add `VIRTUAL_CACHE` to Layer, to fix [#9404](https://github.com/apache/skywalking/issues/9404)
+* Add `VIRTUAL_CACHE` to Layer, to fix conjectured Redis server, which icon can't show on the topology.
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -28,6 +28,7 @@
 * Fix race condition in Banyandb storage
 * Support `SUM_PER_MIN` downsampling in `MAL`.
 * Support `sumHistogramPercentile` in `MAL`.
+* Add `VIRTUAL_CACHE` to Layer, to fix [#9404](https://github.com/apache/skywalking/issues/9404)
 
 #### UI
 

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/RPCAnalysisListener.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/RPCAnalysisListener.java
@@ -395,7 +395,7 @@ public class RPCAnalysisListener extends CommonAnalysisListener implements Entry
             case MQ:
                 return Layer.VIRTUAL_MQ;
             case Cache:
-                return Layer.CACHE;
+                return Layer.VIRTUAL_CACHE;
             case UNRECOGNIZED:
                 return Layer.UNDEFINED;
             case FAAS:

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Layer.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Layer.java
@@ -121,7 +121,12 @@ public enum Layer {
     /**
      * MySQL Server, also known as mysqld, is a single multithreaded program that does most of the work in a MySQL installation. 
      */
-    MYSQL(18, true);
+    MYSQL(18, true),
+
+    /**
+     * Cache conjectured by client side plugin(eg. skywalking-java -> JedisPlugin LettucePlugin)
+     */
+    VIRTUAL_CACHE(19, false);
 
     private final int value;
     /**


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->
↓ ↓ topology screenshot ↓ ↓  
before : 

![before](https://user-images.githubusercontent.com/18047673/182061056-e0b987c7-c353-4379-910a-07bacb220991.png)

after : 

![after](https://user-images.githubusercontent.com/18047673/182061059-ddd09e11-3792-45c2-87b8-bd7f21eb915f.png)

### Fix `https://github.com/apache/skywalking/issues/9404`
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it. 
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #9404.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
