### PR TITLE
Adjust OAP log level in E2E to reduce log size

### DIFF
--- a/test/e2e-v2/script/prepare/setup-oap/log4j2.xml
+++ b/test/e2e-v2/script/prepare/setup-oap/log4j2.xml
@@ -24,15 +24,6 @@
         </Console>
     </Appenders>
     <Loggers>
-        <logger name="org.apache.zookeeper" level="INFO"/>
-        <logger name="io.grpc.netty" level="INFO"/>
-        <logger name="org.apache.skywalking.oap.meter.analyzer" level="DEBUG"/>
-        <logger name="org.apache.skywalking.oap.server.receiver.istio.telemetry" level="DEBUG"/>
-        <logger name="org.apache.skywalking.oap.server.fetcher.prometheus" level="DEBUG"/>
-        <logger name="org.apache.skywalking.oap.server.receiver.envoy.als" level="DEBUG"/>
-        <logger name="org.apache.skywalking.oap.server.storage.plugin.elasticsearch" level="DEBUG"/>
-        <logger name="org.apache.skywalking.oap.server.core.storage.ttl" level="DEBUG"/>
-        <logger name="org.apache.skywalking.library.elasticsearch" level="DEBUG"/>
         <Root level="INFO">
             <AppenderRef ref="Console"/>
         </Root>


### PR DESCRIPTION
Adjust OAP log level to INFO in E2E, so the log file size is not too large!!

<img width="811" alt="image" src="https://user-images.githubusercontent.com/15965696/202185746-bac9aa91-8db3-4ada-95a8-c1679b27bf00.png">