### PR TITLE
Optimize MQ Topology analysis. Use entry span's peer from the consumer side as source service.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -96,7 +96,7 @@
   * Optimize data binary parse methods in *LogQueryDAO
   * Support different indexType
   * Support configuration for TTL and (block|segment) intervals
-* Optimize MQ Topology to organize peer (in consumer EntrySpan) as source service when no producer instrumentation 
+* Optimize MQ Topology analysis. Use entry span's peer from the consumer side as source service when no producer instrumentation(no cross-process reference). 
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -96,6 +96,7 @@
   * Optimize data binary parse methods in *LogQueryDAO
   * Support different indexType
   * Support configuration for TTL and (block|segment) intervals
+* Optimize MQ Topology to organize peer (in consumer EntrySpan) as source service when no producer instrumentation 
 
 #### UI
 

--- a/docs/en/setup/service-agent/virtual-mq.md
+++ b/docs/en/setup/service-agent/virtual-mq.md
@@ -13,3 +13,4 @@ The MQ operation span should have
 - Tag key = `mq.queue`, value = MQ queue name
 - Tag key = `mq.topic`, value = MQ queue topic , it's optional as some MQ don't have topic concept.
 - Tag key = `transmission.latency`, value = Transmission latency from consumer to producer
+- Set `peer` for ExitSpan (at consumer side) ,because producer might not be instrumented  

--- a/docs/en/setup/service-agent/virtual-mq.md
+++ b/docs/en/setup/service-agent/virtual-mq.md
@@ -13,4 +13,4 @@ The MQ operation span should have
 - Tag key = `mq.queue`, value = MQ queue name
 - Tag key = `mq.topic`, value = MQ queue topic , it's optional as some MQ don't have topic concept.
 - Tag key = `transmission.latency`, value = Transmission latency from consumer to producer
-- Set `peer` for EntrySpan (at consumer side) ,because producer might not be instrumented  
+- Set `peer` at both sides(producer and consumer). And the value of peer should represent the MQ server cluster.

--- a/docs/en/setup/service-agent/virtual-mq.md
+++ b/docs/en/setup/service-agent/virtual-mq.md
@@ -13,4 +13,4 @@ The MQ operation span should have
 - Tag key = `mq.queue`, value = MQ queue name
 - Tag key = `mq.topic`, value = MQ queue topic , it's optional as some MQ don't have topic concept.
 - Tag key = `transmission.latency`, value = Transmission latency from consumer to producer
-- Set `peer` for ExitSpan (at consumer side) ,because producer might not be instrumented  
+- Set `peer` for EntrySpan (at consumer side) ,because producer might not be instrumented  

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/RPCAnalysisListener.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/RPCAnalysisListener.java
@@ -125,6 +125,21 @@ public class RPCAnalysisListener extends CommonAnalysisListener implements Entry
                 setPublicAttrs(sourceBuilder, span);
                 callingInTraffic.add(sourceBuilder);
             }
+        } else if (span.getSpanLayer() == SpanLayer.MQ && StringUtil.isNotBlank(span.getPeer())) {
+            // For MQ , if there is no producer side instrumentation , and consumer has peer , we set the peer as source service name
+            RPCTrafficSourceBuilder sourceBuilder = new RPCTrafficSourceBuilder(namingControl);
+            sourceBuilder.setSourceServiceName(span.getPeer());
+            sourceBuilder.setSourceServiceInstanceName(span.getPeer());
+            sourceBuilder.setDestEndpointName(span.getOperationName());
+            sourceBuilder.setSourceLayer(Layer.MQ);
+            sourceBuilder.setDestEndpointName(span.getOperationName());
+            sourceBuilder.setDestServiceInstanceName(segmentObject.getServiceInstance());
+            sourceBuilder.setDestServiceName(segmentObject.getService());
+            sourceBuilder.setDestLayer(identifyServiceLayer(span.getSpanLayer()));
+            sourceBuilder.setDetectPoint(DetectPoint.SERVER);
+            sourceBuilder.setComponentId(span.getComponentId());
+            setPublicAttrs(sourceBuilder, span);
+            callingInTraffic.add(sourceBuilder);
         } else {
             RPCTrafficSourceBuilder sourceBuilder = new RPCTrafficSourceBuilder(namingControl);
             sourceBuilder.setSourceServiceName(Const.USER_SERVICE_NAME);
@@ -249,7 +264,7 @@ public class RPCAnalysisListener extends CommonAnalysisListener implements Entry
             sourceReceiver.receive(callingIn.toServiceInstanceRelation());
             // Service is equivalent to endpoint in FaaS (function as a service)
             // Don't generate endpoint and endpoint dependency to avoid unnecessary costs.
-            if (Layer.FAAS != callingIn.getDestLayer()) {        
+            if (Layer.FAAS != callingIn.getDestLayer()) {
                 sourceReceiver.receive(callingIn.toEndpoint());
                 EndpointRelation endpointRelation = callingIn.toEndpointRelation();
                 /*

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/RPCAnalysisListener.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/RPCAnalysisListener.java
@@ -126,7 +126,7 @@ public class RPCAnalysisListener extends CommonAnalysisListener implements Entry
                 callingInTraffic.add(sourceBuilder);
             }
         } else if (span.getSpanLayer() == SpanLayer.MQ && StringUtil.isNotBlank(span.getPeer())) {
-            // For MQ , if there is no producer side instrumentation , and consumer has peer , we set the peer as source service name
+            // For MQ, if there is no producer-side instrumentation, we set the existing peer as the source service name.
             RPCTrafficSourceBuilder sourceBuilder = new RPCTrafficSourceBuilder(namingControl);
             sourceBuilder.setSourceServiceName(span.getPeer());
             sourceBuilder.setSourceServiceInstanceName(span.getPeer());

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/vservice/VirtualMQProcessor.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/vservice/VirtualMQProcessor.java
@@ -45,6 +45,7 @@ public class VirtualMQProcessor implements VirtualServiceProcessor {
 
     private final NamingControl namingControl;
     private final List<Source> sourceList = new ArrayList<>();
+    private static final String UNKNOWN_PEER = "unknown";
 
     @Override
     public void prepareVSIfNecessary(final SpanObject span, final SegmentObject segmentObject) {
@@ -63,7 +64,9 @@ public class VirtualMQProcessor implements VirtualServiceProcessor {
                                     .stream()
                                     .findFirst()
                                     .map(SegmentReference::getNetworkAddressUsedAtPeer)
-                                    .orElse(null);
+                                    .filter(StringUtil::isNotBlank)
+                                    .orElseGet(
+                                        () -> StringUtil.isBlank(span.getPeer()) ? UNKNOWN_PEER : span.getPeer());
             serviceName = namingControl.formatServiceName(peer);
         } else {
             mqOperation = MQOperation.Produce;


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).


As discussion in  https://github.com/apache/skywalking-java/pull/369#discussion_r1011774721 

If there is no producer side instrumentation, we organize `peer` (in consumer EntrySpan ) as source name , virtual mq service name 


![image](https://user-images.githubusercontent.com/3917424/200153222-64851095-66f8-4e6d-baae-3377e0041ad7.png)

The data flow in above screenshot  is  `127.0.0.1:5672 (mq  server )-> Your_ApplicationName (as  consumer )`



