### PR TITLE
Add component ID for lock frameworks

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -50,6 +50,7 @@
 * Apply MQE on Virtual-Cache layer UI-templates
 * Add Echo component ID(5015) language: Golang.
 * Fix `index out of bounds exception` in `aggregate_labels` MQE function.
+* Add component ID for Lock (ID=5016).
 
 #### UI
 

--- a/oap-server/server-starter/src/main/resources/component-libraries.yml
+++ b/oap-server/server-starter/src/main/resources/component-libraries.yml
@@ -622,6 +622,9 @@ GoRedis:
 Echo:
   id: 5015
   language: Golang
+Lock:
+  id: 5016
+  language: Golang,Node.js,Python,java
 
 # Lua components
 # [6000, 7000) for Lua agent


### PR DESCRIPTION
Currently, I'm preparing to add lock-related plugin support in the go agent. Since it can be used in multiple languages, we have set it up for various languages.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
