### PR TITLE
Fix some metrics session wouldn't expire after TTL.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -40,7 +40,6 @@
 * Add global-specific settings used to override global configurations (e.g `segmentIntervalDays`, `blockIntervalHours`) in BanyanDB.
 * Use TTL-driven interval settings for the `measure-default` group in BanyanDB.
 * Fix wrong group of non time-relative metadata in BanyanDB.
-* Fix some metrics session wouldn't expire after TTL.
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -40,6 +40,7 @@
 * Add global-specific settings used to override global configurations (e.g `segmentIntervalDays`, `blockIntervalHours`) in BanyanDB.
 * Use TTL-driven interval settings for the `measure-default` group in BanyanDB.
 * Fix wrong group of non time-relative metadata in BanyanDB.
+* Fix some metrics session wouldn't expire after TTL.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
@@ -320,7 +320,7 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> {
                            // This is a cache-DB inconsistent case:
                            // Metrics keep coming due to traffic, but the entity in the
                            // database has been removed due to TTL.
-                           if (!model.isTimeRelativeID() && supportUpdate) {
+                           if (!model.isTimeRelativeID()) {
                                // Mostly all updatable metadata level metrics are required to do this check.
 
                                if (metricsDAO.isExpiredCache(model, cachedValue, currentTimeMillis, metricsDataTTL)) {


### PR DESCRIPTION
Such as service_traffic is not `supported updates`, but the id is not `TimeRelative`.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
