### PR TITLE
ElasticSearch storage does not check field types when OAP running in `no-init` mode

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -6,6 +6,7 @@
 #### OAP Server
 
 * Fix wrong layer of metric `user error` in DynamoDB monitoring.
+* ElasticSearch storage does not check field types when OAP running in `no-init` mode.
 
 #### Documentation
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexStructures.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndexStructures.java
@@ -107,6 +107,23 @@ public class IndexStructures {
     }
 
     /**
+     * Check whether all the fields are already defined regardless of the field types.
+     * When OAP runs in no-init mode, it doesn't care about the field types, it just
+     * cares about whether the data can be ingested without reporting error.
+     * OAP running in init mode should take care of the field types.
+     */
+    public boolean containsFieldNames(String tableName, Mappings mappings) {
+        if (Objects.isNull(mappings) ||
+            CollectionUtils.isEmpty(mappings.getProperties())) {
+            return true;
+        }
+
+        return mappingStructures.containsKey(tableName) &&
+                mappingStructures.get(tableName)
+                        .containsAllFieldNames(new Fields(mappings));
+    }
+
+    /**
      * Returns true when the current index setting equals the input.
      */
     public boolean compareIndexSetting(String tableName, Map<String, Object> settings) {
@@ -125,7 +142,7 @@ public class IndexStructures {
      */
     public static class Fields {
         private final Map<String, Object> properties;
-        private Mappings.Source source;
+        private final Mappings.Source source;
 
         private Fields(Mappings mapping) {
             this.properties = mapping.getProperties();
@@ -157,6 +174,13 @@ public class IndexStructures {
                 }
             }
             return true;
+        }
+
+        private boolean containsAllFieldNames(Fields fields) {
+            if (this.properties.size() < fields.properties.size()) {
+                return false;
+            }
+            return this.properties.keySet().containsAll(fields.properties.keySet());
         }
 
         /**


### PR DESCRIPTION


<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).


When OAP runs in no-init mode, it only cares about whether the data can be ingested without reporting errors, and the fields are not dropped, it doesn't care about whether the field types are changed or not, the OAP running in init mode should take care about the field types and update the ElasticSearch index/template when needed.