### PR TITLE
Fix PromQL HTTP API `/api/v1/series` response missing `service` label when matching metric

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -35,6 +35,7 @@
 * Support no-proxy mode for aws-firehose receiver
 * Bump up armeria to 1.23.1
 * Support Elasticsearch Monitoring.
+* Fix PromQL HTTP API `/api/v1/series` response missing `service` label when matching metric.
 
 #### UI
 * Revert: cpm5d function. This feature is cancelled from backend.

--- a/oap-server/server-query-plugin/promql-plugin/src/main/java/org/apache/skywalking/oap/query/promql/handler/PromQLApiHandler.java
+++ b/oap-server/server-query-plugin/promql-plugin/src/main/java/org/apache/skywalking/oap/query/promql/handler/PromQLApiHandler.java
@@ -500,11 +500,13 @@ public class PromQLApiHandler {
                 break;
             case ServiceInstance:
                 metricInfo.getLabels().add(new LabelValuePair(LabelName.SCOPE, Scope.ServiceInstance.name()));
+                metricInfo.getLabels().add(new LabelValuePair(LabelName.SERVICE, ""));
                 metricInfo.getLabels().add(new LabelValuePair(LabelName.SERVICE_INSTANCE, ""));
                 metricInfo.getLabels().add(new LabelValuePair(LabelName.PARENT_SERVICE, ""));
                 break;
             case Endpoint:
                 metricInfo.getLabels().add(new LabelValuePair(LabelName.SCOPE, Scope.Endpoint.name()));
+                metricInfo.getLabels().add(new LabelValuePair(LabelName.SERVICE, ""));
                 metricInfo.getLabels().add(new LabelValuePair(LabelName.ENDPOINT, ""));
                 metricInfo.getLabels().add(new LabelValuePair(LabelName.PARENT_SERVICE, ""));
                 break;

--- a/test/e2e-v2/cases/promql/expected/endpoint-metric-series.yml
+++ b/test/e2e-v2/cases/promql/expected/endpoint-metric-series.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{
+  "status": "success",
+  "data": [
+    {
+      "__name__": "endpoint_cpm",
+      "layer": "",
+      "top_n": "",
+      "order": "",
+      "scope": "Endpoint",
+      "service": "",
+      "endpoint": "",
+      "parent_service": ""
+    }
+  ]
+}

--- a/test/e2e-v2/cases/promql/expected/instance-metric-series.yml
+++ b/test/e2e-v2/cases/promql/expected/instance-metric-series.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{
+  "status": "success",
+  "data": [
+    {
+      "__name__": "service_instance_cpm",
+      "layer": "",
+      "top_n": "",
+      "order": "",
+      "scope": "ServiceInstance",
+      "service": "",
+      "service_instance": "",
+      "parent_service": ""
+    }
+  ]
+}

--- a/test/e2e-v2/cases/promql/expected/service-metric-series.yml
+++ b/test/e2e-v2/cases/promql/expected/service-metric-series.yml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{
+  "status": "success",
+  "data": [
+    {
+      "__name__": "service_cpm",
+      "layer": "",
+      "top_n": "",
+      "order": "",
+      "scope": "Service",
+      "service": ""
+    }
+  ]
+}

--- a/test/e2e-v2/cases/promql/promql-cases.yaml
+++ b/test/e2e-v2/cases/promql/promql-cases.yaml
@@ -21,6 +21,13 @@ cases:
     expected: expected/instance-traffic.yml
   - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/series -d 'match[]=endpoint_traffic{layer="GENERAL", service="e2e-service-provider", keyword="POST:/users"}&start='$(($(date +%s)-1800))'&end='$(date +%s)
     expected: expected/endpoint-traffic.yml
+  # metrics series
+  - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/series -d 'match[]=service_cpm&start='$(($(date +%s)-1800))'&end='$(date +%s)
+    expected: expected/service-metric-series.yml
+  - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/series -d 'match[]=service_instance_cpm&start='$(($(date +%s)-1800))'&end='$(date +%s)
+    expected: expected/instance-metric-series.yml
+  - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/series -d 'match[]=endpoint_cpm&start='$(($(date +%s)-1800))'&end='$(date +%s)
+    expected: expected/endpoint-metric-series.yml
   # metrics names query
   - query: curl -X  GET http://${oap_host}:${oap_9090}/api/v1/label/__name__/values
     expected: expected/metrics-names.yml


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
