### PR TITLE
Fix missing HTTP/1.x metrics in network profiling

### DIFF
--- a/oap-server/server-starter/src/main/resources/meter-analyzer-config/network-profiling.yaml
+++ b/oap-server/server-starter/src/main/resources/meter-analyzer-config/network-profiling.yaml
@@ -44,7 +44,7 @@ expPrefix: |-
   })
 metricPrefix: process_relation
 metricsRules:
-  # client side
+  # TCP Metrics: client side
   - name: client_write_cpm
     exp:  rover_net_p_client_write_counts_counter.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component']).downsampling(SUM_PER_MIN)
   - name: client_write_total_bytes
@@ -78,7 +78,7 @@ metricsRules:
   - name: client_read_exe_time_percentile
     exp: rover_net_p_client_read_exe_time_histogram.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component', 'le']).histogram().histogram_percentile([50,70,90,99]).downsampling(SUM)
 
-  # server side
+  # TCP Metrics: server side
   - name: server_write_cpm
     exp:  rover_net_p_server_write_counts_counter.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component']).downsampling(SUM_PER_MIN)
   - name: server_write_total_bytes
@@ -111,3 +111,25 @@ metricsRules:
     exp: rover_net_p_server_write_exe_time_histogram.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component', 'le']).histogram().histogram_percentile([50,70,90,99]).downsampling(SUM)
   - name: server_read_exe_time_percentile
     exp: rover_net_p_server_read_exe_time_histogram.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component', 'le']).histogram().histogram_percentile([50,70,90,99]).downsampling(SUM)
+
+  # HTTP/1.x Metrics
+  - name: http1_request_cpm
+    exp: rover_net_p_http1_request_counter.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component']).downsampling(SUM_PER_MIN)
+  - name: http1_response_status_cpm
+    exp: rover_net_p_http1_response_status_counter.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component', 'code']).downsampling(SUM_PER_MIN)
+  - name: http1_request_package_size
+    exp: rover_net_p_http1_request_package_size_avg.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component'])
+  - name: http1_response_package_size
+    exp: rover_net_p_http1_response_package_size_avg.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component'])
+  - name: http1_request_package_size_percentile
+    exp: rover_net_p_http1_request_package_size_histogram.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component', 'le']).histogram().histogram_percentile([50,70,90,99]).downsampling(SUM)
+  - name: http1_response_package_size_percentile
+    exp: rover_net_p_http1_response_package_size_histogram.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component', 'le']).histogram().histogram_percentile([50,70,90,99]).downsampling(SUM)
+  - name: http1_client_duration
+    exp: rover_net_p_http1_client_duration_avg.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component'])
+  - name: http1_server_duration
+    exp: rover_net_p_http1_server_duration_avg.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component'])
+  - name: http1_client_duration_percentile
+    exp: rover_net_p_http1_client_duration_histogram.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component', 'le']).histogram().histogram_percentile([50,70,90,99]).downsampling(SUM)
+  - name: http1_server_duration_percentile
+    exp: rover_net_p_http1_server_duration_histogram.sum(['service', 'instance', 'side', 'client_process_id', 'server_process_id', 'component', 'le']).histogram().histogram_percentile([50,70,90,99]).downsampling(SUM)


### PR DESCRIPTION
Following https://github.com/apache/skywalking/pull/10044, This PR is fixed missing metrics for analysis HTTP/1.x metrics.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
