### PR TITLE
Do not start server and Kafka consumer in init mode

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -78,6 +78,7 @@
   add `expression` field and remove `metrics-name/count/threshold/op/only-as-condition` fields and remove `composite-rules` configuration.
 * Check results in ALS as per downstream/upstream instead of per log.
 * Fix GraphQL query `listInstances` not using endTime query
+* Do not start server and Kafka consumer in init mode.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
@@ -412,12 +412,14 @@ public class CoreModuleProvider extends ModuleProvider {
     @Override
     public void notifyAfterCompleted() throws ModuleStartException {
         try {
-            grpcServer.start();
-            httpServer.start();
+            if (!RunningMode.isInitMode()) {
+                grpcServer.start();
+                httpServer.start();
+                remoteClientManager.start();
+            }
         } catch (ServerException e) {
             throw new ModuleStartException(e.getMessage(), e);
         }
-        remoteClientManager.start();
         PersistenceTimer.INSTANCE.start(getManager(), moduleConfig);
 
         if (moduleConfig.isEnableDataKeeperExecutor()) {

--- a/oap-server/server-query-plugin/logql-plugin/src/main/java/org/apache/skywalking/oap/query/logql/LogQLProvider.java
+++ b/oap-server/server-query-plugin/logql-plugin/src/main/java/org/apache/skywalking/oap/query/logql/LogQLProvider.java
@@ -22,6 +22,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import java.util.Arrays;
 import org.apache.skywalking.oap.query.logql.handler.LogQLApiHandler;
 import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.RunningMode;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
 import org.apache.skywalking.oap.server.library.module.ModuleProvider;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
@@ -85,7 +86,9 @@ public class LogQLProvider extends ModuleProvider {
 
     @Override
     public void notifyAfterCompleted() {
-        httpServer.start();
+        if (!RunningMode.isInitMode()) {
+            httpServer.start();
+        }
     }
 
     @Override

--- a/oap-server/server-query-plugin/promql-plugin/src/main/java/org/apache/skywalking/oap/query/promql/PromQLProvider.java
+++ b/oap-server/server-query-plugin/promql-plugin/src/main/java/org/apache/skywalking/oap/query/promql/PromQLProvider.java
@@ -22,6 +22,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import java.util.Arrays;
 import org.apache.skywalking.oap.query.promql.handler.PromQLApiHandler;
 import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.RunningMode;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
 import org.apache.skywalking.oap.server.library.module.ModuleProvider;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
@@ -86,7 +87,9 @@ public class PromQLProvider extends ModuleProvider {
 
     @Override
     public void notifyAfterCompleted() {
-        httpServer.start();
+        if (!RunningMode.isInitMode()) {
+            httpServer.start();
+        }
     }
 
     @Override

--- a/oap-server/server-query-plugin/zipkin-query-plugin/src/main/java/org/apache/skywalking/oap/query/zipkin/ZipkinQueryProvider.java
+++ b/oap-server/server-query-plugin/zipkin-query-plugin/src/main/java/org/apache/skywalking/oap/query/zipkin/ZipkinQueryProvider.java
@@ -22,6 +22,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import java.util.Collections;
 import org.apache.skywalking.oap.query.zipkin.handler.ZipkinQueryHandler;
 import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.RunningMode;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
 import org.apache.skywalking.oap.server.library.module.ModuleProvider;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
@@ -86,7 +87,9 @@ public class ZipkinQueryProvider extends ModuleProvider {
 
     @Override
     public void notifyAfterCompleted() {
-        httpServer.start();
+        if (!RunningMode.isInitMode()) {
+            httpServer.start();
+        }
     }
 
     @Override

--- a/oap-server/server-receiver-plugin/aws-firehose-receiver/src/main/java/org/apache/skywalking/oap/server/receiver/aws/firehose/AWSFirehoseReceiverModuleProvider.java
+++ b/oap-server/server-receiver-plugin/aws-firehose-receiver/src/main/java/org/apache/skywalking/oap/server/receiver/aws/firehose/AWSFirehoseReceiverModuleProvider.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.receiver.aws.firehose;
 import com.linecorp.armeria.common.HttpMethod;
 import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.skywalking.oap.server.core.RunningMode;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
 import org.apache.skywalking.oap.server.library.module.ModuleProvider;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
@@ -98,7 +99,9 @@ public class AWSFirehoseReceiverModuleProvider extends ModuleProvider {
 
     @Override
     public void notifyAfterCompleted() throws ServiceNotProvidedException, ModuleStartException {
-        httpServer.start();
+        if (!RunningMode.isInitMode()) {
+            httpServer.start();
+        }
     }
 
     @Override

--- a/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/sharing/server/SharingServerModuleProvider.java
+++ b/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/sharing/server/SharingServerModuleProvider.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.receiver.sharing.server;
 import java.util.Objects;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.RunningMode;
 import org.apache.skywalking.oap.server.core.remote.health.HealthCheckServiceHandler;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegisterImpl;
@@ -98,7 +99,7 @@ public class SharingServerModuleProvider extends ModuleProvider {
             authenticationInterceptor = new AuthenticationInterceptor(config.getAuthentication());
         }
 
-        if (config.getGRPCPort() != 0) {
+        if (config.getGRPCPort() != 0 && !RunningMode.isInitMode()) {
             if (config.isGRPCSslEnabled()) {
                 grpcServer = new GRPCServer(
                     Strings.isBlank(config.getGRPCHost()) ? "0.0.0.0" : config.getGRPCHost(),
@@ -162,10 +163,10 @@ public class SharingServerModuleProvider extends ModuleProvider {
     @Override
     public void notifyAfterCompleted() throws ModuleStartException {
         try {
-            if (Objects.nonNull(grpcServer)) {
+            if (Objects.nonNull(grpcServer) && !RunningMode.isInitMode()) {
                 grpcServer.start();
             }
-            if (Objects.nonNull(httpServer)) {
+            if (Objects.nonNull(httpServer) && !RunningMode.isInitMode()) {
                 httpServer.start();
             }
         } catch (ServerException e) {

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/ZipkinReceiverProvider.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/ZipkinReceiverProvider.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.receiver.zipkin;
 import com.linecorp.armeria.common.HttpMethod;
 import java.util.Arrays;
 import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.RunningMode;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
 import org.apache.skywalking.oap.server.library.module.ModuleProvider;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
@@ -99,11 +100,11 @@ public class ZipkinReceiverProvider extends ModuleProvider {
 
     @Override
     public void notifyAfterCompleted() throws ModuleStartException {
-        if (config.isEnableHttpCollector()) {
+        if (config.isEnableHttpCollector() && !RunningMode.isInitMode()) {
             httpServer.start();
         }
 
-        if (config.isEnableKafkaCollector()) {
+        if (config.isEnableKafkaCollector() && !RunningMode.isInitMode()) {
             kafkaHandler.start();
         }
     }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).


Basically when the node is running in init mode, it should be only responsible for initializing the database storage, should not start gRPC/HTTP servers to occupy ports, nor should it start other service such as Kafka consumer if Kafka is enabled, which might consume some messages but not process them correctly.