### PR TITLE
fix:Utility classes should not have public constructors

### DIFF
--- a/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/BooleanUtils.java
+++ b/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/BooleanUtils.java
@@ -20,6 +20,9 @@ package org.apache.skywalking.oap.server.library.util;
 
 public class BooleanUtils {
 
+    private BooleanUtils() {
+    }
+
     public static final int TRUE = 1;
     public static final int FALSE = 0;
 

--- a/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/CollectionUtils.java
+++ b/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/CollectionUtils.java
@@ -24,6 +24,9 @@ import java.util.Set;
 
 public class CollectionUtils {
 
+    private CollectionUtils() {
+    }
+
     public static boolean isEmpty(Map map) {
         return map == null || map.size() == 0;
     }

--- a/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/ResourceUtils.java
+++ b/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/ResourceUtils.java
@@ -33,6 +33,9 @@ import java.util.Objects;
 
 public class ResourceUtils {
 
+    private ResourceUtils() {
+    }
+
     public static Reader read(String fileName) throws FileNotFoundException {
         return new InputStreamReader(readToStream(fileName), StandardCharsets.UTF_8);
     }

--- a/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/StringUtil.java
+++ b/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/StringUtil.java
@@ -19,6 +19,10 @@
 package org.apache.skywalking.oap.server.library.util;
 
 public final class StringUtil {
+
+    private StringUtil() {
+    }
+
     public static boolean isEmpty(String str) {
         return str == null || str.length() == 0;
     }

--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/MetricsQuery.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/resolver/MetricsQuery.java
@@ -102,7 +102,7 @@ public class MetricsQuery implements GraphQLQueryResolver {
      * Metrics definition metadata query. Response the metrics type which determines the suitable query methods.
      */
     public MetricsType typeOfMetrics(String name) throws IOException {
-        return getMetricsMetadataQueryService().typeOfMetrics(name);
+        return MetricsMetadataQueryService.typeOfMetrics(name);
     }
 
     /**


### PR DESCRIPTION
Utility classes, which are collections of static members, are not meant to be instantiated. Even abstract utility classes, which can be extended, should not have public constructors.
Java adds an implicit public constructor to every class which does not define at least one explicitly. Hence, at least one non-public constructor should be defined.