### PR TITLE
Fix query services by serviceId error when Elasticsearch storage `SW_STORAGE_ES_QUERY_MAX_SIZE` > 10000

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -47,7 +47,8 @@
 * Fix Zipkin trace query the max size of spans.
 * Add `tls` and `https` component IDs for Network Profiling.
 * Support Elasticsearch column alias for the compatibility between storage logicSharding model and no-logicSharding model.
-* Support MySQL  monitoring.
+* Support MySQL monitoring.
+* Fix query services by serviceId error when Elasticsearch storage `SW_STORAGE_ES_QUERY_MAX_SIZE` > 10000.
 
 #### UI
 


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
