### PR TITLE
Sync ui and add a document for adding menus to booster UI

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -36,6 +36,7 @@
 * Update MySQL dashboard to visualize collected slow SQLs.
 * Add virtual cache dashboard
 * Remove `responseCode` fields of all OAL sources, as well as examples to avoid user's confusion.
+* Remove All from the endpoints selector.
 * Enhance menu configurations to make it easier to change.
 
 #### Documentation

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -36,9 +36,11 @@
 * Update MySQL dashboard to visualize collected slow SQLs.
 * Add virtual cache dashboard
 * Remove `responseCode` fields of all OAL sources, as well as examples to avoid user's confusion.
+* Enhance menu configurations to make it easier to change.
 
 #### Documentation
 
 * Add `metadata-uid` setup doc about Kubernetes coordinator in the cluster management.
+* Add a doc for adding menus to booster UI.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/149?closed=1)

--- a/docs/en/guides/How-to-add-menu.md
+++ b/docs/en/guides/How-to-add-menu.md
@@ -1,0 +1,63 @@
+# How to add a new root menu or sub-menu to booster UI
+
+If you would like to add a new root menu or sub-menu, you should add data to `src/router/data/xx` and add translation contents for the title to `src/locales/lang/xx` in [booster UI](https://github.com/apache/skywalking-booster-ui).
+
+## Add a sub-menu to a root menu
+
+Add configurations to `src/router/data/xx` of the children field, and the configurations should be like this.
+```ts
+{
+  path: "/linux",
+  name: "Linux",
+  meta: {
+    title: "linux",
+    layer: "OS_LINUX",
+  },
+},
+```
+
+If there are Tabs widgets in your dashboards, you should add other configurations to the children field of `src/router/data/xx`.
+```ts
+{
+  path: "/linux/tab/:activeTabIndex",
+  name: "LinuxActiveTabIndex",
+  meta: {
+    title: "linux",
+    notShow: true,
+    layer: "OS_LINUX",
+  },
+},
+```
+
+## Add a root menu to side bar
+
+1. Create a new file called `xxx.ts` in `src/router/data`.
+2. Add configurations to the `xxx.ts`, configurations should be like this.
+```ts
+export default [
+  {
+    path: "",
+    name: "Infrastructure",
+    meta: {
+      title: "infrastructure",
+      icon: "scatter_plot",
+      hasGroup: true,
+    },
+    redirect: "/linux",
+    children: [
+      {
+        path: "/linux",
+        name: "Linux",
+        meta: {
+          title: "linux",
+          layer: "OS_LINUX",
+        },
+      },
+    ],
+  },
+];
+```
+3. import configurations in `src/router/data/index.ts`.
+```ts
+import name from "./xxx";
+```

--- a/docs/en/guides/How-to-add-menu.md
+++ b/docs/en/guides/How-to-add-menu.md
@@ -2,40 +2,12 @@
 
 If you would like to add a new root menu or sub-menu, you should add data to `src/router/data/xx` and add translation contents for the title to `src/locales/lang/xx` in [booster UI](https://github.com/apache/skywalking-booster-ui).
 
-## Add a sub-menu to a root menu
-
-Add configurations to `src/router/data/xx` of the children field, and the configurations should be like this.
-```ts
-{
-  path: "/linux",
-  name: "Linux",
-  meta: {
-    title: "linux",
-    layer: "OS_LINUX",
-  },
-},
-```
-
-If there are Tabs widgets in your dashboards, you should add other configurations to the children field of `src/router/data/xx`.
-```ts
-{
-  path: "/linux/tab/:activeTabIndex",
-  name: "LinuxActiveTabIndex",
-  meta: {
-    title: "linux",
-    notShow: true,
-    layer: "OS_LINUX",
-  },
-},
-```
-
-## Add a root menu to side bar
-
 1. Create a new file called `xxx.ts` in `src/router/data`.
 2. Add configurations to the `xxx.ts`, configurations should be like this.
 ```ts
 export default [
   {
+    // Add `Infrastructure` menu
     path: "",
     name: "Infrastructure",
     meta: {
@@ -45,11 +17,22 @@ export default [
     },
     redirect: "/linux",
     children: [
+      // Add a sub menu of the `Infrastructure`
       {
         path: "/linux",
         name: "Linux",
         meta: {
           title: "linux",
+          layer: "OS_LINUX",
+        },
+      },
+      // If there are Tabs widgets in your dashboards, add following extra configuration to provide static links to the specific tab.
+      {
+        path: "/linux/tab/:activeTabIndex",
+        name: "LinuxActiveTabIndex",
+        meta: {
+          title: "linux",
+          notShow: true,
           layer: "OS_LINUX",
         },
       },

--- a/docs/en/guides/README.md
+++ b/docs/en/guides/README.md
@@ -113,6 +113,7 @@ storage implementor in addition to the official one.
 - [Source and scope extension for new metrics](source-extension.md). For analysis of a new metric which SkyWalking
 hasn't yet provided, add a new receiver.
 You would most likely have to add a new source and scope. To learn how to do this, read the document.
+- If you would like to add a new root menu or sub-menu to booster UI, read the [UI menu control document](How-to-add-menu.md).
 
 ### OAP backend dependency management
 > This section is only applicable to dependencies of the backend module.


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

* Remove All from the endpoints selector.
* Enhance menu configurations to make it easier to change.
* Add a document for adding menus to booster UI.

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
