### PR TITLE
Add `LongText` to support longer logs persistent as a text type 

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -109,6 +109,7 @@
 * Add component IDs(135, 136, 137) for EventMesh server and client-side plugins.
 * Bump up Kafka client to 2.8.1 to fix CVE-2021-38153.
 * Remove `lengthEnvVariable` for `Column` as it never works as expected.
+* Add `LongText` to support longer logs persistent as a text type in ElasticSearch, instead of a keyword, to avoid length limitation.
 
 #### UI
 

--- a/docs/en/protocols/README.md
+++ b/docs/en/protocols/README.md
@@ -24,9 +24,11 @@ Please read SkyWalking language agents documentation to see whether it is suppor
 SkyWalking has a native metrics format, and supports widely used metric formats, such as Prometheus, OpenCensus, OpenTelemetry, and Zabbix.
 
 The native metrics format definition could be found [here](https://github.com/apache/skywalking-data-collect-protocol/blob/master/language-agent/Meter.proto).
-Typically, the agent meter plugin (e.g. [Java Meter Plugin](https://skywalking.apache.org/docs/skywalking-java/next/en/setup/service-agent/java-agent/java-plugin-development-guide/#meter-plugin)) and
-Satellite [Prometheus fetcher](https://skywalking.apache.org/docs/skywalking-satellite/next/en/setup/plugins/fetcher_prometheus-metrics-fetcher/)
-would convert metrics into native format and forward them to SkyWalking OAP server.
+The agent meter plugin (e.g. [Java Meter Plugin](https://skywalking.apache.org/docs/skywalking-java/next/en/setup/service-agent/java-agent/java-plugin-development-guide/#meter-plugin)) uses the
+native metric format to report metrics.
+
+OpenTelemetry collector, Telegraf agents, Zabbix agents could use their native protocol(e.g. OTLP)
+and OAP server would convert metrics into native format and forward them to [MAL](../concepts-and-designs/mal.md) engine.
 
 To learn more about receiving 3rd party formats metrics, see [Meter receiver](../setup/backend/backend-meter.md) and [OpenTelemetry receiver](../setup/backend/opentelemetry-receiver.md).
 

--- a/oap-server/exporter/src/main/java/org/apache/skywalking/oap/server/exporter/provider/kafka/log/KafkaLogExporter.java
+++ b/oap-server/exporter/src/main/java/org/apache/skywalking/oap/server/exporter/provider/kafka/log/KafkaLogExporter.java
@@ -142,15 +142,15 @@ public class KafkaLogExporter extends KafkaExportProducer implements LogExportSe
         switch (ContentType.instanceOf(logRecord.getContentType())) {
             case JSON:
                 bodyBuilder.setType(ContentType.JSON.name());
-                bodyBuilder.setJson(JSONLog.newBuilder().setJson(logRecord.getContent()));
+                bodyBuilder.setJson(JSONLog.newBuilder().setJson(logRecord.getContent().getText()));
                 break;
             case YAML:
                 bodyBuilder.setType(ContentType.YAML.name());
-                bodyBuilder.setYaml(YAMLLog.newBuilder().setYaml(logRecord.getContent()));
+                bodyBuilder.setYaml(YAMLLog.newBuilder().setYaml(logRecord.getContent().getText()));
                 break;
             case TEXT:
                 bodyBuilder.setType(ContentType.TEXT.name());
-                bodyBuilder.setText(TextLog.newBuilder().setText(logRecord.getContent()));
+                bodyBuilder.setText(TextLog.newBuilder().setText(logRecord.getContent().getText()));
                 break;
             case NONE:
                 bodyBuilder.setType(ContentType.NONE.name());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/log/AbstractLogRecord.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/log/AbstractLogRecord.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.skywalking.oap.server.core.UnexpectedException;
 import org.apache.skywalking.oap.server.core.analysis.manual.searchtag.Tag;
+import org.apache.skywalking.oap.server.core.analysis.record.LongText;
 import org.apache.skywalking.oap.server.core.analysis.record.Record;
 import org.apache.skywalking.oap.server.core.query.type.ContentType;
 import org.apache.skywalking.oap.server.core.storage.annotation.BanyanDB;
@@ -85,7 +86,7 @@ public abstract class AbstractLogRecord extends Record {
     @Getter
     @Column(columnName = CONTENT, length = 1_000_000)
     @ElasticSearch.MatchQuery(analyzer = ElasticSearch.MatchQuery.AnalyzerType.OAP_LOG_ANALYZER)
-    private String content;
+    private LongText content;
     @Setter
     @Getter
     @Column(columnName = TIMESTAMP)
@@ -118,7 +119,7 @@ public abstract class AbstractLogRecord extends Record {
             record.setTraceSegmentId((String) converter.get(TRACE_SEGMENT_ID));
             record.setSpanId(((Number) converter.get(SPAN_ID)).intValue());
             record.setContentType(((Number) converter.get(CONTENT_TYPE)).intValue());
-            record.setContent((String) converter.get(CONTENT));
+            record.setContent(new LongText((String) converter.get(CONTENT)));
             record.setTimestamp(((Number) converter.get(TIMESTAMP)).longValue());
             record.setTagsRawData(converter.getBytes(TAGS_RAW_DATA));
             record.setTimeBucket(((Number) converter.get(TIME_BUCKET)).longValue());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/log/LogRecordDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/log/LogRecordDispatcher.java
@@ -19,6 +19,7 @@ package org.apache.skywalking.oap.server.core.analysis.manual.log;
 
 import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
 import org.apache.skywalking.oap.server.core.analysis.manual.searchtag.Tag;
+import org.apache.skywalking.oap.server.core.analysis.record.LongText;
 import org.apache.skywalking.oap.server.core.analysis.worker.RecordStreamProcessor;
 import org.apache.skywalking.oap.server.core.source.Log;
 
@@ -37,7 +38,7 @@ public class LogRecordDispatcher implements SourceDispatcher<Log> {
         record.setTraceSegmentId(source.getTraceSegmentId());
         record.setSpanId(source.getSpanId());
         record.setContentType(source.getContentType().value());
-        record.setContent(source.getContent());
+        record.setContent(new LongText(source.getContent()));
         record.setTagsRawData(source.getTagsRawData());
         record.setTagsInString(Tag.Util.toStringList(source.getTags()));
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/record/LongText.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/record/LongText.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.analysis.record;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.skywalking.oap.server.core.storage.type.StorageDataComplexObject;
+
+/**
+ * LongText represents a string field, but the length is not predictable and could be longer than 1000.
+ * This is a wrapper of Java String only, which provides an indicator of long text field.
+ */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class LongText implements StorageDataComplexObject<LongText> {
+    private String text;
+
+    public LongText(final String text) {
+        this.text = text;
+    }
+
+    @Override
+    public String toStorageData() {
+        return text;
+    }
+
+    @Override
+    public void toObject(final String data) {
+        this.text = data;
+    }
+
+    @Override
+    public void copyFrom(final LongText source) {
+        this.text = source.text;
+    }
+}


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #9961.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).


Add `LongText` to support longer logs persistent as a text type in ElasticSearch, instead of a keyword, to avoid length limitation.