### PR TITLE
Fix Kafka e2e format and typos

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -34,6 +34,7 @@
 * Add a component ID for Fiber (ID=5021).
 * BanyanDBStorageClient: Add `define(Property property, PropertyStore.Strategy strategy)` API.
 * Support GraalVM native-image (Experimental).
+* Correct the file format and fix typos in the filenames for monitoring Kafka's e2e tests.
 
 #### UI
 

--- a/test/e2e-v2/cases/kafka/kafka-monitoring/expected/metrics-has-value-gc-label.yml
+++ b/test/e2e-v2/cases/kafka/kafka-monitoring/expected/metrics-has-value-gc-label.yml
@@ -34,13 +34,13 @@ results:
         - key: _
           value: "G1 Old Generation"
     values:
-      { { - contains .values } }
-      - id: { { notEmpty .id } }
-        value: { { .value } }
+      {{- contains .values }}
+      - id: {{ notEmpty .id }}
+        value: {{ .value }}
         traceid: null
-      - id: { { notEmpty .id } }
+      - id: {{ notEmpty .id }}
         value: null
         traceid: null
-      { { - end } }
+      {{- end}}
   {{- end}}
 error: null

--- a/test/e2e-v2/cases/kafka/kafka-monitoring/expected/metrics-has-value-instance-label.yml
+++ b/test/e2e-v2/cases/kafka/kafka-monitoring/expected/metrics-has-value-instance-label.yml
@@ -34,13 +34,13 @@ results:
         - key: _
           value: "Fetch"
     values:
-      { { - contains .values } }
-      - id: { { notEmpty .id } }
-        value: { { .value } }
+      {{- contains .values }}
+      - id: {{ notEmpty .id }}
+        value: {{ .value }}
         traceid: null
-      - id: { { notEmpty .id } }
+      - id: {{ notEmpty .id }}
         value: null
         traceid: null
-      { { - end } }
+      {{- end}}
   {{- end}}
 error: null

--- a/test/e2e-v2/cases/kafka/kafka-monitoring/expected/metrics-has-value-source-label.yml
+++ b/test/e2e-v2/cases/kafka/kafka-monitoring/expected/metrics-has-value-source-label.yml
@@ -34,7 +34,7 @@ results:
         - key: _
           value: "FetchFollower"
     values:
-      {{ - contains .values }}
+      {{- contains .values }}
       - id: {{ notEmpty .id }}
         value: {{ .value }}
         traceid: null

--- a/test/e2e-v2/cases/kafka/kafka-monitoring/expected/metrics-has-value-source-label.yml
+++ b/test/e2e-v2/cases/kafka/kafka-monitoring/expected/metrics-has-value-source-label.yml
@@ -34,26 +34,26 @@ results:
         - key: _
           value: "FetchFollower"
     values:
-      { { - contains .values } }
-      - id: { { notEmpty .id } }
-        value: { { .value } }
+      {{ - contains .values }}
+      - id: {{ notEmpty .id }}
+        value: {{ .value }}
         traceid: null
-      - id: { { notEmpty .id } }
+      - id: {{ notEmpty .id }}
         value: null
         traceid: null
-      { { - end } }
+      {{- end}}
   - metric:
       labels:
         - key: _
           value: "FetchConsumer"
     values:
-      { { - contains .values } }
-      - id: { { notEmpty .id } }
-        value: { { .value } }
+      {{- contains .values }}
+      - id: {{ notEmpty .id }}
+        value: {{ .value }}
         traceid: null
-      - id: { { notEmpty .id } }
+      - id: {{ notEmpty .id }}
         value: null
         traceid: null
-      { { - end } }
+      {{- end}}
   {{- end}}
 error: null

--- a/test/e2e-v2/cases/kafka/kafka-monitoring/kafka-cases.yaml
+++ b/test/e2e-v2/cases/kafka/kafka-monitoring/kafka-cases.yaml
@@ -81,5 +81,3 @@ cases:
     expected: expected/metrics-has-value-source-label.yml
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression=meter_kafka_broker_network_processor_avg_idle_percent --service-name=kafka::kafka-cluster --instance-name=broker1:7071
     expected: expected/metrics-has-value.yml
-
-

--- a/test/e2e-v2/cases/kafka/kafka-monitoring/kafka-cases.yaml
+++ b/test/e2e-v2/cases/kafka/kafka-monitoring/kafka-cases.yaml
@@ -72,13 +72,13 @@ cases:
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression=meter_kafka_broker_garbage_collector_count --service-name=kafka::kafka-cluster --instance-name=broker1:7071
     expected: expected/metrics-has-value-gc-label.yml
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression=meter_kafka_broker_request_queue_time_ms --service-name=kafka::kafka-cluster --instance-name=broker1:7071
-    expected: expected/metrics-has-value-scource-label.yml
+    expected: expected/metrics-has-value-source-label.yml
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression=meter_kafka_broker_remote_time_ms --service-name=kafka::kafka-cluster --instance-name=broker1:7071
-    expected: expected/metrics-has-value-scource-label.yml
+    expected: expected/metrics-has-value-source-label.yml
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression=meter_kafka_broker_response_queue_time_ms --service-name=kafka::kafka-cluster --instance-name=broker1:7071
-    expected: expected/metrics-has-value-scource-label.yml
+    expected: expected/metrics-has-value-source-label.yml
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression=meter_kafka_broker_response_send_time_ms --service-name=kafka::kafka-cluster --instance-name=broker1:7071
-    expected: expected/metrics-has-value-scource-label.yml
+    expected: expected/metrics-has-value-source-label.yml
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression=meter_kafka_broker_network_processor_avg_idle_percent --service-name=kafka::kafka-cluster --instance-name=broker1:7071
     expected: expected/metrics-has-value.yml
 


### PR DESCRIPTION

### Fix <https://github.com/apache/skywalking/pull/11282> 
- [x] Explain briefly why the bug exists and how to fix it.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

Correct the file format and fix typos in the filenames for monitoring Kafka's e2e tests.
