### PR TITLE
Fix display name of `endpoint_cpm` for endpoint list in `General-Service` dashboard.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -31,6 +31,7 @@
 #### UI
 
 * Fix metric name `browser_app_error_rate` in `Browser-Root` dashboard.
+* Fix display name of `endpoint_cpm` for endpoint list in `General-Service` dashboard.
 
 #### Documentation
 

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/general/general-service.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/general/general-service.json
@@ -697,9 +697,9 @@
                   },
                   "metricConfig": [
                     {
-                      "label": "Success Rate",
-                      "detailLabel": "success_rate",
-                      "unit": "%"
+                      "label": "Load",
+                      "detailLabel": "load",
+                      "unit": "calls / min"
                     },
                     {
                       "label": "Success Rate",


### PR DESCRIPTION
fix: https://github.com/apache/skywalking/pull/11003#issuecomment-1610278999

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
