### PR TITLE
Silent NPE fix

### DIFF
--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/BatchProcessEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/BatchProcessEsDAO.java
@@ -86,7 +86,9 @@ public class BatchProcessEsDAO extends EsDAO implements IBatchDAO {
 
     @Override
     public void endOfFlush() {
-        // Flush forcedly due to this kind of metrics has been pushed into the bulk processor.
-        bulkProcessor.flush();
+        // Flush forcibly due to this kind of metrics has been pushed into the bulk processor.
+        if (bulkProcessor != null) {
+            bulkProcessor.flush();
+        }
     }
 }


### PR DESCRIPTION
I don't think this change has much affect but noticed that a NPE was being thrown when https://github.com/apache/skywalking/blob/d32a318637bc506364928456aff0f5b02f9bc9c9/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/PersistenceTimer.java#L129-L131 is called on the first pass. Since `bulkProcessor` isn't set till https://github.com/apache/skywalking/blob/d32a318637bc506364928456aff0f5b02f9bc9c9/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/PersistenceTimer.java#L135 so calling `endOfFlush` throws silent NPE.