### PR TITLE
Fix wrong classpath that might cause OOM in startup

### DIFF
--- a/dist-material/bin/oapService.sh
+++ b/dist-material/bin/oapService.sh
@@ -29,7 +29,12 @@ fi
 _RUNJAVA=${JAVA_HOME}/bin/java
 [ -z "$JAVA_HOME" ] && _RUNJAVA=java
 
-CLASSPATH="$OAP_HOME/config:$CLASSPATH"
+if [ -z "$CLASSPATH" ]; then
+  CLASSPATH="$OAP_HOME/config"
+else
+  CLASSPATH="$OAP_HOME/config:$CLASSPATH"
+fi
+
 for i in "$OAP_HOME"/oap-libs/*.jar
 do
     CLASSPATH="$i:$CLASSPATH"

--- a/dist-material/bin/oapServiceInit.sh
+++ b/dist-material/bin/oapServiceInit.sh
@@ -29,7 +29,12 @@ fi
 _RUNJAVA=${JAVA_HOME}/bin/java
 [ -z "$JAVA_HOME" ] && _RUNJAVA=java
 
-CLASSPATH="$OAP_HOME/config:$CLASSPATH"
+if [ -z "$CLASSPATH" ]; then
+  CLASSPATH="$OAP_HOME/config"
+else
+  CLASSPATH="$OAP_HOME/config:$CLASSPATH"
+fi
+
 for i in "$OAP_HOME"/oap-libs/*.jar
 do
     CLASSPATH="$i:$CLASSPATH"

--- a/dist-material/bin/oapServiceNoInit.sh
+++ b/dist-material/bin/oapServiceNoInit.sh
@@ -29,7 +29,12 @@ fi
 _RUNJAVA=${JAVA_HOME}/bin/java
 [ -z "$JAVA_HOME" ] && _RUNJAVA=java
 
-CLASSPATH="$OAP_HOME/config:$CLASSPATH"
+if [ -z "$CLASSPATH" ]; then
+  CLASSPATH="$OAP_HOME/config"
+else
+  CLASSPATH="$OAP_HOME/config:$CLASSPATH"
+fi
+
 for i in "$OAP_HOME"/oap-libs/*.jar
 do
     CLASSPATH="$i:$CLASSPATH"

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -72,6 +72,7 @@
 * Add component ID for Nacos (ID=150).
 * Support `Compare Operation` in MQE.
 * Fix the Kubernetes resource cache not refreshed.
+* Fix wrong classpath that might cause OOM in startup.
 
 #### UI
 


### PR DESCRIPTION
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

When the following conditions are met, the OOM exception will be thrown in startup:

- `CLASSPATH` env var is not set, mostly (if not always) this won't be set by users. and the `CLASSPATH` in the script becomes `<jars under oap-libs>:config:`, note the last `:`, which indicate the current path is included.
- the startup script is executed under the `/`, e.g.

```shell
cd /
/usr/local/skywalking/bin/oapService.sh
```

OOM will be thrown. 

This is always the case when you execute the service in systemd service and didn't set the working path.

FYI @rabajaj0509 