### PR TITLE
Support composite ID to replace entity ID in BanyanDB case.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -71,7 +71,7 @@
 * Add OpenTelemetry log protocol support.
 * [Breaking Change] Configuration key `enabledOtelRules` is renamed to `enabledOtelMetricsRules` and
   the corresponding environment variable is renamed to `SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES`.
-* Support composite ID declared from existing columns, rather a new virtual column, in the BanyanDB.
+* Support composite ID declared from existing columns, rather than a new virtual column, in the BanyanDB.
 * In the BanyanDB implementation, metrics built from ServiceInstance and Endpoint sources are not using `entity_id` as ID,
   instead, they use composite ID built by `service_id` and `name` to reduce redundant indices in the database.
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -71,6 +71,9 @@
 * Add OpenTelemetry log protocol support.
 * [Breaking Change] Configuration key `enabledOtelRules` is renamed to `enabledOtelMetricsRules` and
   the corresponding environment variable is renamed to `SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES`.
+* Support composite ID declared from existing columns, rather a new virtual column, in the BanyanDB.
+* In the BanyanDB implementation, metrics built from ServiceInstance and Endpoint sources are not using `entity_id` as ID,
+  instead, they use composite ID built by `service_id` and `name` to reduce redundant indices in the database.
 
 #### Documentation
 

