### PR TITLE
Support `sumPerMinLabeled` in `MAL`

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -62,6 +62,7 @@
   is acceptable in our case.
 * Optimize the query time of tasks in ProfileTaskCache.
 * Fix metrics was put into wrong slot of the window in the alerting kernel.
+* Support `sumPerMinLabeled` in `MAL`.
 
 #### UI
 

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/Analyzer.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/Analyzer.java
@@ -34,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.CaseUtils;
 import org.apache.skywalking.oap.meter.analyzer.dsl.DSL;
 import org.apache.skywalking.oap.meter.analyzer.dsl.DownsamplingType;
 import org.apache.skywalking.oap.meter.analyzer.dsl.Expression;
@@ -247,8 +248,8 @@ public class Analyzer {
     private void createMetric(final ScopeType scopeType,
                               final String dataType,
                               final DownsamplingType downsamplingType) {
-        String functionName = String.format(
-            "%s%s", downsamplingType.toString().toLowerCase(), StringUtils.capitalize(dataType));
+        String downSamplingStr = CaseUtils.toCamelCase(downsamplingType.toString().toLowerCase(), false, '_');
+        String functionName = String.format("%s%s", downSamplingStr, StringUtils.capitalize(dataType));
         meterSystem.create(metricName, functionName, scopeType);
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sumpermin/SumPerMinLabeledFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sumpermin/SumPerMinLabeledFunction.java
@@ -20,7 +20,6 @@ package org.apache.skywalking.oap.server.core.analysis.meter.function.sumpermin;
 
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.UnexpectedException;
 import org.apache.skywalking.oap.server.core.analysis.manual.instance.InstanceTraffic;
@@ -28,7 +27,8 @@ import org.apache.skywalking.oap.server.core.analysis.meter.Meter;
 import org.apache.skywalking.oap.server.core.analysis.meter.MeterEntity;
 import org.apache.skywalking.oap.server.core.analysis.meter.function.AcceptableValue;
 import org.apache.skywalking.oap.server.core.analysis.meter.function.MeterFunction;
-import org.apache.skywalking.oap.server.core.analysis.metrics.LongValueHolder;
+import org.apache.skywalking.oap.server.core.analysis.metrics.DataTable;
+import org.apache.skywalking.oap.server.core.analysis.metrics.LabeledValueHolder;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
 import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.Entrance;
 import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.SourceFrom;
@@ -36,15 +36,16 @@ import org.apache.skywalking.oap.server.core.query.sql.Function;
 import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
 import org.apache.skywalking.oap.server.core.storage.annotation.BanyanDB;
 import org.apache.skywalking.oap.server.core.storage.annotation.Column;
+import org.apache.skywalking.oap.server.core.storage.annotation.ElasticSearch;
 import org.apache.skywalking.oap.server.core.storage.type.Convert2Entity;
 import org.apache.skywalking.oap.server.core.storage.type.Convert2Storage;
 import org.apache.skywalking.oap.server.core.storage.type.StorageBuilder;
 
 import java.util.Objects;
 
-@ToString
-@MeterFunction(functionName = "sumPerMin")
-public abstract class SumPerMinFunction extends Meter implements AcceptableValue<Long>, LongValueHolder {
+@MeterFunction(functionName = "sumPerMinLabeled")
+public abstract class SumPerMinLabeledFunction extends Meter implements AcceptableValue<DataTable>, LabeledValueHolder {
+
     protected static final String VALUE = "value";
     protected static final String TOTAL = "total";
 
@@ -62,33 +63,53 @@ public abstract class SumPerMinFunction extends Meter implements AcceptableValue
     @Getter
     @Setter
     @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Avg)
-    private long value;
+    @ElasticSearch.Column(columnAlias = "datatable_value")
+    private DataTable value = new DataTable(30);
 
     @Getter
     @Setter
     @Column(columnName = TOTAL, storageOnly = true)
-    private long total;
+    @ElasticSearch.Column(columnAlias = "datatable_total")
+    private DataTable total = new DataTable(30);
 
     @Entrance
-    public final void combine(@SourceFrom long value) {
-        this.total += value;
+    public final void combine(@SourceFrom DataTable value) {
+        this.total.append(value);
+    }
+
+    @Override
+    public void accept(MeterEntity entity, DataTable value) {
+        setEntityId(entity.id());
+        setServiceId(entity.serviceId());
+        this.total.append(value);
+    }
+
+    @Override
+    public Class<? extends StorageBuilder> builder() {
+        return SumPerMinLabeledStorageBuilder.class;
     }
 
     @Override
     public boolean combine(Metrics metrics) {
-        final SumPerMinFunction sumPerMinFunction = (SumPerMinFunction) metrics;
-        combine(sumPerMinFunction.getTotal());
+        final SumPerMinLabeledFunction sumPerMinLabeledFunction = (SumPerMinLabeledFunction) metrics;
+        combine(sumPerMinLabeledFunction.getTotal());
         return true;
     }
 
     @Override
     public void calculate() {
-        setValue(this.total / getDurationInMinute());
+        for (String key : total.keys()) {
+            final Long val = total.get(key);
+            if (Objects.isNull(val)) {
+                continue;
+            }
+            value.put(key, val / getDurationInMinute());
+        }
     }
 
     @Override
     public Metrics toHour() {
-        final SumPerMinFunction metrics = (SumPerMinFunction) createNew();
+        final SumPerMinLabeledFunction metrics = (SumPerMinLabeledFunction) createNew();
         metrics.setEntityId(getEntityId());
         metrics.setTimeBucket(toTimeBucketInHour());
         metrics.setServiceId(getServiceId());
@@ -98,7 +119,7 @@ public abstract class SumPerMinFunction extends Meter implements AcceptableValue
 
     @Override
     public Metrics toDay() {
-        final SumPerMinFunction metrics = (SumPerMinFunction) createNew();
+        final SumPerMinLabeledFunction metrics = (SumPerMinLabeledFunction) createNew();
         metrics.setEntityId(getEntityId());
         metrics.setTimeBucket(toTimeBucketInDay());
         metrics.setServiceId(getServiceId());
@@ -107,14 +128,14 @@ public abstract class SumPerMinFunction extends Meter implements AcceptableValue
     }
 
     @Override
-    public int remoteHashCode() {
-        return getEntityId().hashCode();
+    protected String id0() {
+        return getTimeBucket() + Const.ID_CONNECTOR + getEntityId();
     }
 
     @Override
     public void deserialize(RemoteData remoteData) {
-        setTotal(remoteData.getDataLongs(0));
-        setTimeBucket(remoteData.getDataLongs(1));
+        setTotal(new DataTable(remoteData.getDataObjectStrings(0)));
+        setTimeBucket(remoteData.getDataLongs(0));
 
         setEntityId(remoteData.getDataStrings(0));
         setServiceId(remoteData.getDataStrings(1));
@@ -124,7 +145,7 @@ public abstract class SumPerMinFunction extends Meter implements AcceptableValue
     public RemoteData.Builder serialize() {
         final RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
 
-        remoteBuilder.addDataLongs(getTotal());
+        remoteBuilder.addDataObjectStrings(total.toStorageData());
         remoteBuilder.addDataLongs(getTimeBucket());
 
         remoteBuilder.addDataStrings(getEntityId());
@@ -133,33 +154,22 @@ public abstract class SumPerMinFunction extends Meter implements AcceptableValue
     }
 
     @Override
-    protected String id0() {
-        return getTimeBucket() + Const.ID_CONNECTOR + getEntityId();
+    public int remoteHashCode() {
+        return getEntityId().hashCode();
     }
 
-    @Override
-    public void accept(MeterEntity entity, Long value) {
-        setEntityId(entity.id());
-        setServiceId(entity.serviceId());
-        setTotal(getTotal() + value);
-    }
+    public static class SumPerMinLabeledStorageBuilder implements StorageBuilder<SumPerMinLabeledFunction> {
 
-    @Override
-    public Class<? extends StorageBuilder> builder() {
-        return SumPerMinStorageBuilder.class;
-    }
-
-    public static class SumPerMinStorageBuilder implements StorageBuilder<SumPerMinFunction> {
         @Override
-        public SumPerMinFunction storage2Entity(final Convert2Entity converter) {
-            final SumPerMinFunction metrics = new SumPerMinFunction() {
+        public SumPerMinLabeledFunction storage2Entity(Convert2Entity converter) {
+            final SumPerMinLabeledFunction metrics = new SumPerMinLabeledFunction() {
                 @Override
-                public AcceptableValue<Long> createNew() {
+                public AcceptableValue<DataTable> createNew() {
                     throw new UnexpectedException("createNew should not be called");
                 }
             };
-            metrics.setValue(((Number) converter.get(VALUE)).longValue());
-            metrics.setTotal(((Number) converter.get(TOTAL)).longValue());
+            metrics.setValue(new DataTable((String) converter.get(VALUE)));
+            metrics.setTotal(new DataTable((String) converter.get(TOTAL)));
             metrics.setTimeBucket(((Number) converter.get(TIME_BUCKET)).longValue());
             metrics.setServiceId((String) converter.get(InstanceTraffic.SERVICE_ID));
             metrics.setEntityId((String) converter.get(ENTITY_ID));
@@ -167,30 +177,12 @@ public abstract class SumPerMinFunction extends Meter implements AcceptableValue
         }
 
         @Override
-        public void entity2Storage(final SumPerMinFunction storageData, final Convert2Storage converter) {
+        public void entity2Storage(SumPerMinLabeledFunction storageData, Convert2Storage converter) {
             converter.accept(VALUE, storageData.getValue());
             converter.accept(TOTAL, storageData.getTotal());
             converter.accept(TIME_BUCKET, storageData.getTimeBucket());
             converter.accept(InstanceTraffic.SERVICE_ID, storageData.getServiceId());
             converter.accept(ENTITY_ID, storageData.getEntityId());
         }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof SumPerMinFunction)) {
-            return false;
-        }
-        final SumPerMinFunction function = (SumPerMinFunction) o;
-        return Objects.equals(getEntityId(), function.getEntityId())
-            && Objects.equals(getTimeBucket(), function.getTimeBucket());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getEntityId(), getTimeBucket());
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sumpermin/SumPerMinLabeledFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sumpermin/SumPerMinLabeledFunction.java
@@ -46,8 +46,8 @@ import java.util.Objects;
 @MeterFunction(functionName = "sumPerMinLabeled")
 public abstract class SumPerMinLabeledFunction extends Meter implements AcceptableValue<DataTable>, LabeledValueHolder {
 
-    protected static final String VALUE = "value";
-    protected static final String TOTAL = "total";
+    protected static final String VALUE = "datatable_value";
+    protected static final String TOTAL = "datatable_total";
 
     @Setter
     @Getter
@@ -62,14 +62,12 @@ public abstract class SumPerMinLabeledFunction extends Meter implements Acceptab
 
     @Getter
     @Setter
-    @Column(columnName = VALUE, dataType = Column.ValueDataType.COMMON_VALUE, function = Function.Avg)
-    @ElasticSearch.Column(columnAlias = "datatable_value")
+    @Column(columnName = VALUE, dataType = Column.ValueDataType.LABELED_VALUE, storageOnly = true)
     private DataTable value = new DataTable(30);
 
     @Getter
     @Setter
     @Column(columnName = TOTAL, storageOnly = true)
-    @ElasticSearch.Column(columnAlias = "datatable_total")
     private DataTable total = new DataTable(30);
 
     @Entrance

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sumpermin/SumPerMinLabeledFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sumpermin/SumPerMinLabeledFunction.java
@@ -32,11 +32,9 @@ import org.apache.skywalking.oap.server.core.analysis.metrics.LabeledValueHolder
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
 import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.Entrance;
 import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.SourceFrom;
-import org.apache.skywalking.oap.server.core.query.sql.Function;
 import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
 import org.apache.skywalking.oap.server.core.storage.annotation.BanyanDB;
 import org.apache.skywalking.oap.server.core.storage.annotation.Column;
-import org.apache.skywalking.oap.server.core.storage.annotation.ElasticSearch;
 import org.apache.skywalking.oap.server.core.storage.type.Convert2Entity;
 import org.apache.skywalking.oap.server.core.storage.type.Convert2Storage;
 import org.apache.skywalking.oap.server.core.storage.type.StorageBuilder;

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sumpermin/SumPerMinLabeledFunctionTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/meter/function/sumpermin/SumPerMinLabeledFunctionTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.analysis.meter.function.sumpermin;
+
+import org.apache.skywalking.oap.server.core.analysis.Layer;
+import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
+import org.apache.skywalking.oap.server.core.analysis.meter.MeterEntity;
+import org.apache.skywalking.oap.server.core.analysis.meter.function.AcceptableValue;
+import org.apache.skywalking.oap.server.core.analysis.metrics.DataTable;
+import org.apache.skywalking.oap.server.core.config.NamingControl;
+import org.apache.skywalking.oap.server.core.config.group.EndpointNameGrouping;
+import org.apache.skywalking.oap.server.core.storage.type.HashMapConverter;
+import org.apache.skywalking.oap.server.core.storage.type.StorageBuilder;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SumPerMinLabeledFunctionTest {
+
+    private SumPerMinLabeledFunctionInst function;
+    private DataTable table1;
+    private DataTable table2;
+
+    @BeforeClass
+    public static void setup() {
+        MeterEntity.setNamingControl(
+            new NamingControl(512, 512, 512, new EndpointNameGrouping()));
+    }
+
+    @Before
+    public void before() {
+        function = new SumPerMinLabeledFunctionInst();
+        function.setTimeBucket(TimeBucket.getMinuteTimeBucket(System.currentTimeMillis()));
+
+        table1 = new DataTable();
+        table1.put("200", 100L);
+        table1.put("300", 50L);
+
+        table2 = new DataTable();
+        table2.put("200", 120L);
+        table2.put("300", 17L);
+        table2.put("400", 77L);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        MeterEntity.setNamingControl(null);
+    }
+
+    @Test
+    public void testAccept() {
+        function.accept(MeterEntity.newService("sum_sync_time", Layer.GENERAL), table1);
+        function.calculate();
+        assertThat(function.getValue(), is(table1));
+        function.accept(MeterEntity.newService("sum_sync_time", Layer.GENERAL), table2);
+        function.calculate();
+        assertThat(function.getValue(), is(table1.append(table2)));
+    }
+
+    @Test
+    public void testCalculate() {
+        function.accept(MeterEntity.newService("sum_sync_time", Layer.GENERAL), table1);
+        function.accept(MeterEntity.newService("sum_sync_time", Layer.GENERAL), table2);
+        function.calculate();
+        assertThat(function.getValue(), is(table1.append(table2)));
+    }
+
+    @Test
+    public void testHour() {
+        function.setTimeBucket(TimeBucket.getMinuteTimeBucket(System.currentTimeMillis()));
+        function.accept(MeterEntity.newService("sum_sync_time", Layer.GENERAL), table1);
+        function.accept(MeterEntity.newService("sum_sync_time", Layer.GENERAL), table2);
+        function.calculate();
+        final SumPerMinLabeledFunction hourFunction = (SumPerMinLabeledFunction) function.toHour();
+        hourFunction.calculate();
+        final DataTable result = new DataTable();
+        result.append(table1);
+        result.append(table2);
+        for (String key : result.keys()) {
+            result.put(key, result.get(key) / 60);
+        }
+        assertThat(hourFunction.getValue(), is(result));
+    }
+
+    @Test
+    public void testSerialize() {
+        function.accept(MeterEntity.newService("sum_sync_time", Layer.GENERAL), table1);
+        SumPerMinLabeledFunction function2 = Mockito.spy(SumPerMinLabeledFunction.class);
+        function2.deserialize(function.serialize().build());
+        assertThat(function2.getEntityId(), is(function.getEntityId()));
+        assertThat(function2.getTimeBucket(), is(function.getTimeBucket()));
+    }
+
+    @Test
+    public void testBuilder() throws IllegalAccessException, InstantiationException {
+        function.accept(MeterEntity.newService("sum_sync_time", Layer.GENERAL), table1);
+        function.calculate();
+        StorageBuilder<SumPerMinLabeledFunction> storageBuilder = function.builder().newInstance();
+
+        final HashMapConverter.ToStorage toStorage = new HashMapConverter.ToStorage();
+        storageBuilder.entity2Storage(function, toStorage);
+        final Map<String, Object> map = toStorage.obtain();
+        map.put(SumPerMinLabeledFunction.VALUE, ((DataTable) map.get(SumPerMinLabeledFunction.VALUE)).toStorageData());
+        map.put(SumPerMinLabeledFunction.TOTAL, ((DataTable) map.get(SumPerMinLabeledFunction.TOTAL)).toStorageData());
+
+        SumPerMinLabeledFunction function2 = storageBuilder.storage2Entity(new HashMapConverter.ToEntity(map));
+        assertThat(function2.getValue(), is(function.getValue()));
+    }
+
+    private static class SumPerMinLabeledFunctionInst extends SumPerMinLabeledFunction {
+        @Override
+        public AcceptableValue<DataTable> createNew() {
+            return new SumPerMinLabeledFunctionInst();
+        }
+    }
+}


### PR DESCRIPTION
### Support `sumPerMinLabeled` in `MAL`
When implementing the https://github.com/apache/skywalking/issues/9802, we can generate the metrics that calculate the count of response status code in minutes, so the `sumPerMinLabeled` needs to be added. 

- [x] Tests(including UT, IT, E2E) are added to verify the new feature.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
