### PR TITLE
Remove `lengthEnvVariable` for `Column` as it never works as expected

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -105,9 +105,10 @@
 * Support span attached event concept in Zipkin and SkyWalking trace query.
 * Support span attached events on Zipkin lens UI.
 * Force UTF-8 encoding in `JsonLogHandler` of `kafka-fetcher-plugin`.
-* Fix max length to 512 of entity, instance and endpoint IDs in trace, log, profiling, topN tables(JDBC storages). The value was 200 by default. 
+* Fix max length to 512 of entity, instance and endpoint IDs in trace, log, profiling, topN tables(JDBC storages). The value was 200 by default.
 * Add component IDs(135, 136, 137) for EventMesh server and client-side plugins.
 * Bump up Kafka client to 2.8.1 to fix CVE-2021-38153.
+* Remove `lengthEnvVariable` for `Column` as it never works as expected.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/cache/TopNCacheReadCommand.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/cache/TopNCacheReadCommand.java
@@ -41,7 +41,7 @@ public class TopNCacheReadCommand extends TopN {
     private String id;
     @Getter
     @Setter
-    @Column(columnName = STATEMENT, length = 2000, lengthEnvVariable = "SW_SLOW_DB_THRESHOLD", storageOnly = true)
+    @Column(columnName = STATEMENT, length = 2000, storageOnly = true)
     private String command;
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/cache/TopNCacheWriteCommand.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/cache/TopNCacheWriteCommand.java
@@ -42,7 +42,7 @@ public class TopNCacheWriteCommand extends TopN {
     private String id;
     @Getter
     @Setter
-    @Column(columnName = STATEMENT, length = 2000, lengthEnvVariable = "SW_SLOW_DB_THRESHOLD", storageOnly = true)
+    @Column(columnName = STATEMENT, length = 2000, storageOnly = true)
     private String command;
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/database/TopNDatabaseStatement.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/database/TopNDatabaseStatement.java
@@ -41,7 +41,7 @@ public class TopNDatabaseStatement extends TopN {
     private String id;
     @Getter
     @Setter
-    @Column(columnName = STATEMENT, length = 2000, lengthEnvVariable = "SW_SLOW_DB_THRESHOLD", storageOnly = true)
+    @Column(columnName = STATEMENT, length = 2000, storageOnly = true)
     private String statement;
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/Column.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/annotation/Column.java
@@ -70,14 +70,6 @@ public @interface Column {
     int length() default 200;
 
     /**
-     * The return name of system environment could provide an override value of the length limitation.
-     *
-     * @return the variable name of system environment.
-     * @since 8.2.0
-     */
-    String lengthEnvVariable() default "";
-
-    /**
      * Column with data type != {@link ValueDataType#NOT_VALUE} represents this is a value column. Indicate it would be
      * queried by UI/CLI.
      *

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/StorageModels.java
@@ -35,7 +35,6 @@ import org.apache.skywalking.oap.server.core.storage.annotation.SQLDatabase;
 import org.apache.skywalking.oap.server.core.storage.annotation.Storage;
 import org.apache.skywalking.oap.server.core.storage.annotation.SuperDataset;
 import org.apache.skywalking.oap.server.core.storage.annotation.ValueColumnMetadata;
-import org.apache.skywalking.oap.server.library.util.StringUtil;
 
 /**
  * StorageModels manages all models detected by the core.
@@ -154,19 +153,6 @@ public class StorageModels implements IModelManager, ModelCreator, ModelManipula
                 // Use the column#length as the default column length, as read the system env as the override mechanism.
                 // Log the error but don't block the startup sequence.
                 int columnLength = column.length();
-                final String lengthEnvVariable = column.lengthEnvVariable();
-                if (StringUtil.isNotEmpty(lengthEnvVariable)) {
-                    final String envValue = System.getenv(lengthEnvVariable);
-                    if (StringUtil.isNotEmpty(envValue)) {
-                        try {
-                            columnLength = Integer.parseInt(envValue);
-                        } catch (NumberFormatException e) {
-                            log.error("Model [{}] Column [{}], illegal value {} of column length from system env [{}]",
-                                      modelName, column.columnName(), envValue, lengthEnvVariable
-                            );
-                        }
-                    }
-                }
 
                 // SQL Database extension
                 SQLDatabaseExtension sqlDatabaseExtension = new SQLDatabaseExtension();


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).


This was introduced in https://github.com/apache/skywalking/pull/5238 and it never works as expected so I just remove this and won't consider it as breaking change.

In https://github.com/apache/skywalking/pull/5238 we meant to add `lengthEnvVariable` as an mechanism to override the column length, but the env var it uses is `SW_SLOW_DB_THRESHOLD`, which is the duration threshold instead of length threshold, what's more, the content of `SW_SLOW_DB_THRESHOLD` is something like `default:200,mongodb:100` but `StorageModels` always tries to parse the content of `SW_SLOW_DB_THRESHOLD` as an integer, which causes the following errors 

```
2022-11-12 04:02:25,306 org.apache.skywalking.oap.server.core.storage.model.StorageModels 164 [main] ERROR [] - [9.3.0-SNAPSHOT-7c8867b] Model [top_n_cache_read_command] Column [statement], illegal value default:0,mongodb:100 of column length from system env [SW_SLOW_DB_THRESHOLD]
2022-11-12 04:02:25,311 org.apache.skywalking.oap.server.core.storage.model.StorageModels 164 [main] ERROR [] - [9.3.0-SNAPSHOT-7c8867b] Model [top_n_cache_write_command] Column [statement], illegal value default:0,mongodb:100 of column length from system env [SW_SLOW_DB_THRESHOLD]
2022-11-12 04:02:25,312 org.apache.skywalking.oap.server.core.storage.model.StorageModels 164 [main] ERROR [] - [9.3.0-SNAPSHOT-7c8867b] Model [top_n_database_statement] Column [statement], illegal value default:0,mongodb:100 of column length from system env [SW_SLOW_DB_THRESHOLD]
```

