### PR TITLE
Fix MySQL related E2E failures

### DIFF
--- a/test/e2e-v2/script/prepare/setup-oap/download-mysql.sh
+++ b/test/e2e-v2/script/prepare/setup-oap/download-mysql.sh
@@ -21,6 +21,11 @@ SW_HOME=/skywalking
 MYSQL_URL="https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/8.0.13/mysql-connector-java-8.0.13.jar"
 MYSQL_DRIVER="mysql-connector-java-8.0.13.jar"
 
+# ensure the curl command been installed
+if ! command -v curl &> /dev/null; then
+    apt update -y && apt install -y curl
+fi
+
 if ! curl -Lo "${SW_HOME}/oap-libs/${MYSQL_DRIVER}" ${MYSQL_URL}; then
     echo "Fail to download ${MYSQL_DRIVER}."
     exit 1


### PR DESCRIPTION
Since the OAP base image `eclipse-temurin` was updated, the `curl` command no longer exists, so we need to reinstall the `curl` command to restore the execution of the E2E tests. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
