### PR TITLE
refactor: more consistent with other listener managers

### DIFF
--- a/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/EventAnalyzer.java
+++ b/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/EventAnalyzer.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.network.event.v3.Event;
 import org.apache.skywalking.oap.server.analyzer.event.listener.EventAnalyzerListener;
-import org.apache.skywalking.oap.server.analyzer.event.listener.EventAnalyzerListenerFactoryManager;
+import org.apache.skywalking.oap.server.analyzer.event.listener.IEventAnalyzerListenerFactoryManager;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 
 /**
@@ -35,7 +35,7 @@ import org.apache.skywalking.oap.server.library.module.ModuleManager;
 public class EventAnalyzer {
     private final ModuleManager moduleManager;
 
-    private final EventAnalyzerListenerFactoryManager factoryManager;
+    private final IEventAnalyzerListenerFactoryManager factoryManager;
 
     private final List<EventAnalyzerListener> listeners = new ArrayList<>();
 
@@ -54,7 +54,7 @@ public class EventAnalyzer {
     }
 
     private void createListeners() {
-        factoryManager.factories()
+        factoryManager.getEventAnalyzerListenerFactories()
                       .forEach(factory -> listeners.add(factory.create(moduleManager)));
     }
 }

--- a/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/EventAnalyzer.java
+++ b/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/EventAnalyzer.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.network.event.v3.Event;
 import org.apache.skywalking.oap.server.analyzer.event.listener.EventAnalyzerListener;
-import org.apache.skywalking.oap.server.analyzer.event.listener.IEventAnalyzerListenerFactoryManager;
+import org.apache.skywalking.oap.server.analyzer.event.listener.IEventAnalyzerListenerManager;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 
 /**
@@ -35,7 +35,7 @@ import org.apache.skywalking.oap.server.library.module.ModuleManager;
 public class EventAnalyzer {
     private final ModuleManager moduleManager;
 
-    private final IEventAnalyzerListenerFactoryManager factoryManager;
+    private final IEventAnalyzerListenerManager factoryManager;
 
     private final List<EventAnalyzerListener> listeners = new ArrayList<>();
 

--- a/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/EventAnalyzerServiceImpl.java
+++ b/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/EventAnalyzerServiceImpl.java
@@ -25,11 +25,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.network.event.v3.Event;
 import org.apache.skywalking.oap.server.analyzer.event.listener.EventAnalyzerListener;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
-import org.apache.skywalking.oap.server.analyzer.event.listener.EventAnalyzerListenerFactoryManager;
+import org.apache.skywalking.oap.server.analyzer.event.listener.IEventAnalyzerListenerFactoryManager;
 
 @Slf4j
 @RequiredArgsConstructor
-public class EventAnalyzerServiceImpl implements EventAnalyzerService, EventAnalyzerListenerFactoryManager {
+public class EventAnalyzerServiceImpl implements EventAnalyzerService, IEventAnalyzerListenerFactoryManager {
     private final ModuleManager moduleManager;
 
     private final List<EventAnalyzerListener.Factory> factories = new ArrayList<>();
@@ -57,7 +57,7 @@ public class EventAnalyzerServiceImpl implements EventAnalyzerService, EventAnal
     }
 
     @Override
-    public List<EventAnalyzerListener.Factory> factories() {
+    public List<EventAnalyzerListener.Factory> getEventAnalyzerListenerFactories() {
         return factories;
     }
 }

--- a/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/EventAnalyzerServiceImpl.java
+++ b/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/EventAnalyzerServiceImpl.java
@@ -25,11 +25,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.network.event.v3.Event;
 import org.apache.skywalking.oap.server.analyzer.event.listener.EventAnalyzerListener;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
-import org.apache.skywalking.oap.server.analyzer.event.listener.IEventAnalyzerListenerFactoryManager;
+import org.apache.skywalking.oap.server.analyzer.event.listener.IEventAnalyzerListenerManager;
 
 @Slf4j
 @RequiredArgsConstructor
-public class EventAnalyzerServiceImpl implements EventAnalyzerService, IEventAnalyzerListenerFactoryManager {
+public class EventAnalyzerServiceImpl implements EventAnalyzerService, IEventAnalyzerListenerManager {
     private final ModuleManager moduleManager;
 
     private final List<EventAnalyzerListener.Factory> factories = new ArrayList<>();

--- a/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/listener/IEventAnalyzerListenerFactoryManager.java
+++ b/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/listener/IEventAnalyzerListenerFactoryManager.java
@@ -21,9 +21,9 @@ package org.apache.skywalking.oap.server.analyzer.event.listener;
 import java.util.List;
 import org.apache.skywalking.oap.server.library.module.Service;
 
-public interface EventAnalyzerListenerFactoryManager extends Service {
+public interface IEventAnalyzerListenerFactoryManager extends Service {
 
     void add(EventAnalyzerListener.Factory factory);
 
-    List<EventAnalyzerListener.Factory> factories();
+    List<EventAnalyzerListener.Factory> getEventAnalyzerListenerFactories();
 }

--- a/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/listener/IEventAnalyzerListenerManager.java
+++ b/oap-server/analyzer/event-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/event/listener/IEventAnalyzerListenerManager.java
@@ -19,9 +19,8 @@
 package org.apache.skywalking.oap.server.analyzer.event.listener;
 
 import java.util.List;
-import org.apache.skywalking.oap.server.library.module.Service;
 
-public interface IEventAnalyzerListenerFactoryManager extends Service {
+public interface IEventAnalyzerListenerManager {
 
     void add(EventAnalyzerListener.Factory factory);
 

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/provider/log/ILogAnalysisListenerManager.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/provider/log/ILogAnalysisListenerManager.java
@@ -19,9 +19,8 @@ package org.apache.skywalking.oap.log.analyzer.provider.log;
 
 import java.util.List;
 import org.apache.skywalking.oap.log.analyzer.provider.log.listener.LogAnalysisListenerFactory;
-import org.apache.skywalking.oap.server.library.module.Service;
 
-public interface ILogAnalysisListenerFactoryManager extends Service {
+public interface ILogAnalysisListenerManager {
 
     void addListenerFactory(LogAnalysisListenerFactory factory);
 

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/provider/log/LogAnalyzer.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/provider/log/LogAnalyzer.java
@@ -36,7 +36,7 @@ import org.apache.skywalking.oap.server.library.module.ModuleManager;
 public class LogAnalyzer {
     private final ModuleManager moduleManager;
     private final LogAnalyzerModuleConfig moduleConfig;
-    private final ILogAnalysisListenerFactoryManager factoryManager;
+    private final ILogAnalysisListenerManager factoryManager;
 
     private final List<LogAnalysisListener> listeners = new ArrayList<>();
 

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/provider/log/LogAnalyzerServiceImpl.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/provider/log/LogAnalyzerServiceImpl.java
@@ -27,7 +27,7 @@ import org.apache.skywalking.oap.log.analyzer.provider.log.listener.LogAnalysisL
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 
 @RequiredArgsConstructor
-public class LogAnalyzerServiceImpl implements ILogAnalyzerService, ILogAnalysisListenerFactoryManager {
+public class LogAnalyzerServiceImpl implements ILogAnalyzerService, ILogAnalysisListenerManager {
     private final ModuleManager moduleManager;
     private final LogAnalyzerModuleConfig moduleConfig;
     private final List<LogAnalysisListenerFactory> factories = new ArrayList<>();


### PR DESCRIPTION
#### Renamed `EventAnalyzerListenerFactoryManager` to `IEventAnalyzerListenerManager`

Consistent with:
- `ISegmentParserListenerManager`
- `ErrorLogParserListenerManager`
- `PerfDataParserListenerManager`

#### Renamed `ILogAnalysisListenerFactoryManager` to `ILogAnalysisListenerManager`

Consistent with: 
- `ISegmentParserListenerManager`
- `ErrorLogParserListenerManager`
- `PerfDataParserListenerManager`

#### Removed `extends Service` from `IEventAnalyzerListenerManager` & `ILogAnalysisListenerManager`

Consistent with `ISegmentParserListenerManager` plus they were not being registered as service implementations.

#### Renamed `EventAnalyzerListenerFactoryManager.factories()` to `IEventAnalyzerListenerManager.getEventAnalyzerListenerFactories()`

Consistent with:
- `ISegmentParserListenerManager.getSpanListenerFactories()`
- `ILogAnalysisListenerManager.getLogAnalysisListenerFactories()`