### PR TITLE
Fix `index out of bounds exception` in `aggregate_labels` func

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -49,6 +49,7 @@
 * Bump up graphql-java to 21.0.
 * Apply MQE on Virtual-Cache layer UI-templates
 * Add Echo component ID(5015) language: Golang.
+* Fix `index out of bounds exception` in `aggregate_labels` MQE function.
 
 #### UI
 

--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/mqe/rt/operation/AggregateLabelsOp.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/mqe/rt/operation/AggregateLabelsOp.java
@@ -32,6 +32,7 @@ import org.apache.skywalking.oap.query.graphql.type.mql.ExpressionResult;
 import org.apache.skywalking.oap.query.graphql.type.mql.MQEValue;
 import org.apache.skywalking.oap.query.graphql.type.mql.MQEValues;
 import org.apache.skywalking.oap.query.graphql.type.mql.Metadata;
+import org.apache.skywalking.oap.server.library.util.CollectionUtils;
 
 public class AggregateLabelsOp {
 
@@ -54,6 +55,9 @@ public class AggregateLabelsOp {
     private static ExpressionResult aggregateLabeledValueResult(ExpressionResult expResult,
                                                                 AggregateLabelsFuncFactory factory) {
         List<MQEValues> results = expResult.getResults();
+        if (CollectionUtils.isEmpty(results)) {
+            return expResult;
+        }
 
         List<MQEValue> combineTo = results.get(0).getValues();
         for (int i = 0; i < combineTo.size(); i++) {


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### when metric data is empty in the duration, aggregate_labels func will produce index out of bounds exception
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
