### PR TITLE
Fix typo in backend-meter doc

### DIFF
--- a/docs/en/setup/backend/backend-meter.md
+++ b/docs/en/setup/backend/backend-meter.md
@@ -73,7 +73,7 @@ All available meter analysis scripts could be found [here](../../../../oap-serve
 |satellite| Metrics of SkyWalking Satellite self-observability(so11y)| meter-analyzer-config/satellite.yaml| SkyWalking Satellite --meter format-->SkyWalking OAP Server|
 |threadpool| Metrics of Thread Pool | meter-analyzer-config/threadpool.yaml | Thread Pool --meter format--> SkyWalking OAP Server |
 |datasource| Metrics of DataSource metrics | meter-analyzer-config/datasource.yaml | Datasource --meter format--> SkyWalking OAP Server |
-|spring-micrometer| Metrics of Spring Sleuth Application | meter-analyzer-config/spring-micrometer.yaml | Sprign Sleuth Application --meter format--> SkyWalking OAP Server |
+|spring-micrometer| Metrics of Spring Sleuth Application | meter-analyzer-config/spring-micrometer.yaml | Spring Sleuth Application --meter format--> SkyWalking OAP Server |
 
 An example can be found [here](../../../../oap-server/server-starter/src/main/resources/meter-analyzer-config/spring-micrometer.yaml).
 If you're using Spring MicroMeter Observations, see [Spring MicroMeter Observations APIs](micrometer-observations.md).


### PR DESCRIPTION
The word 'Sprign' in document [docs/en/setup/backend/backend-meter.md] is wrong.It is shoud be 'Spring'.so changed  'Sprign' to 'Spring'.