### PR TITLE
Fix miss set `LastUpdateTimestamp` that caused the metrics session to expire

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -25,6 +25,7 @@
 * Correct `MetricsExtension` annotations declarations in manual entities.
 * Support component IDs' priority in process relation metrics.
 * Remove abandon logic in MergableBufferedData, which caused unexpected no-update.
+* Fix the missing set `LastUpdateTimestamp` that caused the metrics session to expire.
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -25,7 +25,7 @@
 * Correct `MetricsExtension` annotations declarations in manual entities.
 * Support component IDs' priority in process relation metrics.
 * Remove abandon logic in MergableBufferedData, which caused unexpected no-update.
-* Fix the missing set `LastUpdateTimestamp` that caused the metrics session to expire.
+* Fix miss set `LastUpdateTimestamp` that caused the metrics session to expire.
 
 #### UI
 


### PR DESCRIPTION
In the previous, when the metrics do not support `update/combine` would miss set `LastUpdateTimestamp`.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
