### PR TITLE
Fix wrong time bucket on attached event

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -137,6 +137,7 @@
 * Rename `BanyanDB.ShardingKey` to `BanyanDB.SeriesID`.
 * Self-Observability: Add counters for metrics reading from DB or cached. Dashboard:`Metrics Persistent Cache Count`.
 * Self-Observability: Fix `GC Time` calculation.
+* Update the `trace_id` field as storage only(cannot be queried) in `top_n_database_statement`, `top_n_cache_read_command`, `top_n_cache_read_command` index.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/spanattach/SpanAttachedEventRecord.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/spanattach/SpanAttachedEventRecord.java
@@ -47,7 +47,7 @@ public class SpanAttachedEventRecord extends Record {
     public static final String END_TIME_SECOND = "end_time_second";
     public static final String END_TIME_NANOS = "end_time_nanos";
     public static final String TRACE_REF_TYPE = "trace_ref_type";
-    public static final String TRACE_ID = "trace_id";
+    public static final String RELATED_TRACE_ID = "related_trace_id";
     public static final String TRACE_SEGMENT_ID = "trace_segment_id";
     public static final String TRACE_SPAN_ID = "trace_span_id";
     public static final String DATA_BINARY = "data_binary";
@@ -66,9 +66,9 @@ public class SpanAttachedEventRecord extends Record {
     private int endTimeNanos;
     @Column(columnName = TRACE_REF_TYPE)
     private int traceRefType;
-    @Column(columnName = TRACE_ID)
+    @Column(columnName = RELATED_TRACE_ID)
     @BanyanDB.GlobalIndex
-    private String traceId;
+    private String relatedTraceId;
     @Column(columnName = TRACE_SEGMENT_ID)
     private String traceSegmentId;
     @Column(columnName = TRACE_SPAN_ID)
@@ -95,7 +95,7 @@ public class SpanAttachedEventRecord extends Record {
             record.setEndTimeSecond(((Number) converter.get(END_TIME_SECOND)).longValue());
             record.setEndTimeNanos(((Number) converter.get(END_TIME_NANOS)).intValue());
             record.setTraceRefType(((Number) converter.get(TRACE_REF_TYPE)).intValue());
-            record.setTraceId((String) converter.get(TRACE_ID));
+            record.setRelatedTraceId((String) converter.get(RELATED_TRACE_ID));
             record.setTraceSegmentId((String) converter.get(TRACE_SEGMENT_ID));
             record.setTraceSpanId((String) converter.get(TRACE_SPAN_ID));
             record.setDataBinary(converter.getBytes(DATA_BINARY));
@@ -111,7 +111,7 @@ public class SpanAttachedEventRecord extends Record {
             converter.accept(END_TIME_SECOND, entity.getEndTimeSecond());
             converter.accept(END_TIME_NANOS, entity.getEndTimeNanos());
             converter.accept(TRACE_REF_TYPE, entity.getTraceRefType());
-            converter.accept(TRACE_ID, entity.getTraceId());
+            converter.accept(RELATED_TRACE_ID, entity.getRelatedTraceId());
             converter.accept(TRACE_SEGMENT_ID, entity.getTraceSegmentId());
             converter.accept(TRACE_SPAN_ID, entity.getTraceSpanId());
             converter.accept(DATA_BINARY, entity.getDataBinary());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/spanattach/SpanAttachedEventRecord.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/spanattach/SpanAttachedEventRecord.java
@@ -58,6 +58,7 @@ public class SpanAttachedEventRecord extends Record {
     @Column(columnName = START_TIME_NANOS)
     private int startTimeNanos;
     @Column(columnName = EVENT)
+    @BanyanDB.SeriesID(index = 0)
     private String event;
     @Column(columnName = END_TIME_SECOND)
     private long endTimeSecond;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/spanattach/SpanAttachedEventRecord.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/spanattach/SpanAttachedEventRecord.java
@@ -66,7 +66,7 @@ public class SpanAttachedEventRecord extends Record {
     @Column(columnName = TRACE_REF_TYPE)
     private int traceRefType;
     @Column(columnName = TRACE_ID)
-    @BanyanDB.SeriesID(index = 0)
+    @BanyanDB.GlobalIndex
     private String traceId;
     @Column(columnName = TRACE_SEGMENT_ID)
     private String traceSegmentId;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/trace/SampledSlowTraceRecord.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/trace/SampledSlowTraceRecord.java
@@ -53,9 +53,9 @@ public class SampledSlowTraceRecord extends Record {
     @Column(columnName = SCOPE)
     private int scope;
     @Column(columnName = ENTITY_ID)
-    private String entityId;
-    @Column(columnName = TRACE_ID)
     @BanyanDB.SeriesID(index = 0)
+    private String entityId;
+    @Column(columnName = TRACE_ID, storageOnly = true)
     private String traceId;
     @Column(columnName = URI, storageOnly = true)
     private String uri;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/trace/SampledStatus4xxTraceRecord.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/trace/SampledStatus4xxTraceRecord.java
@@ -54,9 +54,9 @@ public class SampledStatus4xxTraceRecord extends Record {
     @Column(columnName = SCOPE)
     private int scope;
     @Column(columnName = ENTITY_ID)
-    private String entityId;
-    @Column(columnName = TRACE_ID)
     @BanyanDB.SeriesID(index = 0)
+    private String entityId;
+    @Column(columnName = TRACE_ID, storageOnly = true)
     private String traceId;
     @Column(columnName = URI, storageOnly = true)
     private String uri;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/trace/SampledStatus5xxTraceRecord.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/trace/SampledStatus5xxTraceRecord.java
@@ -54,9 +54,9 @@ public class SampledStatus5xxTraceRecord extends Record {
     @Column(columnName = SCOPE)
     private int scope;
     @Column(columnName = ENTITY_ID)
-    private String entityId;
-    @Column(columnName = TRACE_ID)
     @BanyanDB.SeriesID(index = 0)
+    private String entityId;
+    @Column(columnName = TRACE_ID, storageOnly = true)
     private String traceId;
     @Column(columnName = URI, storageOnly = true)
     private String uri;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/topn/TopN.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/topn/TopN.java
@@ -41,7 +41,7 @@ public abstract class TopN extends Record implements ComparableStorageData {
     private long latency;
     @Getter
     @Setter
-    @Column(columnName = TRACE_ID)
+    @Column(columnName = TRACE_ID, storageOnly = true)
     private String traceId;
     @Getter
     @Setter

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/handler/v8/grpc/SpanAttachedEventReportServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/handler/v8/grpc/SpanAttachedEventReportServiceHandler.java
@@ -53,7 +53,7 @@ public class SpanAttachedEventReportServiceHandler extends SpanAttachedEventRepo
                 record.setEndTimeSecond(event.getEndTime().getSeconds());
                 record.setEndTimeNanos(event.getEndTime().getNanos());
                 record.setTraceRefType(event.getTraceContext().getTypeValue());
-                record.setTraceId(event.getTraceContext().getTraceId());
+                record.setRelatedTraceId(event.getTraceContext().getTraceId());
                 record.setTraceSegmentId(event.getTraceContext().getTraceSegmentId());
                 record.setTraceSpanId(event.getTraceContext().getSpanId());
                 record.setDataBinary(event.toByteArray());

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/handler/v8/grpc/SpanAttachedEventReportServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/handler/v8/grpc/SpanAttachedEventReportServiceHandler.java
@@ -59,7 +59,7 @@ public class SpanAttachedEventReportServiceHandler extends SpanAttachedEventRepo
                 record.setDataBinary(event.toByteArray());
                 long timestamp = TimeUnit.SECONDS.toMillis(record.getStartTimeSecond())
                     + TimeUnit.NANOSECONDS.toMillis(record.getStartTimeNanos());
-                record.setTimeBucket(TimeBucket.getMinuteTimeBucket(timestamp));
+                record.setTimeBucket(TimeBucket.getRecordTimeBucket(timestamp));
                 record.setTimestamp(timestamp);
                 RecordStreamProcessor.getInstance().in(record);
             }

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/stream/BanyanDBSpanAttachedEventQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/stream/BanyanDBSpanAttachedEventQueryDAO.java
@@ -41,7 +41,7 @@ public class BanyanDBSpanAttachedEventQueryDAO extends AbstractBanyanDBDAO imple
         SpanAttachedEventRecord.END_TIME_SECOND,
         SpanAttachedEventRecord.END_TIME_NANOS,
         SpanAttachedEventRecord.TRACE_REF_TYPE,
-        SpanAttachedEventRecord.TRACE_ID,
+        SpanAttachedEventRecord.RELATED_TRACE_ID,
         SpanAttachedEventRecord.TRACE_SEGMENT_ID,
         SpanAttachedEventRecord.TRACE_SPAN_ID,
         SpanAttachedEventRecord.DATA_BINARY);
@@ -55,7 +55,7 @@ public class BanyanDBSpanAttachedEventQueryDAO extends AbstractBanyanDBDAO imple
         final StreamQueryResponse resp = query(SpanAttachedEventRecord.INDEX_NAME, TAGS, new QueryBuilder<StreamQuery>() {
             @Override
             protected void apply(StreamQuery query) {
-                query.and(eq(SpanAttachedEventRecord.TRACE_ID, traceId));
+                query.and(eq(SpanAttachedEventRecord.RELATED_TRACE_ID, traceId));
                 query.and(eq(SpanAttachedEventRecord.TRACE_REF_TYPE, type.value()));
                 query.setOrderBy(new StreamQuery.OrderBy(SpanAttachedEventRecord.START_TIME_SECOND, AbstractQuery.Sort.ASC));
             }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/SpanAttachedEventEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/SpanAttachedEventEsDAO.java
@@ -59,7 +59,7 @@ public class SpanAttachedEventEsDAO extends EsDAO implements ISpanAttachedEventQ
             query.must(Query.term(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME, SpanAttachedEventRecord.INDEX_NAME));
         }
         final SearchBuilder search = Search.builder().query(query).size(scrollingBatchSize);
-        query.must(Query.terms(SpanAttachedEventRecord.TRACE_ID, traceId));
+        query.must(Query.terms(SpanAttachedEventRecord.RELATED_TRACE_ID, traceId));
         query.must(Query.terms(SpanAttachedEventRecord.TRACE_REF_TYPE, type.value()));
         search.sort(SpanAttachedEventRecord.START_TIME_SECOND, Sort.Order.ASC);
         search.sort(SpanAttachedEventRecord.START_TIME_NANOS, Sort.Order.ASC);

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCSpanAttachedEventQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCSpanAttachedEventQueryDAO.java
@@ -42,7 +42,7 @@ public class JDBCSpanAttachedEventQueryDAO implements ISpanAttachedEventQueryDAO
         StringBuilder sql = new StringBuilder("select * from " + SpanAttachedEventRecord.INDEX_NAME + " where ");
         List<Object> parameters = new ArrayList<>(2);
 
-        sql.append(" ").append(SpanAttachedEventRecord.TRACE_ID).append(" = ?");
+        sql.append(" ").append(SpanAttachedEventRecord.RELATED_TRACE_ID).append(" = ?");
         parameters.add(traceId);
         sql.append(" and ").append(SpanAttachedEventRecord.TRACE_REF_TYPE).append(" = ?");
         parameters.add(type.value());
@@ -62,7 +62,7 @@ public class JDBCSpanAttachedEventQueryDAO implements ISpanAttachedEventQueryDAO
                     record.setEndTimeSecond(resultSet.getLong(SpanAttachedEventRecord.END_TIME_SECOND));
                     record.setEndTimeNanos(resultSet.getInt(SpanAttachedEventRecord.END_TIME_NANOS));
                     record.setTraceRefType(resultSet.getInt(SpanAttachedEventRecord.TRACE_REF_TYPE));
-                    record.setTraceId(resultSet.getString(SpanAttachedEventRecord.TRACE_ID));
+                    record.setRelatedTraceId(resultSet.getString(SpanAttachedEventRecord.RELATED_TRACE_ID));
                     record.setTraceSegmentId(resultSet.getString(SpanAttachedEventRecord.TRACE_SEGMENT_ID));
                     record.setTraceSpanId(resultSet.getString(SpanAttachedEventRecord.TRACE_SPAN_ID));
                     String dataBinaryBase64 = resultSet.getString(SpanAttachedEventRecord.DATA_BINARY);


### PR DESCRIPTION
Fix the wrong time bucket on the attached event, otherwise, the event will write to the monthly index in ES storage.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
