### PR TITLE
Fix dependency license's NOTICE and binary jar included issues in the source release.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -217,6 +217,7 @@ The text of each license is the standard Apache 2.0 license.
 
    proto files from cncf/udpa: https://github.com/cncf/udpa Apache 2.0
    proto files from envoyproxy/data-plane-api: https://github.com/envoyproxy/data-plane-api  Apache 2.0
+   proto filrs from opencensus: https://github.com/census-instrumentation/opencensus-proto/tree/master/gen-go
    proto files from prometheus/client_model: https://github.com/prometheus/client_model Apache 2.0
    proto files from opentelemetry: https://github.com/open-telemetry/opentelemetry-proto/tree/main/opentelemetry/proto Apache 2.0
    flatbuffers files from istio/proxy: https://github.com/istio/proxy Apache 2.0

--- a/LICENSE
+++ b/LICENSE
@@ -217,7 +217,6 @@ The text of each license is the standard Apache 2.0 license.
 
    proto files from cncf/udpa: https://github.com/cncf/udpa Apache 2.0
    proto files from envoyproxy/data-plane-api: https://github.com/envoyproxy/data-plane-api  Apache 2.0
-   proto files from satellite/envoy/: https://github.com/envoyproxy/envoy  Apache 2.0
    proto files from opencensus: https://github.com/census-instrumentation/opencensus-proto/tree/master/gen-go  Apache 2.0
    proto files from prometheus/client_model: https://github.com/prometheus/client_model Apache 2.0
    proto files from opentelemetry: https://github.com/open-telemetry/opentelemetry-proto/tree/main/opentelemetry/proto Apache 2.0

--- a/LICENSE
+++ b/LICENSE
@@ -217,7 +217,8 @@ The text of each license is the standard Apache 2.0 license.
 
    proto files from cncf/udpa: https://github.com/cncf/udpa Apache 2.0
    proto files from envoyproxy/data-plane-api: https://github.com/envoyproxy/data-plane-api  Apache 2.0
-   proto filrs from opencensus: https://github.com/census-instrumentation/opencensus-proto/tree/master/gen-go
+   proto files from satellite/envoy/: https://github.com/envoyproxy/envoy  Apache 2.0
+   proto files from opencensus: https://github.com/census-instrumentation/opencensus-proto/tree/master/gen-go  Apache 2.0
    proto files from prometheus/client_model: https://github.com/prometheus/client_model Apache 2.0
    proto files from opentelemetry: https://github.com/open-telemetry/opentelemetry-proto/tree/main/opentelemetry/proto Apache 2.0
    flatbuffers files from istio/proxy: https://github.com/istio/proxy Apache 2.0

--- a/NOTICE
+++ b/NOTICE
@@ -3,3 +3,24 @@ Copyright 2017-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+-----------------------------------------------------------------------
+This product contains code form the Prometheus Project:
+
+Data model artifacts for Prometheus.
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+-----------------------------------------------------------------------
+This product contains code form the Apache Maven Wrapper Project:
+
+Apache Maven Wrapper
+Copyright 2013-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The original idea and initial implementation of the maven-wrapper module is derived 
+from the Gradle Wrapper which was written originally by Hans Dockter and Adam Murdoch.
+Copyright 2007 the original author or authors.

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -106,5 +106,6 @@
 * Add a table for metric calculations in the ui doc.
 * Add an explanation for alerting kernel and its in-memory window mechanism.
 * Add more docs for widget details.
+* Fix dependency license's NOTICE and binary jar included issues in the source release.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/136?closed=1)

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -71,6 +71,7 @@ tar czf ${PRODUCT_NAME}-src.tgz \
     --exclude .github \
     --exclude .gitignore \
     --exclude .gitmodules \
+    --exclude .mvn/wrapper/maven-wrapper.jar \
     ${PRODUCT_NAME}
 
 gpg --armor --detach-sig ${PRODUCT_NAME}-src.tgz


### PR DESCRIPTION
I checked: https://github.com/apache/skywalking/blob/77ba2d553d77a4acacd8b2498cb09ea983a9baf4/LICENSE#L215-L225
Only `maven-wrapper` and `Prometheus` need to add notice

this closed #9512 