### PR TITLE
Retain +1 day tables when deleting history

### DIFF
--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCHistoryDeleteDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCHistoryDeleteDAO.java
@@ -50,8 +50,8 @@ public class JDBCHistoryDeleteDAO implements IHistoryDeleteDAO {
     @Override
     @SneakyThrows
     public void deleteHistory(Model model, String timeBucketColumnName, int ttl) {
-        final var endTimeBucket = TimeBucket.getTimeBucket(clock.millis(), DownSampling.Day);
-        final var startTimeBucket = endTimeBucket - ttl;
+        final var endTimeBucket = TimeBucket.getTimeBucket(clock.millis() + TimeUnit.DAYS.toMillis(1), DownSampling.Day);
+        final var startTimeBucket = endTimeBucket - ttl - 1;
         log.info(
             "Deleting history data, ttl: {}, now: {}. Keep [{}, {}]",
             ttl,
@@ -73,7 +73,7 @@ public class JDBCHistoryDeleteDAO implements IHistoryDeleteDAO {
             return;
         }
 
-        final var ttlTables = tableHelper.getTablesForRead(model.getName(), startTimeBucket, endTimeBucket);
+        final var ttlTables = tableHelper.getTablesInTimeBucketRange(model.getName(), startTimeBucket, endTimeBucket);
         final var tablesToDrop = new HashSet<String>();
         final var tableName = TableHelper.getTableName(model);
 


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md). No need, not released yet.

Currently when deleting outdated tables, the DAO only filters the tables that are in `T - ttl`, causing the newly created table for `T + 1` is deleted, this makes the table schema for `T + 1` incomplete, for example, when 2 (or more) metrics, `metrics_1` and `metrics_2` are the same function type (`metrics_longavg`), when deleting history tables for `metrics_1`, it will delete all tables in the pattern `metrics_longavg_\d{8}` except for the `[T - ttl, T]`, and a new table `metrics_longavg_<T+1>` is created, but at the same time when deleting the same for `metrics_2`, it will delete all tables except for `[T - ttl, T]`, causing the newly created `metrics_longavg_<T+1>` be deleted, and the data columns for `metrics_1` is gone.
