### PR TITLE
Sync ui: add a calculation to convert seconds to days

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -67,6 +67,7 @@
 * Associate the event widget with the trace and log widget.
 * Add the MYSQL layer and update layer routers.
 * Fix query order for trace list.
+* Add a calculation to convert seconds to days.
 
 #### Documentation
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -73,5 +73,6 @@
 
 * Fix invalid links in release docs.
 * Clean up doc about event metrics.
+* Add a table for metric calculations in the ui doc.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/136?closed=1)

--- a/docs/en/ui/README.md
+++ b/docs/en/ui/README.md
@@ -24,6 +24,24 @@ so).
 **Notice, dashboard editable is disabled on release; set system env(**SW_ENABLE_UPDATE_UI_TEMPLATE=true**) to activate
 them.** Before you save the edited dashboard, it is just stored in memory. Closing a tab would **LOSE** the change permanently.
 
+There are some calculations for metric values in the dashboard.
+
+|Label|Calculation|
+|----|----|
+|Percentage|Value / 100|
+|Apdex|Value / 10000|
+|Average|Sum of values / Count of values|
+|Percentage + Avg-preview|Sum of values / Count of values / 100|
+|Apdex + Avg-preview|Sum of values / Count of values / 10000|
+|Byte to KB|Value / 1024|
+|Byte to MB|Value / 1024 / 1024|
+|Byte to GB|Value / 1024 / 1024 / 1024|
+|Seconds to YYYY-MM-DD HH:mm:ss|dayjs(value * 1000).format("YYYY-MM-DD HH:mm:ss")|
+|Milliseconds to YYYY-MM-DD HH:mm:ss|dayjs(value).format("YYYY-MM-DD HH:mm:ss")|
+|Precision|Value.toFixed(2)|
+|Milliseconds to seconds|Value / 1000|
+|Seconds to days|Value / 86400|
+
 ## Settings
 
 Settings provide language, server time zone, and auto-fresh options. These settings are stored in the browser's local storage. Unless you clear them manually, those will not change. 


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

Add a calculation to convert seconds to days.
Update the ui doc.

Screenshot


<img width="1150" alt="2" src="https://user-images.githubusercontent.com/20871783/183332986-809a45d2-9c4b-45a2-b449-5f94a56747a7.png">


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
