### PR TITLE
Optimize `flushInterval` of ElasticSearch BulkProcessor 

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -33,6 +33,7 @@
 * Remove the dependency of `refresh_interval` of ElasticSearch indices from `elasticsearch/flushInterval` config. Now,
   it uses `core/persistentPeriod` + 5s as `refresh_interval` for all indices instead.
 * Change `elasticsearch/flushInterval` to 5s(was 15s).
+* Optimize `flushInterval` of ElasticSearch BulkProcessor to avoid extra periodical flush in continuous bulk stream. 
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -33,7 +33,7 @@
 * Remove the dependency of `refresh_interval` of ElasticSearch indices from `elasticsearch/flushInterval` config. Now,
   it uses `core/persistentPeriod` + 5s as `refresh_interval` for all indices instead.
 * Change `elasticsearch/flushInterval` to 5s(was 15s).
-* Optimize `flushInterval` of ElasticSearch BulkProcessor to avoid extra periodical flush in continuous bulk stream. 
+* Optimize `flushInterval` of ElasticSearch BulkProcessor to avoid extra periodical flush in the continuous bulk streams. 
 
 #### UI
 

--- a/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/bulk/BulkProcessor.java
+++ b/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/bulk/BulkProcessor.java
@@ -109,7 +109,7 @@ public final class BulkProcessor {
     private void doPeriodicalFlush() {
         if (System.currentTimeMillis() - lastFlushTS > flushInternalInMillis / 2) {
             // Run periodical flush if there is no `flushIfNeeded` executed in the second half of the flush period.
-            // Otherwise, wait for next round. By default, last 2 seconds of 5s period.
+            // Otherwise, wait for the next round. By default, the last 2 seconds of the 5s period.
             // This could avoid periodical flush running among bulks(controlled by bulkActions).
             flush();
         }

--- a/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/bulk/BulkProcessor.java
+++ b/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/bulk/BulkProcessor.java
@@ -127,14 +127,14 @@ public final class BulkProcessor {
             return;
         }
 
-        lastFlushTS = System.currentTimeMillis();
-
         final List<Holder> batch = new ArrayList<>(requests.size());
         requests.drainTo(batch);
 
         final CompletableFuture<Void> flush = doFlush(batch);
         flush.whenComplete((ignored1, ignored2) -> semaphore.release());
         flush.join();
+
+        lastFlushTS = System.currentTimeMillis();
     }
 
     private CompletableFuture<Void> doFlush(final List<Holder> batch) {


### PR DESCRIPTION

<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

* Optimize `flushInterval` of ElasticSearch BulkProcessor to avoid extra periodical flush in the continuous bulk streams. 

Run periodical flush if there is no `flushIfNeeded` executed in the second half of the flush period.
Otherwise, wait for the next round. By default, the last 2 seconds of the 5s period.
This could avoid periodical flush running among bulks(controlled by bulkActions).

@kezhenxu94 This is following my #10129, also from my review about `BulkProcessor` logic. Please check whether this makes sense.