### PR TITLE
Revert selecting `Ready` Pods, remove `Terminating` Pods in OAP cluster

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -8,7 +8,6 @@
 
 * Add Neo4j component ID(112) language: Python.
 * Add Istio ServiceEntry registry to resolve unknown IPs in ALS.
-* Improve Kubernetes coordinator to only select ready OAP Pods to build cluster.
 * Wrap `deleteProperty` API to the BanyanDBStorageClient.
 * [Breaking change] Remove `matchedCounter` from `HttpUriRecognitionService#feedRawData`.
 * Remove patterns from `HttpUriRecognitionService#feedRawData` and add max 10 candidates of raw URIs for each pattern.
@@ -17,6 +16,7 @@
 * Fix `NPE` in metrics query when the metric is not exist.
 * Remove E2E tests for Istio < 1.15, ElasticSearch < 7.16.3, they might still work but are not supported as planed.
 * Scroll all results in ElasticSearch storage and refactor scrolling logics, including Service, Instance, Endpoint, Process, etc.
+* Improve Kubernetes coordinator to remove `Terminating` OAP Pods in cluster.
 
 #### UI
 * Fix metric name `browser_app_error_rate` in `Browser-Root` dashboard.

--- a/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/kubernetes/KubernetesCoordinator.java
+++ b/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/kubernetes/KubernetesCoordinator.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.skywalking.library.kubernetes.KubernetesPods;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.cluster.ClusterCoordinator;
 import org.apache.skywalking.oap.server.core.cluster.ClusterHealthStatus;
@@ -179,9 +178,9 @@ public class KubernetesCoordinator extends ClusterCoordinator {
                 switch (event) {
                     case ADDED:
                     case MODIFIED:
-                        if (KubernetesPods.isReady(pod)) {
+                        if ("Running".equalsIgnoreCase(pod.getStatus().getPhase())) {
                             remoteInstanceMap.put(remoteInstance.getAddress().toString(), remoteInstance);
-                        } else {
+                        } else if ("Terminating".equalsIgnoreCase(pod.getStatus().getPhase())) {
                             remoteInstanceMap.remove(remoteInstance.getAddress().toString());
                         }
                         break;

--- a/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/kubernetes/NamespacedPodListInformer.java
+++ b/oap-server/server-cluster-plugin/cluster-kubernetes-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/kubernetes/NamespacedPodListInformer.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.cache.Lister;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.skywalking.library.kubernetes.KubernetesPods;
 
 import java.util.List;
 import java.util.Optional;
@@ -68,7 +67,7 @@ public enum NamespacedPodListInformer {
         return Optional.ofNullable(podLister.list().size() != 0
             ? podLister.list()
                        .stream()
-                       .filter(KubernetesPods::isReady)
+                       .filter(pod -> "Running".equalsIgnoreCase(pod.getStatus().getPhase()))
                        .collect(Collectors.toList())
             : null);
     }

--- a/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesPods.java
+++ b/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesPods.java
@@ -72,16 +72,6 @@ public enum KubernetesPods {
         });
     }
 
-    public static boolean isReady(Pod pod) {
-        return "Running".equalsIgnoreCase(pod.getStatus().getPhase()) &&
-            pod.getStatus()
-               .getConditions()
-               .stream()
-               .anyMatch(condition ->
-                   "Ready".equalsIgnoreCase(condition.getType()) &&
-                       "True".equalsIgnoreCase(condition.getStatus()));
-    }
-
     @SneakyThrows
     public Optional<Pod> findByIP(final String ip) {
         return podByIP.get(ip);


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).


Reverts https://github.com/apache/skywalking/pull/10950 and https://github.com/apache/skywalking/pull/10969, as they look to be buggy