### PR TITLE
Enhance #9437 fix to avoid too many small flushing.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/IBatchDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/IBatchDAO.java
@@ -45,4 +45,14 @@ public interface IBatchDAO extends DAO {
      * @param prepareRequests data to insert or update. No delete happens in streaming mode.
      */
     CompletableFuture<Void> flush(List<PrepareRequest> prepareRequests);
+
+    /**
+     * End of flush is an event to notify the whole flush period is ending.
+     * This provides a time point to do clean up works.
+     *
+     * @since 9.2.0
+     */
+    default void endOfFlush() {
+
+    }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/PersistenceTimer.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/PersistenceTimer.java
@@ -136,6 +136,7 @@ public enum PersistenceTimer {
                             .whenComplete(($1, $2) -> executeLatencyTimer.close());
                 }, prepareExecutorService);
             }).toArray(CompletableFuture[]::new));
+        batchDAO.endOfFlush();
         future.whenComplete((unused, throwable) -> {
             allTimer.close();
             if (log.isDebugEnabled()) {

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/BatchProcessEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/BatchProcessEsDAO.java
@@ -73,19 +73,20 @@ public class BatchProcessEsDAO extends EsDAO implements IBatchDAO {
         }
 
         if (CollectionUtils.isNotEmpty(prepareRequests)) {
-            try {
-                return CompletableFuture.allOf(prepareRequests.stream().map(prepareRequest -> {
-                    if (prepareRequest instanceof InsertRequest) {
-                        return bulkProcessor.add(((IndexRequestWrapper) prepareRequest).getRequest());
-                    } else {
-                        return bulkProcessor.add(((UpdateRequestWrapper) prepareRequest).getRequest());
-                    }
-                }).toArray(CompletableFuture[]::new));
-            } finally {
-                // Flush forcedly due to this kind of metrics has been pushed into the bulk processor.
-                bulkProcessor.flush();
-            }
+            return CompletableFuture.allOf(prepareRequests.stream().map(prepareRequest -> {
+                if (prepareRequest instanceof InsertRequest) {
+                    return bulkProcessor.add(((IndexRequestWrapper) prepareRequest).getRequest());
+                } else {
+                    return bulkProcessor.add(((UpdateRequestWrapper) prepareRequest).getRequest());
+                }
+            }).toArray(CompletableFuture[]::new));
         }
         return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void endOfFlush() {
+        // Flush forcedly due to this kind of metrics has been pushed into the bulk processor.
+        bulkProcessor.flush();
     }
 }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

I am moving the forcedly flush out of each worker's `#flush`, which would only make the left data flushing into the storage ASAP. In my previous fix, it would increase the number of flushing as the number of workers, which is unnecessary too.