### PR TITLE
Fix the Kubernetes resource cache not refreshed

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -71,6 +71,7 @@
 * Fix MQE Binary Operation between labeled metrics and other type of value result.
 * Add component ID for Nacos (ID=150).
 * Support `Compare Operation` in MQE.
+* Fix the Kubernetes resource cache not refreshed.
 
 #### UI
 

--- a/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/IstioServiceEntries.java
+++ b/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/IstioServiceEntries.java
@@ -40,7 +40,7 @@ public enum IstioServiceEntries {
     IstioServiceEntries() {
         final CacheBuilder<Object, Object> cacheBuilder =
             CacheBuilder.newBuilder()
-                .expireAfterAccess(Duration.ofMinutes(3));
+                .expireAfterWrite(Duration.ofMinutes(3));
 
         serviceEntries = cacheBuilder.build(CacheLoader.from(() -> {
             try (final var istioClient = new DefaultIstioClient()) {

--- a/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesEndpoints.java
+++ b/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesEndpoints.java
@@ -39,8 +39,8 @@ public enum KubernetesEndpoints {
     @SneakyThrows
     KubernetesEndpoints() {
         final CacheBuilder<Object, Object> cacheBuilder =
-                CacheBuilder.newBuilder()
-                        .expireAfterAccess(Duration.ofMinutes(3));
+            CacheBuilder.newBuilder()
+                        .expireAfterWrite(Duration.ofMinutes(3));
 
         endpoints = cacheBuilder.build(CacheLoader.from(() -> {
             try (final var kubernetesClient = new KubernetesClientBuilder().build()) {

--- a/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesPods.java
+++ b/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesPods.java
@@ -38,8 +38,8 @@ public enum KubernetesPods {
     @SneakyThrows
     KubernetesPods() {
         final CacheBuilder<Object, Object> cacheBuilder =
-                CacheBuilder.newBuilder()
-                        .expireAfterAccess(Duration.ofMinutes(5));
+            CacheBuilder.newBuilder()
+                        .expireAfterWrite(Duration.ofMinutes(5));
 
         podByIP = cacheBuilder.build(new CacheLoader<>() {
             @Override

--- a/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesServices.java
+++ b/oap-server/server-library/library-kubernetes-support/src/main/java/org/apache/skywalking/library/kubernetes/KubernetesServices.java
@@ -41,8 +41,8 @@ public enum KubernetesServices {
     @SneakyThrows
     KubernetesServices() {
         final CacheBuilder<Object, Object> cacheBuilder =
-                CacheBuilder.newBuilder()
-                        .expireAfterAccess(Duration.ofMinutes(3));
+            CacheBuilder.newBuilder()
+                        .expireAfterWrite(Duration.ofMinutes(3));
 
         services = cacheBuilder.build(CacheLoader.from(() -> {
             try (final var kubernetesClient = new KubernetesClientBuilder().build()) {

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/TableHelper.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/TableHelper.java
@@ -60,7 +60,7 @@ public class TableHelper {
 
     private final LoadingCache<String, Boolean> tableExistence =
         CacheBuilder.newBuilder()
-                    .expireAfterAccess(Duration.ofMinutes(10))
+                    .expireAfterWrite(Duration.ofMinutes(10))
                     .build(new CacheLoader<>() {
                         @Override
                         public @NonNull Boolean load(@NonNull String tableName) throws Exception {


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
