### PR TITLE
refactor: make more consistent

### DIFF
--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/ISegmentParserListenerManager.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/ISegmentParserListenerManager.java
@@ -20,6 +20,10 @@ package org.apache.skywalking.oap.server.analyzer.provider.trace.parser;
 
 import org.apache.skywalking.oap.server.analyzer.provider.trace.parser.listener.AnalysisListenerFactory;
 
+import java.util.List;
+
 public interface ISegmentParserListenerManager {
     void add(AnalysisListenerFactory analysisListenerFactory);
+
+    List<AnalysisListenerFactory> getSpanListenerFactories();
 }

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/SegmentParserListenerManager.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/SegmentParserListenerManager.java
@@ -36,7 +36,8 @@ public class SegmentParserListenerManager implements ISegmentParserListenerManag
         spanListenerFactories.add(analysisListenerFactory);
     }
 
-    List<AnalysisListenerFactory> getSpanListenerFactories() {
+    @Override
+    public List<AnalysisListenerFactory> getSpanListenerFactories() {
         return spanListenerFactories;
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
@@ -44,7 +44,7 @@ import org.joda.time.DateTime;
 public class MetricsEsDAO extends EsDAO implements IMetricsDAO {
     protected final StorageBuilder<Metrics> storageBuilder;
 
-    protected MetricsEsDAO(ElasticSearchClient client,
+    public MetricsEsDAO(ElasticSearchClient client,
                            StorageBuilder<Metrics> storageBuilder) {
         super(client);
         this.storageBuilder = storageBuilder;


### PR DESCRIPTION
Small refactorings to make code more consistent.

#### Added `ISegmentParserListenerManager.getSpanListenerFactories`

This now matches `ILogAnalysisListenerFactoryManager.getLogAnalysisListenerFactories()`

#### Made `MetricsEsDAO` constructor public

This now matches the constructors in `BanyanDBMetricsDAO` & `H2MetricsDAO`