--- a/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/SourceColumn.java
+++ b/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/SourceColumn.java
@@ -34,9 +34,11 @@ public class SourceColumn {
     private int length;
     private String fieldSetter;
     private String fieldGetter;
+    private final int idxOfCompositeID;
     private final boolean groupByCondInTopN;
 
     public SourceColumn(String fieldName, String columnName, Class<?> type, boolean isID, int length,
+                        final int idxOfCompositeID,
                         boolean groupByCondInTopN) {
         this.fieldName = fieldName;
         this.columnName = columnName;
@@ -47,6 +49,7 @@ public class SourceColumn {
 
         this.fieldGetter = ClassMethodUtil.toGetMethod(fieldName);
         this.fieldSetter = ClassMethodUtil.toSetMethod(fieldName);
+        this.idxOfCompositeID = idxOfCompositeID;
         this.groupByCondInTopN = groupByCondInTopN;
     }
 

--- a/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/SourceColumnsFactory.java
+++ b/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/SourceColumnsFactory.java
@@ -30,8 +30,10 @@ public class SourceColumnsFactory {
         List<ScopeDefaultColumn> columns = DefaultScopeDefine.getDefaultColumns(source);
         for (ScopeDefaultColumn defaultColumn : columns) {
             sourceColumns.add(
-                new SourceColumn(defaultColumn.getFieldName(), defaultColumn.getColumnName(), defaultColumn
-                    .getType(), defaultColumn.isID(), defaultColumn.getLength(), defaultColumn.isGroupByCondInTopN()));
+                new SourceColumn(defaultColumn.getFieldName(), defaultColumn.getColumnName(),
+                                 defaultColumn.getType(), defaultColumn.isID(), defaultColumn.getLength(),
+                                 defaultColumn.getIdxOfCompositeID(), defaultColumn.isGroupByCondInTopN()
+                ));
         }
         return sourceColumns;
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/oal/rt/OALEngine.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/oal/rt/OALEngine.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.core.oal.rt;
 import org.apache.skywalking.oap.server.core.analysis.DispatcherDetectorListener;
 import org.apache.skywalking.oap.server.core.analysis.StreamAnnotationListener;
 import org.apache.skywalking.oap.server.core.storage.StorageBuilderFactory;
+import org.apache.skywalking.oap.server.core.storage.StorageCharacter;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
 
 /**
@@ -36,4 +37,6 @@ public interface OALEngine {
     void start(ClassLoader currentClassLoader) throws ModuleStartException, OALCompileException;
 
     void notifyAllListeners() throws ModuleStartException;
+
+    void setStorageCharacter(StorageCharacter character);
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/oal/rt/OALEngineLoaderService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/oal/rt/OALEngineLoaderService.java
@@ -26,6 +26,7 @@ import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.StreamAnnotationListener;
 import org.apache.skywalking.oap.server.core.source.SourceReceiver;
 import org.apache.skywalking.oap.server.core.storage.StorageBuilderFactory;
+import org.apache.skywalking.oap.server.core.storage.StorageCharacter;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.module.ModuleProvider;
@@ -61,6 +62,9 @@ public class OALEngineLoaderService implements Service {
             engine.setStorageBuilderFactory(moduleManager.find(StorageModule.NAME)
                                                          .provider()
                                                          .getService(StorageBuilderFactory.class));
+            engine.setStorageCharacter(moduleManager.find(StorageModule.NAME)
+                                                         .provider()
+                                                         .getService(StorageCharacter.class));
 
             engine.start(OALEngineLoaderService.class.getClassLoader());
             engine.notifyAllListeners();

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DefaultScopeDefine.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DefaultScopeDefine.java
@@ -203,9 +203,10 @@ public class DefaultScopeDefine {
         ScopeDefaultColumn.VirtualColumnDefinition virtualColumn = (ScopeDefaultColumn.VirtualColumnDefinition) originalClass
             .getAnnotation(ScopeDefaultColumn.VirtualColumnDefinition.class);
         if (virtualColumn != null) {
+            // Virtual column doesn't use composite ID mechanism.
             scopeDefaultColumns.add(
                 new ScopeDefaultColumn(virtualColumn.fieldName(), virtualColumn.columnName(), virtualColumn
-                    .type(), virtualColumn.isID(), virtualColumn.length(), false));
+                    .type(), virtualColumn.isID(), virtualColumn.length(), -1, false));
         }
         Field[] scopeClassField = originalClass.getDeclaredFields();
         if (scopeClassField != null) {
@@ -216,8 +217,14 @@ public class DefaultScopeDefine {
                     if (!definedByField.requireDynamicActive() || ACTIVE_EXTRA_MODEL_COLUMNS) {
                         scopeDefaultColumns.add(
                             new ScopeDefaultColumn(
-                                field.getName(), definedByField.columnName(), field.getType(), false,
-                                definedByField.length(), definedByField.groupByCondInTopN()
+                                field.getName(),
+                                definedByField.columnName(),
+                                field.getType(),
+                                // If the index for the composite ID, this column is an ID.
+                                definedByField.idxOfCompositeID() > -1,
+                                definedByField.length(),
+                                definedByField.idxOfCompositeID(),
+                                definedByField.groupByCondInTopN()
                             ));
                     }
                 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Endpoint.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Endpoint.java
@@ -51,10 +51,10 @@ public class Endpoint extends Source {
 
     @Getter
     @Setter
-    @ScopeDefaultColumn.DefinedByField(columnName = "name", requireDynamicActive = true)
+    @ScopeDefaultColumn.DefinedByField(columnName = "name", requireDynamicActive = true, idxOfCompositeID = 1)
     private String name;
     @Getter
-    @ScopeDefaultColumn.DefinedByField(columnName = "service_id", groupByCondInTopN = true)
+    @ScopeDefaultColumn.DefinedByField(columnName = "service_id", groupByCondInTopN = true, idxOfCompositeID = 0)
     private String serviceId;
     @Getter
     @Setter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ScopeDefaultColumn.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ScopeDefaultColumn.java
@@ -24,28 +24,22 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Define the default columns of source scope. These columns pass down into the persistent entity(OAL metrics entity)
  * automatically.
  */
 @Getter
+@RequiredArgsConstructor
 public class ScopeDefaultColumn {
-    private String fieldName;
-    private String columnName;
-    private Class<?> type;
-    private boolean isID;
-    private int length;
+    private final String fieldName;
+    private final String columnName;
+    private final Class<?> type;
+    private final boolean isID;
+    private final int length;
+    private final int idxOfCompositeID;
     private final boolean groupByCondInTopN;
-
-    public ScopeDefaultColumn(String fieldName, String columnName, Class<?> type, boolean isID, int length, boolean groupByCondInTopN) {
-        this.fieldName = fieldName;
-        this.columnName = columnName;
-        this.type = type;
-        this.isID = isID;
-        this.length = length;
-        this.groupByCondInTopN = groupByCondInTopN;
-    }
 
     @Target({ElementType.FIELD})
     @Retention(RetentionPolicy.RUNTIME)
@@ -71,6 +65,17 @@ public class ScopeDefaultColumn {
          * @since 9.5.0
          */
         boolean groupByCondInTopN() default false;
+
+        /**
+         * Each metric should include all fields composing the raw ID.
+         * In the previous implementation, we build an entity_id by {@link VirtualColumnDefinition#isID()} == true,
+         * but in now, some storage like BanyanDB, it supports a composite ID by multiple existing fields natively,
+         * so, this new composite ID is created, logically as same as the virtual ID.
+         *
+         * @return the index of this field when it is a part of ID. Or return -1 if not a part of ID.
+         * @since 9.5.0
+         */
+        int idxOfCompositeID() default -1;
     }
 
     @Target({ElementType.TYPE})

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstance.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstance.java
@@ -47,11 +47,11 @@ public class ServiceInstance extends Source {
     }
 
     @Getter
-    @ScopeDefaultColumn.DefinedByField(columnName = "service_id")
+    @ScopeDefaultColumn.DefinedByField(columnName = "service_id", idxOfCompositeID = 0)
     private String serviceId;
     @Getter
     @Setter
-    @ScopeDefaultColumn.DefinedByField(columnName = "name", requireDynamicActive = true)
+    @ScopeDefaultColumn.DefinedByField(columnName = "name", requireDynamicActive = true, idxOfCompositeID = 1)
     private String name;
     @Getter
     @Setter

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/StorageCharacter.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/StorageCharacter.java
@@ -1,0 +1,27 @@
+package org.apache.skywalking.oap.server.core.storage;
+
+import org.apache.skywalking.oap.server.core.source.ScopeDefaultColumn;
+import org.apache.skywalking.oap.server.library.module.Service;
+
+/**
+ * StorageCharacter provides core aware characters which make the core could run optimized codes accordingly.
+ *
+ * @since 9.5.0
+ */
+public interface StorageCharacter extends Service {
+    /**
+     * See {@link ScopeDefaultColumn.DefinedByField#idxOfCompositeID()}
+     *
+     * @return true if ID is declared through existing column, but not a virtual column. Typically, there was an entity_id
+     * column to represent a subject(service, endpoint, et.c)
+     */
+    boolean supportCompositeID();
+
+    class Default implements StorageCharacter {
+
+        @Override
+        public boolean supportCompositeID() {
+            return false;
+        }
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/StorageModule.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/StorageModule.java
@@ -59,6 +59,7 @@ public class StorageModule extends ModuleDefine {
     public Class[] services() {
         return new Class[] {
             StorageBuilderFactory.class,
+            StorageCharacter.class,
             IBatchDAO.class,
             StorageDAO.class,
             IHistoryDeleteDAO.class,

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBStorageProvider.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBStorageProvider.java
@@ -24,6 +24,7 @@ import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.storage.IBatchDAO;
 import org.apache.skywalking.oap.server.core.storage.IHistoryDeleteDAO;
 import org.apache.skywalking.oap.server.core.storage.StorageBuilderFactory;
+import org.apache.skywalking.oap.server.core.storage.StorageCharacter;
 import org.apache.skywalking.oap.server.core.storage.StorageDAO;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.cache.INetworkAddressAliasDAO;
@@ -116,6 +117,15 @@ public class BanyanDBStorageProvider extends ModuleProvider {
     @Override
     public void prepare() throws ServiceNotProvidedException, ModuleStartException {
         this.registerServiceImplementation(StorageBuilderFactory.class, new StorageBuilderFactory.Default());
+        this.registerServiceImplementation(
+            StorageCharacter.class,
+            new StorageCharacter() {
+                @Override
+                public boolean supportCompositeID() {
+                    return true;
+                }
+            }
+        );
 
         this.client = new BanyanDBStorageClient(config.getHost(), config.getPort());
         this.modelInstaller = new BanyanDBIndexInstaller(client, getManager(), this.config);

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchProvider.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchProvider.java
@@ -27,6 +27,7 @@ import org.apache.skywalking.oap.server.core.config.ConfigService;
 import org.apache.skywalking.oap.server.core.storage.IBatchDAO;
 import org.apache.skywalking.oap.server.core.storage.IHistoryDeleteDAO;
 import org.apache.skywalking.oap.server.core.storage.StorageBuilderFactory;
+import org.apache.skywalking.oap.server.core.storage.StorageCharacter;
 import org.apache.skywalking.oap.server.core.storage.StorageDAO;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.cache.INetworkAddressAliasDAO;
@@ -132,6 +133,11 @@ public class StorageModuleElasticsearchProvider extends ModuleProvider {
     @Override
     public void prepare() throws ServiceNotProvidedException {
         this.registerServiceImplementation(StorageBuilderFactory.class, new StorageBuilderFactory.Default());
+
+        this.registerServiceImplementation(
+            StorageCharacter.class,
+            new StorageCharacter.Default()
+        );
 
         if (StringUtil.isEmpty(config.getNamespace())) {
             config.setNamespace("sw");

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/JDBCStorageProvider.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/JDBCStorageProvider.java
@@ -22,6 +22,7 @@ import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.storage.IBatchDAO;
 import org.apache.skywalking.oap.server.core.storage.IHistoryDeleteDAO;
 import org.apache.skywalking.oap.server.core.storage.StorageBuilderFactory;
+import org.apache.skywalking.oap.server.core.storage.StorageCharacter;
 import org.apache.skywalking.oap.server.core.storage.StorageDAO;
 import org.apache.skywalking.oap.server.core.storage.StorageException;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
@@ -129,6 +130,11 @@ public abstract class JDBCStorageProvider extends ModuleProvider {
         this.registerServiceImplementation(
             StorageBuilderFactory.class,
             new StorageBuilderFactory.Default());
+
+        this.registerServiceImplementation(
+            StorageCharacter.class,
+            new StorageCharacter.Default()
+        );
 
         this.registerServiceImplementation(
             IBatchDAO.class,


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

* Support composite ID declared from existing columns, rather than a new virtual column, in the BanyanDB.
* In the BanyanDB implementation, metrics built from ServiceInstance and Endpoint sources are not using `entity_id` as ID,
  instead, they use composite ID built by `service_id` and `name` to reduce redundant indices in the database.

@lujiajing1126 This is a request from Gao according to his perf test benchmark. I made most parts of the implementation, and hope the idea is clear enough for both of you to continue. 

I am marking this as a draft PR, as it is not tested. These should be expected
* In all other storages, the column and logic should be unchanged, entity_id is still treated as the major ID.
* BanyanDB storage would not generate entity IDs for metrics built from ServiceInstance and Endpoint. 