### PR TITLE
Fix ESEventQueryDAO miss metric_table boolQuery criteria.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -113,7 +113,7 @@
 * Fix wrong system variable name `SW_CORE_ENABLE_ENDPOINT_NAME_GROUPING_BY_OPENAPI`. It was **opaenapi**.
 * Fix not-time-series model blocking OAP boots in no-init mode.
 * Changed system variable `SW_SUPERDATASET_STORAGE_DAY_STEP` to `SW_STORAGE_ES_SUPER_DATASET_DAY_STEP` to be consistent with other ES storage related variables.
-* Fix ESEventQueryDAO miss metric_table boolQuery criteria.
+* Fix ESEventQueryDAO missing metric_table boolQuery criteria.
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -113,6 +113,7 @@
 * Fix wrong system variable name `SW_CORE_ENABLE_ENDPOINT_NAME_GROUPING_BY_OPENAPI`. It was **opaenapi**.
 * Fix not-time-series model blocking OAP boots in no-init mode.
 * Changed system variable `SW_SUPERDATASET_STORAGE_DAY_STEP` to `SW_STORAGE_ES_SUPER_DATASET_DAY_STEP` to be consistent with other ES storage related variables.
+* Fix ESEventQueryDAO miss metric_table boolQuery criteria.
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/ESEventQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/ESEventQueryDAO.java
@@ -78,6 +78,10 @@ public class ESEventQueryDAO extends EsDAO implements IEventQueryDAO {
 
     private void buildMustQueryListByCondition(final EventQueryCondition condition,
                                                final BoolQueryBuilder query) {
+        if (IndexController.LogicIndicesRegister.isPhysicalTable(Event.INDEX_NAME)) {
+            query.must(Query.term(IndexController.LogicIndicesRegister.METRIC_TABLE_NAME, Event.INDEX_NAME));
+        }
+        
         if (!isNullOrEmpty(condition.getUuid())) {
             query.must(Query.term(Event.UUID, condition.getUuid()));
         }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

Fix ESEventQueryDAO miss metric_table boolQuery criteria.
