### PR TITLE
Fix query history process data failure

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -50,6 +50,7 @@
 * Support MySQL monitoring.
 * Fix query services by serviceId error when Elasticsearch storage `SW_STORAGE_ES_QUERY_MAX_SIZE` > 10000.
 * Support sending alarm messages to Discord.
+* Fix query history process data failure.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetadataQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetadataQueryService.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.core.query;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -104,6 +105,9 @@ public class MetadataQueryService implements org.apache.skywalking.oap.server.li
     }
 
     public List<Process> listProcesses(final Duration duration, final String instanceId) throws IOException {
+        if (duration.getEndTimeBucket() < duration.getStartTimeBucket()) {
+            return Collections.emptyList();
+        }
         return getMetadataQueryDAO().listProcesses(instanceId, duration.getStartTimeBucket(), duration.getEndTimeBucket());
     }
 

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetadataQueryDAO.java
@@ -210,7 +210,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                 protected void apply(MeasureQuery query) {
                     query.and(eq(ProcessTraffic.SERVICE_ID, serviceId));
                     query.and(gte(ProcessTraffic.LAST_PING_TIME_BUCKET, lastPingStartTimeBucket));
-                    query.and(lte(ProcessTraffic.LAST_PING_TIME_BUCKET, lastPingEndTimeBucket));
                     query.and(eq(ProcessTraffic.PROFILING_SUPPORT_STATUS, supportStatus.value()));
                     query.and(ne(ProcessTraffic.DETECT_TYPE, ProcessDetectType.VIRTUAL.value()));
                 }
@@ -235,7 +234,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                 protected void apply(MeasureQuery query) {
                     query.and(eq(ProcessTraffic.INSTANCE_ID, serviceInstanceId));
                     query.and(gte(ProcessTraffic.LAST_PING_TIME_BUCKET, lastPingStartTimeBucket));
-                    query.and(lte(ProcessTraffic.LAST_PING_TIME_BUCKET, lastPingEndTimeBucket));
                     query.and(ne(ProcessTraffic.DETECT_TYPE, ProcessDetectType.VIRTUAL.value()));
                 }
             });
@@ -281,7 +279,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                 protected void apply(MeasureQuery query) {
                     query.and(eq(ProcessTraffic.SERVICE_ID, serviceId));
                     query.and(gte(ProcessTraffic.LAST_PING_TIME_BUCKET, lastPingStartTimeBucket));
-                    query.and(lte(ProcessTraffic.LAST_PING_TIME_BUCKET, lastPingEndTimeBucket));
                     query.and(eq(ProcessTraffic.PROFILING_SUPPORT_STATUS, profilingSupportStatus.value()));
                     query.and(ne(ProcessTraffic.DETECT_TYPE, ProcessDetectType.VIRTUAL.value()));
                 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
@@ -331,14 +331,9 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         if (profilingSupportStatus != null) {
             query.must(Query.term(ProcessTraffic.PROFILING_SUPPORT_STATUS, profilingSupportStatus.value()));
         }
-        final RangeQueryBuilder rangeQuery = Query.range(ProcessTraffic.LAST_PING_TIME_BUCKET);
         if (lastPingStartTimeBucket > 0) {
+            final RangeQueryBuilder rangeQuery = Query.range(ProcessTraffic.LAST_PING_TIME_BUCKET);
             rangeQuery.gte(lastPingStartTimeBucket);
-        }
-        if (lastPingEndTimeBucket > 0) {
-            rangeQuery.lte(lastPingEndTimeBucket);
-        }
-        if (lastPingStartTimeBucket > 0 || lastPingEndTimeBucket > 0) {
             query.must(rangeQuery);
         }
         query.mustNot(Query.term(ProcessTraffic.DETECT_TYPE, ProcessDetectType.VIRTUAL.value()));

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
@@ -365,13 +365,6 @@ public class H2MetadataQueryDAO implements IMetadataQueryDAO {
             sql.append(ProcessTraffic.LAST_PING_TIME_BUCKET).append(">=?");
             condition.add(lastPingStartTimeBucket);
         }
-        if (lastPingEndTimeBucket > 0) {
-            if (!condition.isEmpty()) {
-                sql.append(" and ");
-            }
-            sql.append(ProcessTraffic.LAST_PING_TIME_BUCKET).append("<=?");
-            condition.add(lastPingEndTimeBucket);
-        }
         if (!condition.isEmpty()) {
             sql.append(" and ");
         }


### PR DESCRIPTION

### Fix Fix query history process data failure
The process data query is based on the `lastPingTimestamp` of the `ProcessTraffic`.So, if we add the end time in the query condition, then we cannot query the history data. So In this PR, I delete the end time filter of the process query to fix it. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
