### PR TITLE
Fix Elasticsearch storage TTL timer, move created the latest index before retrieval indexes by aliases to avoid the 404 exception.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -50,6 +50,7 @@
 * Apply MQE on Virtual-Cache layer UI-templates
 * Add Echo component ID(5015) language: Golang.
 * Fix `index out of bounds exception` in `aggregate_labels` MQE function.
+* Fix Elasticsearch storage TTL timer, move created the latest index before retrieval indexes by aliases to avoid the 404 exception. 
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -50,7 +50,7 @@
 * Apply MQE on Virtual-Cache layer UI-templates
 * Add Echo component ID(5015) language: Golang.
 * Fix `index out of bounds exception` in `aggregate_labels` MQE function.
-* Fix Elasticsearch storage TTL timer, move created the latest index before retrieval indexes by aliases to avoid the 404 exception. 
+* Move created the latest index before retrieval indexes by aliases to avoid the 404 exception. This just prevents some interference from manual operations.
 
 #### UI
 


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).


When there is no index under the related es-template (There's no clear reason, but it's possible, such as someone manually deleted it), query indexes by aliases will cause 404 and prevents the following TTL process from executing. And will stop deleting and creating related indexes.

I move created the latest index logic before retrieving indexes by aliases to ensure there is at least has one index.


