### PR TITLE
Reduce the buffer size(queue) of MAL(only) metric streams

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -82,6 +82,7 @@
 * Support Python runtime metrics analysis.
 * Support `sampledTrace` in LAL.
 * Support multiple rules with different names under the same layer of LAL script.
+* (Optimization) Reduce the buffer size(queue) of MAL(only) metric streams. Set L1 queue size as 1/20, L2 queue size as 1/2.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/StreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/StreamProcessor.java
@@ -18,12 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.analysis;
 
-import org.apache.skywalking.oap.server.core.storage.StorageException;
-import org.apache.skywalking.oap.server.library.module.ModuleDefineHolder;
-
 public interface StreamProcessor<STREAM> {
 
     void in(STREAM stream);
-
-    void create(ModuleDefineHolder moduleDefineHolder, Stream stream, Class<? extends STREAM> streamClass) throws StorageException;
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/ManagementStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/ManagementStreamProcessor.java
@@ -60,7 +60,6 @@ public class ManagementStreamProcessor implements StreamProcessor<ManagementData
         }
     }
 
-    @Override
     public void create(final ModuleDefineHolder moduleDefineHolder, final Stream stream, final Class<? extends ManagementData> streamClass) throws StorageException {
         final StorageBuilderFactory storageBuilderFactory = moduleDefineHolder.find(StorageModule.NAME)
                                                                               .provider()

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricStreamKind.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricStreamKind.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.analysis.worker;
+
+/**
+ * MetricStreamKind represents the kind of metric character.
+ */
+public enum MetricStreamKind {
+    /**
+     * Metric built by {@link org.apache.skywalking.oap.server.core.oal.rt.OALEngine}
+     *
+     * OAL is SkyWalking native metrics from SkyWalking native analyzers, for traces and service mesh logs.
+     * The {@link org.apache.skywalking.oap.server.core.source.Source} implementations represent the raw traffic.
+     *
+     * The significant different between OAL and {@link #MAL} type is, the traffic load of OAL metrics is much more.
+     * So,in the stream process, kernel assigned larger buffer and more resources for this kind.
+     */
+    OAL,
+    /**
+     * Metric built by {@link org.apache.skywalking.oap.server.core.analysis.meter.MeterSystem}
+     *
+     * MAL metrics are from existing metric system, such as SkyWalking meter, Prometheus, OpenTelemetry
+     */
+    MAL
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
@@ -50,13 +50,26 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
     private CounterMetrics aggregationCounter;
     private long lastSendTime = 0;
 
-    MetricsAggregateWorker(ModuleDefineHolder moduleDefineHolder, AbstractWorker<Metrics> nextWorker,
-                           String modelName, long l1FlushPeriod) {
+    MetricsAggregateWorker(ModuleDefineHolder moduleDefineHolder,
+                           AbstractWorker<Metrics> nextWorker,
+                           String modelName,
+                           long l1FlushPeriod,
+                           MetricStreamKind kind) {
         super(moduleDefineHolder);
         this.nextWorker = nextWorker;
         this.mergeDataCache = new MergableBufferedData();
         String name = "METRICS_L1_AGGREGATION";
-        this.dataCarrier = new DataCarrier<>("MetricsAggregateWorker." + modelName, name, 2, 10000);
+        int queueChannelSize = 2;
+        int queueBufferSize = 10_000;
+        if (MetricStreamKind.MAL == kind) {
+            // In MAL meter streaming, the load of data flow is much less as they are statistics already,
+            // but in OAL sources, they are raw data.
+            // Set the buffer(size of queue) as 1/20 to reduce unnecessary resource costs.
+            queueChannelSize = 1;
+            queueBufferSize = 1_000;
+        }
+        this.dataCarrier = new DataCarrier<>(
+            "MetricsAggregateWorker." + modelName, name, queueChannelSize, queueBufferSize);
 
         BulkConsumePool.Creator creator = new BulkConsumePool.Creator(
             name, BulkConsumePool.Creator.recommendMaxSize() * 2, 20);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsStreamProcessor.java
@@ -106,23 +106,31 @@ public class MetricsStreamProcessor implements StreamProcessor<Metrics> {
     }
 
     /**
-     * Create the workers and work flow for every metrics.
+     * Create the workers and work flow for OAL metrics.
      *
      * @param moduleDefineHolder pointer of the module define.
      * @param stream             definition of the metrics class.
      * @param metricsClass       data type of the streaming calculation.
      */
-    @Override
     public void create(ModuleDefineHolder moduleDefineHolder,
                        Stream stream,
                        Class<? extends Metrics> metricsClass) throws StorageException {
-        this.create(moduleDefineHolder, StreamDefinition.from(stream), metricsClass);
+        this.create(moduleDefineHolder, StreamDefinition.from(stream), metricsClass, MetricStreamKind.OAL);
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Create the workers and work flow for MAL meter
+     */
     public void create(ModuleDefineHolder moduleDefineHolder,
                        StreamDefinition stream,
-                       Class<? extends Metrics> metricsClass) throws StorageException {
+                       Class<? extends Metrics> meterClass) throws StorageException {
+        this.create(moduleDefineHolder, stream, meterClass, MetricStreamKind.MAL);
+    }
+
+    private void create(ModuleDefineHolder moduleDefineHolder,
+                        StreamDefinition stream,
+                        Class<? extends Metrics> metricsClass,
+                        MetricStreamKind kind) throws StorageException {
         final StorageBuilderFactory storageBuilderFactory = moduleDefineHolder.find(StorageModule.NAME)
                                                                               .provider()
                                                                               .getService(StorageBuilderFactory.class);
@@ -133,7 +141,8 @@ public class MetricsStreamProcessor implements StreamProcessor<Metrics> {
         IMetricsDAO metricsDAO;
         try {
             metricsDAO = storageDAO.newMetricsDao(builder.getDeclaredConstructor().newInstance());
-        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException |
+                 InvocationTargetException e) {
             throw new UnexpectedException("Create " + stream.getBuilder().getSimpleName() + " metrics DAO failure.", e);
         }
 
@@ -165,14 +174,14 @@ public class MetricsStreamProcessor implements StreamProcessor<Metrics> {
                     metricsClass, stream.getScopeId(), new Storage(stream.getName(), timeRelativeID, DownSampling.Hour),
                     false
                 );
-                hourPersistentWorker = downSamplingWorker(moduleDefineHolder, metricsDAO, model, supportUpdate);
+                hourPersistentWorker = downSamplingWorker(moduleDefineHolder, metricsDAO, model, supportUpdate, kind);
             }
             if (configService.shouldToDay()) {
                 Model model = modelSetter.add(
                     metricsClass, stream.getScopeId(), new Storage(stream.getName(), timeRelativeID, DownSampling.Day),
                     false
                 );
-                dayPersistentWorker = downSamplingWorker(moduleDefineHolder, metricsDAO, model, supportUpdate);
+                dayPersistentWorker = downSamplingWorker(moduleDefineHolder, metricsDAO, model, supportUpdate, kind);
             }
 
             transWorker = new MetricsTransWorker(
@@ -184,7 +193,7 @@ public class MetricsStreamProcessor implements StreamProcessor<Metrics> {
             false
         );
         MetricsPersistentWorker minutePersistentWorker = minutePersistentWorker(
-            moduleDefineHolder, metricsDAO, model, transWorker, supportUpdate);
+            moduleDefineHolder, metricsDAO, model, transWorker, supportUpdate, kind);
 
         String remoteReceiverWorkerName = stream.getName() + "_rec";
         IWorkerInstanceSetter workerInstanceSetter = moduleDefineHolder.find(CoreModule.NAME)
@@ -194,7 +203,7 @@ public class MetricsStreamProcessor implements StreamProcessor<Metrics> {
 
         MetricsRemoteWorker remoteWorker = new MetricsRemoteWorker(moduleDefineHolder, remoteReceiverWorkerName);
         MetricsAggregateWorker aggregateWorker = new MetricsAggregateWorker(
-            moduleDefineHolder, remoteWorker, stream.getName(), l1FlushPeriod);
+            moduleDefineHolder, remoteWorker, stream.getName(), l1FlushPeriod, kind);
 
         entryWorkers.put(metricsClass, aggregateWorker);
     }
@@ -203,13 +212,14 @@ public class MetricsStreamProcessor implements StreamProcessor<Metrics> {
                                                            IMetricsDAO metricsDAO,
                                                            Model model,
                                                            MetricsTransWorker transWorker,
-                                                           boolean supportUpdate) {
+                                                           boolean supportUpdate,
+                                                           MetricStreamKind kind) {
         AlarmNotifyWorker alarmNotifyWorker = new AlarmNotifyWorker(moduleDefineHolder);
         ExportMetricsWorker exportWorker = new ExportMetricsWorker(moduleDefineHolder);
 
         MetricsPersistentWorker minutePersistentWorker = new MetricsPersistentWorker(
             moduleDefineHolder, model, metricsDAO, alarmNotifyWorker, exportWorker, transWorker,
-            enableDatabaseSession, supportUpdate, storageSessionTimeout, metricsDataTTL
+            enableDatabaseSession, supportUpdate, storageSessionTimeout, metricsDataTTL, kind
         );
         persistentWorkers.add(minutePersistentWorker);
 
@@ -219,10 +229,11 @@ public class MetricsStreamProcessor implements StreamProcessor<Metrics> {
     private MetricsPersistentWorker downSamplingWorker(ModuleDefineHolder moduleDefineHolder,
                                                        IMetricsDAO metricsDAO,
                                                        Model model,
-                                                       boolean supportUpdate) {
+                                                       boolean supportUpdate,
+                                                       MetricStreamKind kind) {
         MetricsPersistentWorker persistentWorker = new MetricsPersistentWorker(
             moduleDefineHolder, model, metricsDAO,
-            enableDatabaseSession, supportUpdate, storageSessionTimeout, metricsDataTTL
+            enableDatabaseSession, supportUpdate, storageSessionTimeout, metricsDataTTL, kind
         );
         persistentWorkers.add(persistentWorker);
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/NoneStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/NoneStreamProcessor.java
@@ -60,7 +60,6 @@ public class NoneStreamProcessor implements StreamProcessor<NoneStream> {
         }
     }
 
-    @Override
     public void create(ModuleDefineHolder moduleDefineHolder, Stream stream, Class<? extends NoneStream> streamClass) throws StorageException {
         final StorageBuilderFactory storageBuilderFactory = moduleDefineHolder.find(StorageModule.NAME)
                                                                               .provider()

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/RecordStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/RecordStreamProcessor.java
@@ -56,8 +56,6 @@ public class RecordStreamProcessor implements StreamProcessor<Record> {
         }
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
     public void create(ModuleDefineHolder moduleDefineHolder, Stream stream, Class<? extends Record> recordClass) throws StorageException {
         final StorageBuilderFactory storageBuilderFactory = moduleDefineHolder.find(StorageModule.NAME)
                                                                               .provider()

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/TopNStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/TopNStreamProcessor.java
@@ -71,8 +71,6 @@ public class TopNStreamProcessor implements StreamProcessor<TopN> {
         this.topNWorkerReportCycle = topNWorkerReportCycle;
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
     public void create(ModuleDefineHolder moduleDefineHolder,
                        Stream stream,
                        Class<? extends TopN> topNClass) throws StorageException {


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

(Optimization) Reduce the buffer size(queue) of MAL(only) metric streams. Set L1 queue size as 1/20, L2 queue size as 1/2.

In MAL meter streaming, the load of data flow is much less as they are statistics already,
but in OAL sources, they are raw data.Set the buffer(size of queue) as 1/2 to reduce unnecessary resource costs.