### PR TITLE
Fix and optimize AI endpoint grouping related functionalities

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -26,6 +26,7 @@
 * Add component ID for Aerospike(ID=149).
 * Packages with name `recevier` are renamed to `receiver`.
 * `BanyanDBMetricsDAO` handles `storeIDTag` in `multiGet` for `BanyanDBModelExtension`.
+* Fix endpoint grouping-related logic and enhance the performance of PatternTree retrieval. 
 
 #### UI
 

--- a/oap-server/microbench/src/main/java/org/apache/skywalking/oap/server/microbench/core/config/group/uri/RegexVSQuickMatchBenchmark.java
+++ b/oap-server/microbench/src/main/java/org/apache/skywalking/oap/server/microbench/core/config/group/uri/RegexVSQuickMatchBenchmark.java
@@ -126,69 +126,70 @@ public class RegexVSQuickMatchBenchmark extends AbstractMicrobenchmark {
 
 /**
  * # JMH version: 1.25
- * # VM version: JDK 11.0.18, OpenJDK 64-Bit Server VM, 11.0.18+10
- * # VM invoker: /Users/wusheng/Library/Java/JavaVirtualMachines/temurin-11.0.18/Contents/Home/bin/java
- * # VM options: -ea --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Didea.test.cyclic.buffer.size=1048576 -javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=53714:/Applications/IntelliJ IDEA.app/Contents/bin -Dfile.encoding=UTF-8 -Xmx512m -Xms512m -XX:MaxDirectMemorySize=512m -XX:BiasedLockingStartupDelay=0 -Djmh.executor=CUSTOM -Djmh.executor.class=org.apache.skywalking.oap.server.microbench.base.AbstractMicrobenchmark$JmhThreadExecutor
+ * # VM version: JDK 16.0.1, OpenJDK 64-Bit Server VM, 16.0.1+9-24
+ * # VM invoker: C:\Users\Sky\.jdks\openjdk-16.0.1\bin\java.exe
+ * # VM options: -ea --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Didea.test.cyclic.buffer.size=1048576 -javaagent:Y:\jetbrains\apps\IDEA-U\ch-0\231.8109.175\lib\idea_rt.jar=54938:Y:\jetbrains\apps\IDEA-U\ch-0\231.8109.175\bin -Dfile.encoding=UTF-8 -Xmx512m -Xms512m -XX:MaxDirectMemorySize=512m -XX:BiasedLockingStartupDelay=0 -Djmh.executor=CUSTOM -Djmh.executor.class=org.apache.skywalking.oap.server.microbench.base.AbstractMicrobenchmark$JmhThreadExecutor
  * # Warmup: 1 iterations, 10 s each
  * # Measurement: 1 iterations, 10 s each
  * # Timeout: 10 min per iteration
  * # Threads: 4 threads, will synchronize iterations
  * # Benchmark mode: Throughput, ops/time
- * # Benchmark: org.apache.skywalking.oap.server.microbench.core.config.group.uri.RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping
+ * # Benchmark: org.apache.skywalking.oap.server.microbench.core.config.group.uri.RegexVSQuickMatchBenchmark.notMatchRegex
+ * Benchmark                                                                                 Mode  Cnt         Score   Error   Units
+ * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping                                    thrpt       48317763.786           ops/s
+ * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.alloc.rate                     thrpt           8773.225          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.alloc.rate.norm                thrpt            200.014            B/op
+ * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Eden_Space            thrpt           8807.405          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Eden_Space.norm       thrpt            200.794            B/op
+ * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Survivor_Space        thrpt              0.050          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Survivor_Space.norm   thrpt              0.001            B/op
+ * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.count                          thrpt            303.000          counts
+ * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.time                           thrpt            325.000              ms
+ * RegexVSQuickMatchBenchmark.matchFirstRegex                                               thrpt       41040542.288           ops/s
+ * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.alloc.rate                                thrpt           8348.690          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.alloc.rate.norm                           thrpt            224.016            B/op
+ * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Eden_Space                       thrpt           8378.454          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Eden_Space.norm                  thrpt            224.815            B/op
+ * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Survivor_Space                   thrpt              0.057          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Survivor_Space.norm              thrpt              0.002            B/op
+ * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.count                                     thrpt            288.000          counts
+ * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.time                                      thrpt            282.000              ms
+ * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping                                   thrpt       35658131.267           ops/s
+ * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.alloc.rate                    thrpt           8020.546          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.alloc.rate.norm               thrpt            248.018            B/op
+ * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Eden_Space           thrpt           8043.279          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Eden_Space.norm      thrpt            248.721            B/op
+ * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Survivor_Space       thrpt              0.045          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Survivor_Space.norm  thrpt              0.001            B/op
+ * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.count                         thrpt            277.000          counts
+ * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.time                          thrpt            302.000              ms
+ * RegexVSQuickMatchBenchmark.matchFourthRegex                                              thrpt       11066068.208           ops/s
+ * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.alloc.rate                               thrpt           8273.312          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.alloc.rate.norm                          thrpt            824.060            B/op
+ * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Eden_Space                      thrpt           8279.984          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Eden_Space.norm                 thrpt            824.724            B/op
+ * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Survivor_Space                  thrpt              0.052          MB/sec
+ * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Survivor_Space.norm             thrpt              0.005            B/op
+ * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.count                                    thrpt            285.000          counts
+ * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.time                                     thrpt            324.000              ms
+ * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping                                      thrpt       45843193.472           ops/s
+ * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.alloc.rate                       thrpt           8653.215          MB/sec
+ * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.alloc.rate.norm                  thrpt            208.015            B/op
+ * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Eden_Space              thrpt           8652.365          MB/sec
+ * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Eden_Space.norm         thrpt            207.995            B/op
+ * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Survivor_Space          thrpt              0.048          MB/sec
+ * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Survivor_Space.norm     thrpt              0.001            B/op
+ * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.count                            thrpt            298.000          counts
+ * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.time                             thrpt            358.000              ms
+ * RegexVSQuickMatchBenchmark.notMatchRegex                                                 thrpt        3434953.426           ops/s
+ * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.alloc.rate                                  thrpt           8898.075          MB/sec
+ * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.alloc.rate.norm                             thrpt           2856.206            B/op
+ * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Eden_Space                         thrpt           8886.568          MB/sec
+ * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Eden_Space.norm                    thrpt           2852.512            B/op
+ * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Survivor_Space                     thrpt              0.052          MB/sec
+ * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Survivor_Space.norm                thrpt              0.017            B/op
+ * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.count                                       thrpt            306.000          counts
+ * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.time                                        thrpt            377.000              ms
  *
- Benchmark                                                                             Mode  Cnt         Score   Error   Units
- RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping                                thrpt       28464926.797           ops/s
- RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.alloc.rate                 thrpt           6194.492          MB/sec
- RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.alloc.rate.norm            thrpt            240.000            B/op
- RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Eden_Space        thrpt           6222.267          MB/sec
- RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Eden_Space.norm   thrpt            241.076            B/op
- RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Old_Gen           thrpt              0.023          MB/sec
- RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Old_Gen.norm      thrpt              0.001            B/op
- RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.count                      thrpt            214.000          counts
- RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.time                       thrpt            194.000              ms
- RegexVSQuickMatchBenchmark.matchFirstRegex                                           thrpt       51679120.204           ops/s
- RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.alloc.rate                            thrpt           7130.116          MB/sec
- RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.alloc.rate.norm                       thrpt            152.000            B/op
- RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Eden_Space                   thrpt           7162.842          MB/sec
- RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Eden_Space.norm              thrpt            152.698            B/op
- RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Old_Gen                      thrpt              0.020          MB/sec
- RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Old_Gen.norm                 thrpt             ≈ 10⁻³            B/op
- RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.count                                 thrpt            246.000          counts
- RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.time                                  thrpt            224.000              ms
- RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping                               thrpt       23359343.934           ops/s
- RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.alloc.rate                thrpt           6106.164          MB/sec
- RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.alloc.rate.norm           thrpt            288.000            B/op
- RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Eden_Space       thrpt           6143.526          MB/sec
- RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Eden_Space.norm  thrpt            289.762            B/op
- RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Old_Gen          thrpt              0.023          MB/sec
- RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Old_Gen.norm     thrpt              0.001            B/op
- RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.count                     thrpt            211.000          counts
- RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.time                      thrpt            143.000              ms
- RegexVSQuickMatchBenchmark.matchFourthRegex                                          thrpt       24074353.094           ops/s
- RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.alloc.rate                           thrpt          17999.991          MB/sec
- RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.alloc.rate.norm                      thrpt            824.000            B/op
- RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Eden_Space                  thrpt          18070.905          MB/sec
- RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Eden_Space.norm             thrpt            827.246            B/op
- RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Old_Gen                     thrpt              0.095          MB/sec
- RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Old_Gen.norm                thrpt              0.004            B/op
- RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.count                                thrpt            621.000          counts
- RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.time                                 thrpt            934.000              ms
- RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping                                  thrpt       27031477.704           ops/s
- RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.alloc.rate                   thrpt           6081.482          MB/sec
- RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.alloc.rate.norm              thrpt            248.000            B/op
- RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Eden_Space          thrpt           6109.321          MB/sec
- RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Eden_Space.norm     thrpt            249.135            B/op
- RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Old_Gen             thrpt              0.022          MB/sec
- RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Old_Gen.norm        thrpt              0.001            B/op
- RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.count                        thrpt            210.000          counts
- RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.time                         thrpt            171.000              ms
- RegexVSQuickMatchBenchmark.notMatchRegex                                             thrpt        9368757.119           ops/s
- RegexVSQuickMatchBenchmark.notMatchRegex:·gc.alloc.rate                              thrpt          23999.619          MB/sec
- RegexVSQuickMatchBenchmark.notMatchRegex:·gc.alloc.rate.norm                         thrpt           2824.000            B/op
- RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Eden_Space                     thrpt          24087.019          MB/sec
- RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Eden_Space.norm                thrpt           2834.284            B/op
- RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Old_Gen                        thrpt              0.114          MB/sec
- RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Old_Gen.norm                   thrpt              0.013            B/op
- RegexVSQuickMatchBenchmark.notMatchRegex:·gc.count                                   thrpt            828.000          counts
- RegexVSQuickMatchBenchmark.notMatchRegex:·gc.time                                    thrpt            896.000              ms
+ * Process finished with exit code 0
  */

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGrouping.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/EndpointNameGrouping.java
@@ -145,8 +145,6 @@ public class EndpointNameGrouping {
 
     private Tuple2<String, Boolean> formatByQuickUriPattern(String serviceName, String endpointName) {
         final StringFormatGroup.FormatResult formatResult = quickUriGroupingRule.format(serviceName, endpointName);
-
-        log.info("formatByQuickUriPattern: {} {}, formatResult {}", serviceName, endpointName, formatResult);
         if (log.isDebugEnabled() || log.isTraceEnabled()) {
             if (formatResult.isMatch()) {
                 log.debug(

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/openapi/EndpointGroupingRule4Openapi.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/openapi/EndpointGroupingRule4Openapi.java
@@ -44,7 +44,7 @@ public class EndpointGroupingRule4Openapi {
     public StringFormatGroup.FormatResult format(String service, String endpointName) {
         Map<String, String> endpointNameLookup = directLookup.get(service);
         if (endpointNameLookup != null && endpointNameLookup.get(endpointName) != null) {
-            return new StringFormatGroup.FormatResult(true, endpointNameLookup.get(endpointName), endpointName);
+            return new StringFormatGroup.FormatResult(true, endpointName, endpointNameLookup.get(endpointName));
         }
 
         Map<String, StringFormatGroup> rules = groupedRules.get(service);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/uri/quickmatch/StringToken.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/uri/quickmatch/StringToken.java
@@ -22,10 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Setter;
-import lombok.ToString;
 
 @EqualsAndHashCode(of = "value")
-@ToString
 public class StringToken implements PatternToken {
     private final String value;
     private final List<PatternToken> children;
@@ -55,5 +53,10 @@ public class StringToken implements PatternToken {
     @Override
     public List<PatternToken> children() {
         return children;
+    }
+
+    @Override
+    public String toString() {
+        return "StringToken: \"" + value + "\"";
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/uri/quickmatch/VarToken.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/group/uri/quickmatch/VarToken.java
@@ -22,10 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Setter;
-import lombok.ToString;
 
 @EqualsAndHashCode(of = "")
-@ToString
 public class VarToken implements PatternToken {
     public static final String VAR_TOKEN = "{var}";
     private List<PatternToken> children = new ArrayList<>();
@@ -53,5 +51,10 @@ public class VarToken implements PatternToken {
     @Override
     public List<PatternToken> children() {
         return children;
+    }
+
+    @Override
+    public String toString() {
+        return "VarToken: \"" + VAR_TOKEN + "\"";
     }
 }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRuleReaderTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/EndpointGroupingRuleReaderTest.java
@@ -36,8 +36,14 @@ public class EndpointGroupingRuleReaderTest {
         Assertions.assertTrue(formatResult.isMatch());
         Assertions.assertEquals("/prod/{var}", formatResult.getReplacedName());
 
+        // This will always match, since after slicing length is 1, which goes into special handling
         formatResult = rule.format("serviceA", "/prod/");
+        Assertions.assertTrue(formatResult.isMatch());
+        Assertions.assertEquals("/prod/", formatResult.getReplacedName());
+
+        formatResult = rule.format("serviceA", "/prod/123/456");
         Assertions.assertFalse(formatResult.isMatch());
+        Assertions.assertEquals("/prod/123/456", formatResult.getReplacedName());
 
         formatResult = rule.format("serviceB", "/prod/123");
         Assertions.assertFalse(formatResult.isMatch());

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/uri/quickmatch/PatternTreeTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/config/group/uri/quickmatch/PatternTreeTest.java
@@ -30,31 +30,49 @@ class PatternTreeTest {
         PatternTree tree = new PatternTree();
         tree.addPattern("/products/{var}");
         tree.addPattern("/products/{var}/detail");
+        tree.addPattern("/products/{var}/refund");
+        tree.addPattern("/products/{var}/reorder/extra");
         tree.addPattern("/sales/{var}");
         tree.addPattern("/employees/{var}/profile");
+        // This should map to exact same tree nodes
+        tree.addPattern("produces/{var}/profile");
+        tree.addPattern("GET:/posts/{var}");
+        tree.addPattern("https://abc.com/posts/{var}");
 
         final Field rootField = PatternTree.class.getDeclaredField("roots");
         rootField.setAccessible(true);
         final List<PatternToken> roots = (List<PatternToken>) rootField.get(tree);
-        final PatternToken root = roots.get(0);
 
-        Assertions.assertEquals(new StringToken(""), root);
-        Assertions.assertEquals(3, root.children().size());
-        final PatternToken prodToken = root.children().get(0);
+        final PatternToken prodToken = roots.get(0);
         Assertions.assertEquals(new StringToken("products"), prodToken);
         Assertions.assertEquals(1, prodToken.children().size());
-        final PatternToken prodVarToken = prodToken.children().get(0);
-        Assertions.assertEquals(new VarToken(), prodVarToken);
-        final PatternToken detailToken = prodVarToken.children().get(0);
+        final PatternToken varToken = prodToken.children().get(0);
+        Assertions.assertEquals(new VarToken(), varToken);
+        Assertions.assertEquals(3, varToken.children().size());
+        final PatternToken detailToken = varToken.children().get(0);
         Assertions.assertEquals(new StringToken("detail"), detailToken);
 
-        final PatternToken salesToken = root.children().get(1);
+        final PatternToken salesToken = roots.get(1);
         Assertions.assertEquals(new StringToken("sales"), salesToken);
         Assertions.assertEquals(1, salesToken.children().size());
 
-        final PatternToken employeeToken = root.children().get(2);
+        final PatternToken employeeToken = roots.get(2);
         Assertions.assertEquals(new StringToken("employees"), employeeToken);
         Assertions.assertEquals(1, employeeToken.children().size());
+
+        final PatternToken producesToken = roots.get(3);
+        Assertions.assertEquals(new StringToken("produces"), producesToken);
+        Assertions.assertEquals(1, producesToken.children().size());
+
+        final PatternToken getPostsToken = roots.get(4);
+        Assertions.assertEquals(new StringToken("GET:"), getPostsToken);
+
+        final PatternToken abcToken = roots.get(5);
+        Assertions.assertEquals(new StringToken("https:"), abcToken);
+        final PatternToken abcComToken = abcToken.children().get(0);
+        // For general performance purposes, double / will result in an empty string token
+        // This is considered an intentional feature rather than a bug
+        Assertions.assertEquals(new StringToken(""), abcComToken);
     }
 
     @Test
@@ -62,8 +80,13 @@ class PatternTreeTest {
         PatternTree tree = new PatternTree();
         tree.addPattern("/products/{var}");
         tree.addPattern("/products/{var}/detail");
+        tree.addPattern("/products/{var}/refund");
+        tree.addPattern("/products/{var}/reorder/extra");
         tree.addPattern("/sales/{var}");
         tree.addPattern("/employees/{var}/profile");
+        tree.addPattern("produces/{var}/profile");
+        tree.addPattern("GET:/posts/{var}");
+        tree.addPattern("https://abc.com/posts/{var}");
 
         StringFormatGroup.FormatResult result;
         result = tree.match("/products/123");
@@ -77,13 +100,34 @@ class PatternTreeTest {
         result = tree.match("/employees/skywalking/profile");
         Assertions.assertTrue(result.isMatch());
 
-        // URI doesn't have / as prefix
+        // URI doesn't have / as prefix but should still match
         result = tree.match("products/123/detail");
+        Assertions.assertTrue(result.isMatch());
+
+        // URI has / as suffix but should still match
+        result = tree.match("products/123/detail/");
+        Assertions.assertTrue(result.isMatch());
+
+        // URI shorter than pattern
+        result = tree.match("/products/123/reorder");
         Assertions.assertFalse(result.isMatch());
+        Assertions.assertEquals("/products/123/reorder", result.getReplacedName());
 
         // URI has extra suffix
         result = tree.match("/products/123/detail/extra");
         Assertions.assertFalse(result.isMatch());
+        Assertions.assertEquals("/products/123/detail/extra", result.getReplacedName());
+
+        // Domain style URI
+        result = tree.match("https://abc.com/posts/123abc");
+        Assertions.assertTrue(result.isMatch());
+
+        // Special case: When endpoint is like /abc or abc,
+        // it will always match since itself cannot be a variable
+        // regardless if abc is actually in the pattern tree
+        result = tree.match("/abc");
+        Assertions.assertTrue(result.isMatch());
+        Assertions.assertEquals("/abc", result.getReplacedName());
     }
 
     @Test

--- a/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/StringFormatGroup.java
+++ b/oap-server/server-library/library-util/src/main/java/org/apache/skywalking/oap/server/library/util/StringFormatGroup.java
@@ -68,7 +68,7 @@ public class StringFormatGroup {
     public FormatResult format(String string) {
         for (PatternRule rule : rules) {
             if (rule.getPattern().matcher(string).matches()) {
-                return new FormatResult(true, rule.getName(), string);
+                return new FormatResult(true, string, rule.getName());
             }
         }
         return new FormatResult(false, string, string);


### PR DESCRIPTION
Now this functionality is working well and can be seen in below screenshot. Showcase changes are pending next.

One problem: I had to change this config to > 1500 for UI to work, otherwise it complains query complexity too high. 
![image](https://github.com/apache/skywalking/assets/26076517/f7eb778b-1fd7-4391-be74-cef0b9aca175)

Demo: (@wu-sheng btw, why are there two success rate metrics on this view?)
![image](https://github.com/apache/skywalking/assets/26076517/8fcf3236-a3de-4ad8-ace0-89c7ed936250)

**Changes:**
* Optimize the splitByCharacter method by ignoring the first slash, also adds a heuristic to consider Length==1 slices to be a pattern itself, therefore always return a match (`/abc`). 
* Some test assertions are changed from False to True given the splitbychar update.
* Trie structure is updated accordingly (basically removes the first layer which is almost always a slash), benchmark is update accordingly which shows the previous 40% perf gain is now more than 300%. 

```
Before:
- StringToken("")
    - StringToken("FirstToken")
        - VarToken("{var}")
            - StringToken("ThirdToken")

Now:
- StringToken("FirstToken")
    - VarToken("{var}")
        - StringToken("ThirdToken")
```

**Bugfix:**
* Atomic execution counter is getting incremented twice so the actual time is halfed, now fixed to resemble actual time.
* Version was ignored thus not updated upon retrieval from remote server, now fixed to update version if different (future should check if version is larger to prevent a rewind on remote service crash).
* FeedRawData grpc operation failed with illegal list access, now fixed.
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

### Improve the performance of QuickMatch
- [x] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [x] The benchmark result.
```text
 * # JMH version: 1.25
 * # VM version: JDK 16.0.1, OpenJDK 64-Bit Server VM, 16.0.1+9-24
 * # VM invoker: C:\Users\Sky\.jdks\openjdk-16.0.1\bin\java.exe
 * # VM options: -ea --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Didea.test.cyclic.buffer.size=1048576 -javaagent:Y:\jetbrains\apps\IDEA-U\ch-0\231.8109.175\lib\idea_rt.jar=54938:Y:\jetbrains\apps\IDEA-U\ch-0\231.8109.175\bin -Dfile.encoding=UTF-8 -Xmx512m -Xms512m -XX:MaxDirectMemorySize=512m -XX:BiasedLockingStartupDelay=0 -Djmh.executor=CUSTOM -Djmh.executor.class=org.apache.skywalking.oap.server.microbench.base.AbstractMicrobenchmark$JmhThreadExecutor
 * # Warmup: 1 iterations, 10 s each
 * # Measurement: 1 iterations, 10 s each
 * # Timeout: 10 min per iteration
 * # Threads: 4 threads, will synchronize iterations
 * # Benchmark mode: Throughput, ops/time
 * # Benchmark: org.apache.skywalking.oap.server.microbench.core.config.group.uri.RegexVSQuickMatchBenchmark.notMatchRegex
 * Benchmark                                                                                 Mode  Cnt         Score   Error   Units
 * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping                                    thrpt       48317763.786           ops/s
 * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.alloc.rate                     thrpt           8773.225          MB/sec
 * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.alloc.rate.norm                thrpt            200.014            B/op
 * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Eden_Space            thrpt           8807.405          MB/sec
 * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Eden_Space.norm       thrpt            200.794            B/op
 * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Survivor_Space        thrpt              0.050          MB/sec
 * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.churn.G1_Survivor_Space.norm   thrpt              0.001            B/op
 * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.count                          thrpt            303.000          counts
 * RegexVSQuickMatchBenchmark.matchFirstQuickUriGrouping:·gc.time                           thrpt            325.000              ms
 * RegexVSQuickMatchBenchmark.matchFirstRegex                                               thrpt       41040542.288           ops/s
 * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.alloc.rate                                thrpt           8348.690          MB/sec
 * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.alloc.rate.norm                           thrpt            224.016            B/op
 * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Eden_Space                       thrpt           8378.454          MB/sec
 * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Eden_Space.norm                  thrpt            224.815            B/op
 * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Survivor_Space                   thrpt              0.057          MB/sec
 * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.churn.G1_Survivor_Space.norm              thrpt              0.002            B/op
 * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.count                                     thrpt            288.000          counts
 * RegexVSQuickMatchBenchmark.matchFirstRegex:·gc.time                                      thrpt            282.000              ms
 * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping                                   thrpt       35658131.267           ops/s
 * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.alloc.rate                    thrpt           8020.546          MB/sec
 * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.alloc.rate.norm               thrpt            248.018            B/op
 * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Eden_Space           thrpt           8043.279          MB/sec
 * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Eden_Space.norm      thrpt            248.721            B/op
 * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Survivor_Space       thrpt              0.045          MB/sec
 * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.churn.G1_Survivor_Space.norm  thrpt              0.001            B/op
 * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.count                         thrpt            277.000          counts
 * RegexVSQuickMatchBenchmark.matchFourthQuickUriGrouping:·gc.time                          thrpt            302.000              ms
 * RegexVSQuickMatchBenchmark.matchFourthRegex                                              thrpt       11066068.208           ops/s
 * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.alloc.rate                               thrpt           8273.312          MB/sec
 * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.alloc.rate.norm                          thrpt            824.060            B/op
 * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Eden_Space                      thrpt           8279.984          MB/sec
 * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Eden_Space.norm                 thrpt            824.724            B/op
 * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Survivor_Space                  thrpt              0.052          MB/sec
 * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.churn.G1_Survivor_Space.norm             thrpt              0.005            B/op
 * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.count                                    thrpt            285.000          counts
 * RegexVSQuickMatchBenchmark.matchFourthRegex:·gc.time                                     thrpt            324.000              ms
 * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping                                      thrpt       45843193.472           ops/s
 * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.alloc.rate                       thrpt           8653.215          MB/sec
 * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.alloc.rate.norm                  thrpt            208.015            B/op
 * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Eden_Space              thrpt           8652.365          MB/sec
 * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Eden_Space.norm         thrpt            207.995            B/op
 * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Survivor_Space          thrpt              0.048          MB/sec
 * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.churn.G1_Survivor_Space.norm     thrpt              0.001            B/op
 * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.count                            thrpt            298.000          counts
 * RegexVSQuickMatchBenchmark.notMatchQuickUriGrouping:·gc.time                             thrpt            358.000              ms
 * RegexVSQuickMatchBenchmark.notMatchRegex                                                 thrpt        3434953.426           ops/s
 * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.alloc.rate                                  thrpt           8898.075          MB/sec
 * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.alloc.rate.norm                             thrpt           2856.206            B/op
 * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Eden_Space                         thrpt           8886.568          MB/sec
 * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Eden_Space.norm                    thrpt           2852.512            B/op
 * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Survivor_Space                     thrpt              0.052          MB/sec
 * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.churn.G1_Survivor_Space.norm                thrpt              0.017            B/op
 * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.count                                       thrpt            306.000          counts
 * RegexVSQuickMatchBenchmark.notMatchRegex:·gc.time                                        thrpt            377.000              ms
```

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
