### PR TITLE
Improve PromQL to allow for multiple metric operations within a single query

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -74,6 +74,7 @@
 * Apply MQE on Infra-Linux layer UI-templates
 * Fix the wrong default value of `k8sServiceNameRule` if it's not explicitly set.
 * Apply MQE on Infra-Windows layer UI-templates
+* Improve PromQL to allow for multiple metric operations within a single query.
 
 #### UI
 

--- a/oap-server/server-query-plugin/promql-plugin/src/main/java/org/apache/skywalking/oap/query/promql/rt/PromOpUtils.java
+++ b/oap-server/server-query-plugin/promql-plugin/src/main/java/org/apache/skywalking/oap/query/promql/rt/PromOpUtils.java
@@ -67,7 +67,7 @@ public class PromOpUtils {
         for (int i = 0; i < matrixLeft.getMetricDataList().size(); i++) {
             MetricRangeData dataLeft = matrixLeft.getMetricDataList().get(i);
             MetricRangeData dataRight = matrixRight.getMetricDataList().get(i);
-            if (!dataLeft.getMetric().equals(dataRight.getMetric())) {
+            if (!dataLeft.getMetric().getLabels().equals(dataRight.getMetric().getLabels())) {
                 throw new IllegalExpressionException(
                     "The metric info result left in conformity with right.");
             }
@@ -171,7 +171,7 @@ public class PromOpUtils {
         for (int i = 0; i < matrixLeft.getMetricDataList().size(); i++) {
             MetricRangeData dataLeft = matrixLeft.getMetricDataList().get(i);
             MetricRangeData dataRight = matrixRight.getMetricDataList().get(i);
-            if (!dataLeft.getMetric().equals(dataRight.getMetric())) {
+            if (!dataLeft.getMetric().getLabels().equals(dataRight.getMetric().getLabels())) {
                 throw new IllegalExpressionException(
                     "The metric info result left in conformity with right.");
             }

--- a/test/e2e-v2/cases/promql/expected/service-metric-labeled-compare-matrix.yml
+++ b/test/e2e-v2/cases/promql/expected/service-metric-labeled-compare-matrix.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+status: success
+data:
+  resultType: vector
+  result:
+    {{- contains .data.result }}
+    - metric:
+        __name__: service_percentile
+        label: p_value
+        layer: GENERAL
+        scope: Service
+        service: e2e-service-consumer
+      value:
+        - "{{ index .value 0 }}"
+        - '{{ index .value 1 }}'
+    {{- end}}

--- a/test/e2e-v2/cases/promql/promql-cases.yaml
+++ b/test/e2e-v2/cases/promql/promql-cases.yaml
@@ -61,6 +61,8 @@ cases:
   ## multiple metrics operation query
   - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/query -d 'query=service_sla{service="e2e-service-consumer", layer="GENERAL"} + service_cpm{service="e2e-service-consumer", layer="GENERAL"}'
     expected: expected/service-metric-vector.yml
+  - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/query -d 'query=service_percentile{service="e2e-service-consumer", layer="GENERAL", labels="4", relabels="p_value"} - service_percentile{service="e2e-service-consumer", layer="GENERAL", labels="3", relabels="p_value"}'
+    expected: expected/service-metric-labeled-compare-matrix.yml
   ## query_range
   - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/query_range -d 'query=service_sla{service="e2e-service-consumer", layer="GENERAL"}&start='$(($(date +%s)-1800))'&end='$(date +%s)
     expected: expected/service-metric-matrix.yml

--- a/test/e2e-v2/cases/promql/promql-cases.yaml
+++ b/test/e2e-v2/cases/promql/promql-cases.yaml
@@ -58,6 +58,9 @@ cases:
     expected: expected/service-metric-sort-vector.yml
   - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/query -d 'query=service_cpm{layer="GENERAL",top_n="10", order="DES"}[30m]'
     expected: expected/service-metric-sort-matrix.yml
+  ## multiple metrics operation query
+  - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/query -d 'query=service_sla{service="e2e-service-consumer", layer="GENERAL"} + service_cpm{service="e2e-service-consumer", layer="GENERAL"}'
+    expected: expected/service-metric-vector.yml
   ## query_range
   - query: curl -X GET http://${oap_host}:${oap_9090}/api/v1/query_range -d 'query=service_sla{service="e2e-service-consumer", layer="GENERAL"}&start='$(($(date +%s)-1800))'&end='$(date +%s)
     expected: expected/service-metric-matrix.yml


### PR DESCRIPTION
When performing multi-metric operations in PromQL, only the labels need to be verified for similarity, and there is no need to verify the names.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
