### PR TITLE
JavaDoc input should contain delombok output and fix javadoc not executed in CI

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Check results
         run: |
           [[ ${{ needs.license-header.result }} == 'success' ]] || exit 1;
-          [[ ${{ needs.code-style.result }} == 'success' ]] || exit 1
+          [[ ${{ needs.code-style.result }} == 'success' ]] || exit 1;
           [[ ${{ needs.check-javadoc.result }} == 'success' ]] || exit 1;
           [[ ${{ needs.dependency-license.result }} == 'success' ]] || [[ ${{ needs.dependency-license.result }} == 'skipped' ]] || exit 1;
 

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -55,6 +55,19 @@ jobs:
       - name: Check code style
         run: ./mvnw -B -q clean checkstyle:check
 
+  check-javadoc:
+    if: (github.event_name == 'schedule' && github.repository == 'apache/skywalking') || (github.event_name != 'schedule')
+    name: Check JavaDoc
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Check JavaDoc
+        run: ./mvnw -B -q clean javadoc:javadoc
+
+
   dependency-license:
     if: |
       ( always() && ! cancelled() ) &&
@@ -89,14 +102,15 @@ jobs:
   sanity-check:
     if: ( always() && ! cancelled() ) && (github.event_name == 'schedule' && github.repository == 'apache/skywalking') || (github.event_name != 'schedule')
     name: Sanity check results
-    needs: [license-header, code-style, dependency-license]
+    needs: [license-header, code-style, check-javadoc, dependency-license]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Check results
         run: |
           [[ ${{ needs.license-header.result }} == 'success' ]] || exit 1;
-          [[ ${{ needs.code-style.result }} == 'success' ]] || exit 1;
+          [[ ${{ needs.code-style.result }} == 'success' ]] || exit 1
+          [[ ${{ needs.check-javadoc.result }} == 'success' ]] || exit 1;
           [[ ${{ needs.dependency-license.result }} == 'success' ]] || [[ ${{ needs.dependency-license.result }} == 'skipped' ]] || exit 1;
 
   changes:

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -55,19 +55,6 @@ jobs:
       - name: Check code style
         run: ./mvnw -B -q clean checkstyle:check
 
-  check-javadoc:
-    if: (github.event_name == 'schedule' && github.repository == 'apache/skywalking') || (github.event_name != 'schedule')
-    name: Check JavaDoc
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Check JavaDoc
-        run: ./mvnw -B -q clean javadoc:javadoc
-
-
   dependency-license:
     if: |
       ( always() && ! cancelled() ) &&
@@ -102,7 +89,7 @@ jobs:
   sanity-check:
     if: ( always() && ! cancelled() ) && (github.event_name == 'schedule' && github.repository == 'apache/skywalking') || (github.event_name != 'schedule')
     name: Sanity check results
-    needs: [license-header, code-style, check-javadoc, dependency-license]
+    needs: [license-header, code-style, dependency-license]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -110,7 +97,6 @@ jobs:
         run: |
           [[ ${{ needs.license-header.result }} == 'success' ]] || exit 1;
           [[ ${{ needs.code-style.result }} == 'success' ]] || exit 1;
-          [[ ${{ needs.check-javadoc.result }} == 'success' ]] || exit 1;
           [[ ${{ needs.dependency-license.result }} == 'success' ]] || [[ ${{ needs.dependency-license.result }} == 'skipped' ]] || exit 1;
 
   changes:
@@ -175,7 +161,7 @@ jobs:
           cache: "maven"
       - name: Build distribution tar
         run: |
-          ./mvnw clean install -B -q \
+          ./mvnw clean install javadoc:javadoc -B -q \
             -Dmaven.test.skip \
             -Dcheckstyle.skip
       - uses: actions/upload-artifact@v3

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,8 @@
         <skipUTs>false</skipUTs>
 
         <system-stubs.version>2.0.2</system-stubs.version>
+
+        <delombok.output.dir>${project.build.directory}/delombok</delombok.output.dir>
     </properties>
 
     <dependencies>
@@ -489,7 +491,7 @@
                 <configuration>
                     <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
                     <addOutputDirectory>false</addOutputDirectory>
-                    <outputDirectory>${project.build.directory}/delombok</outputDirectory>
+                    <outputDirectory>${delombok.output.dir}</outputDirectory>
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <executions>
@@ -513,7 +515,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <sourcepath>
-                        ${project.build.directory}/generated-sources/delombok;
+                        ${delombok.output.dir};
                         ${project.build.directory}/generated-sources/protobuf/java;
                         ${project.build.directory}/generated-sources/protobuf/grpc-java;
                         ${project.build.directory}/generated-sources/antlr4;;


### PR DESCRIPTION
mvn install doesn’t include the javadoc goal so the CI didn’t find the problem introduced in #10532, which changed the delombok output but didn’t change the javadoc input accordingly 