### PR TITLE
Support parse PromQL expression has empty labels in the braces for metadata query.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -20,6 +20,7 @@
 * [Breaking Change] Support cross-thread trace profiling. The data structure and query APIs are changed.
 * Fix PromQL HTTP API `/api/v1/labels` response missing `service` label.
 * Fix possible NPE when initialize `IntList`.
+* Support parse PromQL expression has empty labels in the braces for metadata query.
 
 #### UI
 * Revert: cpm5d function. This feature is cancelled from backend.

--- a/oap-server/server-query-plugin/promql-plugin/src/main/antlr4/org/apache/skywalking/promql/rt/grammar/PromQLParser.g4
+++ b/oap-server/server-query-plugin/promql-plugin/src/main/antlr4/org/apache/skywalking/promql/rt/grammar/PromQLParser.g4
@@ -36,7 +36,7 @@ mulDivMod:       MUL | DIV | MOD;
 compare:        (DEQ | NEQ | LTE | LT | GTE | GT) BOOL?;
 
 metricName:      NAME_STRING;
-metricInstant:   metricName | metricName L_BRACE labelList R_BRACE;
+metricInstant:   metricName | metricName L_BRACE labelList? R_BRACE;
 metricRange:     metricInstant L_BRACKET DURATION R_BRACKET;
 
 labelName:       NAME_STRING;


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
