### PR TITLE
Merge `TIME_BUCKET` of `Metrics` and `Record` into `StorageData`

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -63,6 +63,7 @@
 * Fix the meter value are not correct when using `sumPerMinLabeld` or `sumHistogramPercentile` MAL function.
 * Fix cannot display attached events when using Zipkin Lens UI query traces.
 * Remove `time_bucket` for both Stream and Measure kinds in BanyanDB plugin.
+* Merge `TIME_BUCKET` of `Metrics` and `Record` into `StorageData`.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/Metrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/Metrics.java
@@ -41,8 +41,6 @@ import static org.apache.skywalking.oap.server.core.analysis.metrics.Metrics.ID;
 })
 @SQLDatabase.Sharding(shardingAlgorithm = ShardingAlgorithm.TIME_RELATIVE_ID_SHARDING_ALGORITHM, tableShardingColumn = ID, dataSourceShardingColumn = ENTITY_ID)
 public abstract class Metrics extends StreamData implements StorageData {
-
-    public static final String TIME_BUCKET = "time_bucket";
     public static final String ENTITY_ID = "entity_id";
     public static final String ID = "id";
 
@@ -55,7 +53,8 @@ public abstract class Metrics extends StreamData implements StorageData {
     private long timeBucket;
 
     /**
-     * Time in the cache, only work when MetricsPersistentWorker#enableDatabaseSession == true.
+     * The last update timestamp of the cache.
+     * The `update` means it is combined with the new metrics. This update doesn't mean the database level update ultimately.
      */
     @Getter
     private long lastUpdateTimestamp = 0L;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/record/Record.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/record/Record.java
@@ -29,9 +29,6 @@ import org.apache.skywalking.oap.server.core.storage.annotation.Column;
  * original log data or task records. These data needs to persistent without further analysis.
  */
 public abstract class Record implements StorageData {
-
-    public static final String TIME_BUCKET = "time_bucket";
-
     /**
      * Time attribute, all storage data is time sensitive, as same as {@link Metrics}
      */

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/data/StreamData.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/data/StreamData.java
@@ -21,6 +21,10 @@ package org.apache.skywalking.oap.server.core.remote.data;
 import org.apache.skywalking.oap.server.core.remote.Deserializable;
 import org.apache.skywalking.oap.server.core.remote.Serializable;
 
+/**
+ * StreamData indicates all implementations supporting {@link Serializable}, {@link Deserializable} and remote hashcode
+ * to do L1 and L2 aggregation cross OAP nodes.
+ */
 public abstract class StreamData implements Serializable, Deserializable {
     public abstract int remoteHashCode();
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/StorageData.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/StorageData.java
@@ -22,6 +22,8 @@ package org.apache.skywalking.oap.server.core.storage;
  * Any persistent entity should be an implementation of this interface.
  */
 public interface StorageData {
+    String TIME_BUCKET = "time_bucket";
+
     /**
      * @return the unique id used in any storage option.
      */


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

@lujiajing1126 I noticed this change is easier than we thought. I don't change all the places from metrics.TIME_BUCKET to StorageData.TIME_BUCKET, because the current one seems more readable.
I know you are in COVID, you don't have to follow this, consider this an FYI.

In the PR, there are few comments updated.