### PR TITLE
Add SUM_PER_MIN to MAL documentation

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -42,5 +42,6 @@
 #### Documentation
 
 * Add Profiling related documentations.
+* Add `SUM_PER_MIN` to MAL documentation.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/169?closed=1)

--- a/docs/en/concepts-and-designs/mal.md
+++ b/docs/en/concepts-and-designs/mal.md
@@ -225,6 +225,7 @@ Down sampling function is called `downsampling` in MAL, and it accepts the follo
  - AVG
  - SUM
  - LATEST
+ - SUM_PER_MIN
  - MIN (TODO)
  - MAX (TODO)
  - MEAN (TODO)


### PR DESCRIPTION
Noticed `SUM_PER_MIN` wasn't mentioned in documentation