### PR TITLE
Release alarm window when alarm metrics is expired in case OOM

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -10,6 +10,7 @@
 * Support Kafka Monitoring.
 * [Breaking Change] Elasticsearch storage merge all management data indices into one index `management`, 
   including `ui_template，ui_menu，continuous_profiling_policy`.
+* Fix Release alarm window when alarm metric is expired in case OOM.
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -10,7 +10,7 @@
 * Support Kafka Monitoring.
 * [Breaking Change] Elasticsearch storage merge all management data indices into one index `management`, 
   including `ui_template，ui_menu，continuous_profiling_policy`.
-* Fix Release alarm window when alarm metric is expired in case OOM.
+* Add a release mechanism for alarm windows when it is expired in case of OOM.
 
 #### UI
 

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRule.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRule.java
@@ -198,8 +198,14 @@ public class RunningRule {
      */
     public List<AlarmMessage> check() {
         List<AlarmMessage> alarmMessageList = new ArrayList<>(30);
+        List<AlarmEntity> expiredEntityList = new ArrayList<>();
 
         windows.forEach((alarmEntity, window) -> {
+            if (window.isExpired()) {
+                expiredEntityList.add(alarmEntity);
+                return;
+            }
+
             Optional<AlarmMessage> alarmMessageOptional = window.checkAlarm();
             if (alarmMessageOptional.isPresent()) {
                 AlarmMessage alarmMessage = alarmMessageOptional.get();
@@ -218,6 +224,7 @@ public class RunningRule {
             }
         });
 
+        expiredEntityList.forEach(windows::remove);
         return alarmMessageList;
     }
 
@@ -381,6 +388,17 @@ public class RunningRule {
                 log.trace("Match expression is {}", expression);
             }
             return isMatch == 1;
+        }
+
+        public boolean isExpired() {
+            if (this.values != null) {
+                for (Map<String, Metrics> value : this.values) {
+                    if (value != null) {
+                        return false;
+                    }
+                }
+            }
+            return true;
         }
 
         private void init() {


### PR DESCRIPTION
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

Alarm windows can only increase in alarm module. Even some servivces or endpoint call relations is gone. 
That will finally lead to OOM of OAP.