### PR TITLE
Upgrade CodeQL version to v2

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -46,11 +46,11 @@ jobs:
         submodules: true
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - run: ./mvnw -q -Dmaven.test.skip=true clean install || ./mvnw -q -Dmaven.test.skip=true clean install
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Upgrade CodeQL version to v2.

[shenyu #3907](https://github.com/apache/shenyu/pull/3907)

For more information, see
[Code scanning: deprecation of CodeQL Action v1](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/)