### PR TITLE
Support alarm metric OP `!=`

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -21,6 +21,7 @@
 * Fix PromQL HTTP API `/api/v1/labels` response missing `service` label.
 * Fix possible NPE when initialize `IntList`.
 * Support parse PromQL expression has empty labels in the braces for metadata query.
+* Support alarm metric OP `!=`.
 
 #### UI
 * Revert: cpm5d function. This feature is cancelled from backend.

--- a/docs/en/setup/backend/backend-alarm.md
+++ b/docs/en/setup/backend/backend-alarm.md
@@ -43,7 +43,7 @@ The four label settings mentioned above must implement `LabeledValueHolder`.*
 For multiple-value metrics, such as **percentile**, the threshold is an array. It is described as:  `value1, value2, value3, value4, value5`.
 Each value may serve as the threshold for each value of the metrics. Set the value to `-` if you do not wish to trigger the Alarm by one or more of the values.  
 For example, in **percentile**, `value1` is the threshold of P50, and `-, -, value3, value4, value5` means that there is no threshold for P50 and P75 in the percentile alarm rule.
-- **OP**. The operator. It supports `>`, `>=`, `<`, `<=`, `==`. We welcome contributions of all OPs.
+- **OP**. The operator. It supports `>`, `>=`, `<`, `<=`, `==`, `!=`. We welcome contributions of all OPs.
 - **Period**. The size of metrics cache in minutes for checking the alarm conditions. This is a time window that corresponds to the backend deployment env time.
 - **Count**. Within a period window, if the number of times which **value** goes over the threshold (based on OP) reaches `count`, then an alarm will be sent.
 - **Only as condition**. Indicates if the rule can send notifications or if it simply serves as a condition of the composite rule.

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmRule.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmRule.java
@@ -36,7 +36,6 @@ import lombok.ToString;
 @ToString
 public class AlarmRule {
     private String alarmRuleName;
-
     private String metricsName;
     private ArrayList<String> includeNames;
     private String includeNamesRegex;

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/OP.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/OP.java
@@ -21,28 +21,28 @@ package org.apache.skywalking.oap.server.core.alarm.provider;
 import static java.util.Objects.requireNonNull;
 
 public enum OP {
-    GREATER {
+    GT {
         @Override
         public boolean test(final Number expected, final Number actual) {
             return requireNonNull(actual, "actual").doubleValue() > requireNonNull(expected, "expected").doubleValue();
         }
     },
 
-    GREATER_EQ {
+    GTE {
         @Override
         public boolean test(final Number expected, final Number actual) {
             return requireNonNull(actual, "actual").doubleValue() >= requireNonNull(expected, "expected").doubleValue();
         }
     },
 
-    LESS {
+    LT {
         @Override
         public boolean test(final Number expected, final Number actual) {
             return requireNonNull(actual, "actual").doubleValue() < requireNonNull(expected, "expected").doubleValue();
         }
     },
 
-    LESS_EQ {
+    LTE {
         @Override
         public boolean test(final Number expected, final Number actual) {
             return requireNonNull(actual, "actual").doubleValue() <= requireNonNull(expected, "expected").doubleValue();
@@ -51,25 +51,34 @@ public enum OP {
 
     // NOTICE: double equal is not reliable in Java,
     // match result is not predictable
-    EQUAL {
+    EQ {
         @Override
         public boolean test(final Number expected, final Number actual) {
             return requireNonNull(actual, "actual").doubleValue() == requireNonNull(expected, "expected").doubleValue();
+        }
+    },
+
+    NEQ {
+        @Override
+        public boolean test(final Number expected, final Number actual) {
+            return requireNonNull(actual, "actual").doubleValue() != requireNonNull(expected, "expected").doubleValue();
         }
     };
 
     public static OP get(String op) {
         switch (op) {
             case ">":
-                return GREATER;
+                return GT;
             case ">=":
-                return GREATER_EQ;
+                return GTE;
             case "<":
-                return LESS;
+                return LT;
             case "<=":
-                return LESS_EQ;
+                return LTE;
             case "==":
-                return EQUAL;
+                return EQ;
+            case "!=":
+                return NEQ;
             default:
                 throw new IllegalArgumentException("unknown op, " + op);
         }

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/OPTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/OPTest.java
@@ -25,20 +25,34 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class OPTest {
     @Test
     public void test() {
-        assertTrue(OP.EQUAL.test(123, 123));
-        assertTrue(OP.EQUAL.test(123L, 123L));
-        assertTrue(OP.EQUAL.test(123.0D, 123.0D));
+        assertTrue(OP.EQ.test(123, 123));
+        assertTrue(OP.EQ.test(123L, 123L));
+        assertTrue(OP.EQ.test(123.0D, 123.0D));
 
-        assertTrue(OP.GREATER.test(122, 123));
-        assertTrue(OP.GREATER.test(122L, 123L));
-        assertTrue(OP.GREATER.test(122.0D, 123.0D));
+        assertTrue(OP.NEQ.test(124, 123));
+        assertTrue(OP.NEQ.test(124L, 123L));
+        assertTrue(OP.NEQ.test(124.0D, 123.0D));
 
-        assertTrue(OP.GREATER_EQ.test(122, 123));
-        assertTrue(OP.GREATER_EQ.test(122L, 123L));
-        assertTrue(OP.GREATER_EQ.test(122.0D, 123.0D));
+        assertTrue(OP.GT.test(122, 123));
+        assertTrue(OP.GT.test(122L, 123L));
+        assertTrue(OP.GT.test(122.0D, 123.0D));
 
-        assertTrue(OP.LESS.test(124, 123));
-        assertTrue(OP.LESS.test(124L, 123L));
-        assertTrue(OP.LESS.test(124.0D, 123.0D));
+        assertTrue(OP.GTE.test(122, 123));
+        assertTrue(OP.GTE.test(122L, 123L));
+        assertTrue(OP.GTE.test(122.0D, 123.0D));
+        assertTrue(OP.GTE.test(122, 122));
+        assertTrue(OP.GTE.test(122L, 122L));
+        assertTrue(OP.GTE.test(122.0D, 122.0D));
+
+        assertTrue(OP.LT.test(124, 123));
+        assertTrue(OP.LT.test(124L, 123L));
+        assertTrue(OP.LT.test(124.0D, 123.0D));
+
+        assertTrue(OP.LTE.test(124, 124));
+        assertTrue(OP.LTE.test(124L, 124L));
+        assertTrue(OP.LTE.test(124.0D, 124.0D));
+        assertTrue(OP.LTE.test(124, 123));
+        assertTrue(OP.LTE.test(124L, 123L));
+        assertTrue(OP.LTE.test(124.0D, 123.0D));
     }
 }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
