### PR TITLE
Fix data loss when query continuous profiling task record

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -46,6 +46,7 @@
 * Filter out unknown_cluster metric data.
 * Support RabbitMQ Monitoring.
 * Support Redis slow logs collection.
+* Fix data loss when query continuous profiling task record.
 
 #### UI
 * Revert: cpm5d function. This feature is cancelled from backend.

--- a/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/ContinuousProfilingServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/ContinuousProfilingServiceHandler.java
@@ -33,6 +33,7 @@ import org.apache.skywalking.apm.network.ebpf.profiling.v3.ContinuousProfilingSe
 import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.IDManager;
+import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.analysis.worker.NoneStreamProcessor;
 import org.apache.skywalking.oap.server.core.command.CommandService;
 import org.apache.skywalking.oap.server.core.profiling.continuous.storage.ContinuousProfilingMonitorType;
@@ -178,6 +179,7 @@ public class ContinuousProfilingServiceHandler extends ContinuousProfilingServic
         task.setFixedTriggerDuration(request.getDuration());
         task.setCreateTime(currentTime);
         task.setLastUpdateTime(currentTime);
+        task.setTimeBucket(TimeBucket.getRecordTimeBucket(currentTime));
 
         final EBPFProfilingTaskContinuousProfiling continuousProfiling = new EBPFProfilingTaskContinuousProfiling();
         continuousProfiling.setProcessId(processId);

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/EBPFProfilingTaskEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/EBPFProfilingTaskEsDAO.java
@@ -86,6 +86,9 @@ public class EBPFProfilingTaskEsDAO extends EsDAO implements IEBPFProfilingTaskD
         final String index =
             IndexController.LogicIndicesRegister.getPhysicalTableName(EBPFProfilingTaskRecord.INDEX_NAME);
         final BoolQueryBuilder query = Query.bool();
+        if (IndexController.LogicIndicesRegister.isMergedTable(EBPFProfilingTaskRecord.INDEX_NAME)) {
+            query.must(Query.term(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME, EBPFProfilingTaskRecord.INDEX_NAME));
+        }
 
         if (StringUtil.isNotEmpty(serviceId)) {
             query.must(Query.term(EBPFProfilingTaskRecord.SERVICE_ID, serviceId));


### PR DESCRIPTION
Because Continuous Profiling did not set TimeBucket when reporting the task, the data was deleted by TTL. So I set the TimeBucket field to fix it. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
