### PR TITLE
Revert "Change base image from `eclipse-temurin:x-jre` to `eclipse-temurin:x-jre-alpine` to reduce CVE exposure surface"

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -76,7 +76,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Build and push docker images based on Java 17
         env:
-          SW_OAP_BASE_IMAGE: eclipse-temurin:17-jre-alpine
+          SW_OAP_BASE_IMAGE: eclipse-temurin:17-jre
           TAG: ${{ env.TAG }}-java17
         run: make build.all docker.push
       - name: Build and push docker images

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -211,7 +211,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Build and save docker images
         env:
-          SW_OAP_BASE_IMAGE: eclipse-temurin:${{ matrix.java-version }}-jre-alpine
+          SW_OAP_BASE_IMAGE: eclipse-temurin:${{ matrix.java-version }}-jre
         run: |
           make docker.all || make docker.all
           docker save -o docker-images-skywalking-oap.tar skywalking/oap:latest

--- a/docker/data-generator/Dockerfile
+++ b/docker/data-generator/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE='eclipse-temurin:11-jre-alpine'
+ARG BASE_IMAGE='eclipse-temurin:11-jre'
 
 ARG SKYWALKING_CLI_VERSION
 

--- a/docker/oap/Dockerfile
+++ b/docker/oap/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE='eclipse-temurin:11-jre-alpine'
+ARG BASE_IMAGE='eclipse-temurin:11-jre'
 
 ARG SKYWALKING_CLI_VERSION
 
@@ -35,9 +35,6 @@ ARG DIST
 COPY "$DIST" .
 
 RUN set -ex; \
-    apk update; \
-    apk add libc6-compat; \
-    apk add gcompat; \
     tar -xzf "$DIST" --strip 1; \
     rm -rf "$DIST"; \
     rm -rf "config/log4j2.xml"; \
@@ -56,4 +53,4 @@ RUN mkdir ext-config; \
 
 EXPOSE 12800 11800 1234
 
-ENTRYPOINT ["sh", "docker-entrypoint.sh"]
+ENTRYPOINT ["bash", "docker-entrypoint.sh"]

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:11-jre-alpine
+FROM eclipse-temurin:11-jre
 
 ENV JAVA_OPTS=" -Xms256M " \
     SW_OAP_ADDRESS="http://127.0.0.1:12800" \
@@ -26,8 +26,6 @@ ARG DIST
 COPY "$DIST" .
 
 RUN tar -xzf "$DIST" --strip 1; \
-    apk update; \
-    apk add libc6-compat; \
     rm -rf "$DIST"; \
     rm -rf "config"; \
     rm -rf "bin"; \
@@ -39,4 +37,4 @@ COPY log4j2.xml webapp/
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "docker-entrypoint.sh"]
+ENTRYPOINT ["bash", "docker-entrypoint.sh"]

--- a/docker/ui/docker-entrypoint.sh
+++ b/docker/ui/docker-entrypoint.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+#!/bin/bash
 
 set -e
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -4,7 +4,6 @@
 
 * Bump up Guava to 32.0.1 to avoid the lib listed as vulnerable due to CVE-2020-8908. This API is never used.
 * Maven artifact `skywalking-log-recevier-plugin` is renamed to `skywalking-log-receiver-plugin`.
-* Change base image from `eclipse-temurin:11-jre` to `eclipse-temurin:11-jre-alpine` to reduce CVE exposure surface.
 
 #### OAP Server
 

--- a/test/e2e-v2/cases/simple/ssl/docker-compose.yml
+++ b/test/e2e-v2/cases/simple/ssl/docker-compose.yml
@@ -29,11 +29,6 @@ services:
       SW_CORE_GRPC_SSL_TRUSTED_CA_PATH: /skywalking/certs/ca.crt
     ports:
       - 12800
-    healthcheck:
-      test: ["CMD", "/skywalking/bin/swctl", "health", "--grpcTLS"]
-      interval: 5s
-      timeout: 60s
-      retries: 120
 
   provider:
     extends:

--- a/test/e2e-v2/cases/storage/storage-cases.yaml
+++ b/test/e2e-v2/cases/storage/storage-cases.yaml
@@ -149,7 +149,7 @@ cases:
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics top --name endpoint_cpm --service-name e2e-service-provider 5
     expected: expected/metrics-top-endpoint.yml
   # native event: event list
-  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql event list --type=normal
+  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql event list
     expected: expected/event-list.yml
 
   - query: |

--- a/test/e2e-v2/script/docker-compose/base-compose.yml
+++ b/test/e2e-v2/script/docker-compose/base-compose.yml
@@ -34,12 +34,11 @@ services:
       SW_JDBC_URL: jdbc:mysql://mysql:3306/swtest?allowMultiQueries=true
       SW_STORAGE_INFLUXDB_URL: http://influxdb:8086
       SW_STORAGE_BANYANDB_HOST: "banyandb"
-      SW_HEALTH_CHECKER: default
       SW_CONFIG_ETCD_PERIOD: 1
       SW_CONFIG_ETCD_ENDPOINTS: http://etcd:2379
       SW_CLUSTER_ETCD_ENDPOINTS: http://etcd:2379
     healthcheck:
-      test: ["CMD", "/skywalking/bin/swctl", "health"]
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/11800"]
       interval: 5s
       timeout: 60s
       retries: 120

--- a/test/e2e-v2/script/prepare/setup-oap/download-mysql.sh
+++ b/test/e2e-v2/script/prepare/setup-oap/download-mysql.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -23,7 +23,7 @@ MYSQL_DRIVER="mysql-connector-java-8.0.13.jar"
 
 # ensure the curl command been installed
 if ! command -v curl &> /dev/null; then
-    apk add curl
+    apt update -y && apt install -y curl
 fi
 
 if ! curl -Lo "${LIB_HOME}/${MYSQL_DRIVER}" ${MYSQL_URL}; then


### PR DESCRIPTION
Reverts apache/skywalking#11181

`eclipse-temurin:x-jre-alpine` doesn't support ARM platform.