### PR TITLE
Fix Scope.Finder.valueOf method bug.

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/enumeration/Scope.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/enumeration/Scope.java
@@ -18,11 +18,23 @@
 
 package org.apache.skywalking.oap.server.core.query.enumeration;
 
-import java.util.HashMap;
 import lombok.Getter;
-import org.apache.skywalking.oap.server.core.UnexpectedException;
 import org.apache.skywalking.oap.server.core.source.DefaultScopeDefine;
 
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.inEndpointCatalog;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.inEndpointRelationCatalog;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.inProcessCatalog;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.inProcessRelationCatalog;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.inServiceCatalog;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.inServiceInstanceCatalog;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.inServiceInstanceRelationCatalog;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.inServiceRelationCatalog;
+
+/**
+ * Scope n query stage represents the scope catalog. All scopes with their catalogs are defined in {@link DefaultScopeDefine}.
+ * Scope IDs could be various due to different OAL/MAL input.
+ * Scope catalog provides high dimension classification for all scopes as a hierarchy structure.
+ */
 public enum Scope {
     /**
      * @since Deprecated from 9.0.0
@@ -35,25 +47,46 @@ public enum Scope {
     ServiceRelation(DefaultScopeDefine.SERVICE_RELATION),
     ServiceInstanceRelation(DefaultScopeDefine.SERVICE_INSTANCE_RELATION),
     EndpointRelation(DefaultScopeDefine.ENDPOINT_RELATION),
+    Process(DefaultScopeDefine.PROCESS),
     ProcessRelation(DefaultScopeDefine.PROCESS_RELATION);
 
+    /**
+     * Scope ID is defined in {@link DefaultScopeDefine}.
+     */
     @Getter
     private int scopeId;
 
     Scope(int scopeId) {
         this.scopeId = scopeId;
-        Finder.ALL_QUERY_SCOPES.put(scopeId, this);
     }
 
     public static class Finder {
-        private static HashMap<Integer, Scope> ALL_QUERY_SCOPES = new HashMap<>();
-
         public static Scope valueOf(int scopeId) {
-            Scope scope = ALL_QUERY_SCOPES.get(scopeId);
-            if (scope == null) {
-                throw new UnexpectedException("Can't find scope id =" + scopeId);
+            if (inServiceCatalog(scopeId)) {
+                return Service;
             }
-            return scope;
+            if (inServiceInstanceCatalog(scopeId)) {
+                return ServiceInstance;
+            }
+            if (inEndpointCatalog(scopeId)) {
+                return Endpoint;
+            }
+            if (inServiceRelationCatalog(scopeId)) {
+                return ServiceRelation;
+            }
+            if (inServiceInstanceRelationCatalog(scopeId)) {
+                return ServiceInstanceRelation;
+            }
+            if (inEndpointRelationCatalog(scopeId)) {
+                return EndpointRelation;
+            }
+            if (inProcessCatalog(scopeId)) {
+                return Process;
+            }
+            if (inProcessRelationCatalog(scopeId)) {
+                return ProcessRelation;
+            }
+            return All;
         }
     }
 


### PR DESCRIPTION
The previous implementation could only support scopes being catalogs.

<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

No changelog, as this bug doesn't affect previous versions, but we found it in implementing PromQL.