### PR TITLE
Fix Elasticsearch storage: In `No-Sharding Mode`, add specific analyzer to the template before index creation to avoid update index error.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -130,6 +130,7 @@
   since BanyanDB stream requires a timestamp in milliseconds.
   For SQL-Database: add new column `timestamp` for tables `profile_task_log/top_n_database_statement`,
   requires altering this column or removing these tables before OAP starts, if bump up from previous releases.
+* Fix Elasticsearch storage: In `No-Sharding Mode`, add specific analyzer to the template before index creation to avoid update index error.
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
@@ -266,9 +266,10 @@ public class StorageEsInstaller extends ModelInstaller {
 
     //In the `No-Sharding Mode`:
     //https://skywalking.apache.org/docs/main/next/en/faq/new-elasticsearch-storage-option-explanation-in-9.2.0/
-    //The merged models required analyzer or not are shared the same index.
+    //Some of models require a analyzer to run match query, some others are not.
+    //They are merged into the one physical index(metrics-all or record-all)
     //When adding a new model(with an analyzer) into an existed index by update will be failed, if the index is without analyzer settings.
-    //To avoid this, we should add the analyzer settings to the template before index creation.
+    //To avoid this, add the analyzer settings to the template before index creation.
     private Map getAnalyzerSetting(Model model) throws StorageException {
         if (config.isLogicSharding() || !model.isTimeSeries()) {
             return getAnalyzerSettingByColumn(model);

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
@@ -32,6 +32,7 @@ import org.apache.skywalking.library.elasticsearch.response.IndexTemplate;
 import org.apache.skywalking.library.elasticsearch.response.Mappings;
 import org.apache.skywalking.oap.server.core.RunningMode;
 import org.apache.skywalking.oap.server.core.storage.StorageException;
+import org.apache.skywalking.oap.server.core.storage.annotation.ElasticSearch;
 import org.apache.skywalking.oap.server.core.storage.model.Model;
 import org.apache.skywalking.oap.server.core.storage.model.ModelColumn;
 import org.apache.skywalking.oap.server.core.storage.model.ModelInstaller;
@@ -248,8 +249,7 @@ public class StorageEsInstaller extends ModelInstaller {
             indexRefreshInterval = 5;
         }
         indexSettings.put("refresh_interval", indexRefreshInterval + "s");
-        List<ModelColumn> columns = IndexController.LogicIndicesRegister.getPhysicalTableColumns(model);
-        indexSettings.put("analysis", getAnalyzerSetting(columns));
+        indexSettings.put("analysis", getAnalyzerSetting(model));
         if (!StringUtil.isEmpty(config.getAdvanced())) {
             Map<String, Object> advancedSettings = gson.fromJson(config.getAdvanced(), Map.class);
             setting.putAll(advancedSettings);
@@ -264,8 +264,25 @@ public class StorageEsInstaller extends ModelInstaller {
         return setting;
     }
 
-    private Map getAnalyzerSetting(List<ModelColumn> analyzerTypes) throws StorageException {
+    //In the `No-Sharding Mode`:
+    //https://skywalking.apache.org/docs/main/next/en/faq/new-elasticsearch-storage-option-explanation-in-9.2.0/
+    //The merged models required analyzer or not are shared the same index.
+    //When adding a new model(with an analyzer) into an existed index by update will be failed, if the index is without analyzer settings.
+    //To avoid this, we should add the analyzer settings to the template before index creation.
+    private Map getAnalyzerSetting(Model model) throws StorageException {
+        if (config.isLogicSharding() || !model.isTimeSeries()) {
+            return getAnalyzerSettingByColumn(model);
+        } else if (IndexController.INSTANCE.isRecordModel(model) && model.isSuperDataset()) {
+            //SuperDataset doesn't merge index, the analyzer follow the column config.
+            return getAnalyzerSettingByColumn(model);
+        } else {
+            return getAnalyzerSetting4MergedIndex(model);
+        }
+    }
+
+    private Map getAnalyzerSettingByColumn(Model model) throws StorageException {
         AnalyzerSetting analyzerSetting = new AnalyzerSetting();
+        List<ModelColumn> analyzerTypes = IndexController.LogicIndicesRegister.getPhysicalTableColumns(model);
         for (final ModelColumn column : analyzerTypes) {
             if (!column.getElasticSearchExtension().needMatchQuery()) {
                 continue;
@@ -277,6 +294,16 @@ public class StorageEsInstaller extends ModelInstaller {
             analyzerSetting.combine(setting);
         }
         return gson.fromJson(gson.toJson(analyzerSetting), Map.class);
+    }
+
+    //Indexes `metrics-all and records-all` are required `OAP_ANALYZER`
+    private Map getAnalyzerSetting4MergedIndex(Model model) throws StorageException {
+        AnalyzerSetting setting = AnalyzerSetting.Generator.getGenerator(
+                                                     ElasticSearch.MatchQuery.AnalyzerType.OAP_ANALYZER)
+                                                           .getGenerateFunc()
+                                                           .generate(config);
+
+        return gson.fromJson(gson.toJson(setting), Map.class);
     }
 
     protected Mappings createMapping(Model model) {


### PR DESCRIPTION
 In the `No-Sharding Mode`:
 https://skywalking.apache.org/docs/main/next/en/faq/new-elasticsearch-storage-option-explanation-in-9.2.0/
The merged models required analyzer or not are shared the same index.
When adding a new model(with an analyzer) into an existed index by update will be failed, if the index is without analyzer settings.
To avoid this, we should add the analyzer settings to the template before index creation.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
