### PR TITLE
Fix the wrong watch semantics in Kubernetes watchers

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -24,6 +24,9 @@
   downsampling.
 * Do sorting `readLabeledMetricsValues` result forcedly in case the storage(database) doesn't return data consistent
   with the parameter list.
+* Fix the wrong watch semantics in Kubernetes watchers, which causes heavy traffic to API server in some Kubernetes clusters,
+  we should use `Get State and Start at Most Recent` semantic instead of `Start at Exact`
+  because we don't need the changing history events, see https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-watch.
 
 #### UI
 

--- a/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/kubernetes/NamespacedPodListInformer.java
+++ b/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/kubernetes/NamespacedPodListInformer.java
@@ -85,7 +85,7 @@ public enum NamespacedPodListInformer {
         SharedIndexInformer<V1Pod> podSharedIndexInformer = factory.sharedIndexInformerFor(
             params -> coreV1Api.listNamespacedPodCall(
                 podConfig.getNamespace(), null, null, null, null,
-                podConfig.getLabelSelector(), Integer.MAX_VALUE, params.resourceVersion, null, params.timeoutSeconds,
+                podConfig.getLabelSelector(), Integer.MAX_VALUE, null, null, params.timeoutSeconds,
                 params.watch, null
             ),
             V1Pod.class, V1PodList.class

--- a/oap-server/server-configuration/configuration-k8s-configmap/src/main/java/org/apache/skywalking/oap/server/configuration/configmap/ConfigurationConfigmapInformer.java
+++ b/oap-server/server-configuration/configuration-k8s-configmap/src/main/java/org/apache/skywalking/oap/server/configuration/configmap/ConfigurationConfigmapInformer.java
@@ -76,7 +76,7 @@ public class ConfigurationConfigmapInformer {
         SharedIndexInformer<V1ConfigMap> configMapSharedIndexInformer = factory.sharedIndexInformerFor(
             params -> coreV1Api.listNamespacedConfigMapCall(
                 settings.getNamespace(), null, null, null, null, settings.getLabelSelector()
-                , 1, params.resourceVersion, null, params.timeoutSeconds, params.watch, null
+                , 1, null, null, params.timeoutSeconds, params.watch, null
             ),
             V1ConfigMap.class, V1ConfigMapList.class
         );

--- a/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesEndpointWatcher.java
+++ b/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesEndpointWatcher.java
@@ -94,7 +94,7 @@ public enum KubernetesEndpointWatcher implements ResourceEventHandler<V1Endpoint
                 null,
                 null,
                 null,
-                params.resourceVersion,
+                null,
                 null,
                 params.timeoutSeconds,
                 params.watch,

--- a/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesNodeWatcher.java
+++ b/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesNodeWatcher.java
@@ -93,7 +93,7 @@ public enum KubernetesNodeWatcher implements ResourceEventHandler<V1Node> {
                 null,
                 null,
                 null,
-                params.resourceVersion,
+                null,
                 null,
                 params.timeoutSeconds,
                 params.watch,

--- a/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesPodWatcher.java
+++ b/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesPodWatcher.java
@@ -93,7 +93,7 @@ public enum KubernetesPodWatcher implements ResourceEventHandler<V1Pod> {
                 null,
                 null,
                 null,
-                params.resourceVersion,
+                null,
                 null,
                 params.timeoutSeconds,
                 params.watch,

--- a/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesServiceWatcher.java
+++ b/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesServiceWatcher.java
@@ -93,7 +93,7 @@ public enum KubernetesServiceWatcher implements ResourceEventHandler<V1Service> 
                 null,
                 null,
                 null,
-                params.resourceVersion,
+                null,
                 null,
                 params.timeoutSeconds,
                 params.watch,


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
