### PR TITLE
Support output key parameters in the booting logs.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -36,6 +36,7 @@
 * Support GraalVM native-image (Experimental).
 * Correct the file format and fix typos in the filenames for monitoring Kafka's e2e tests.
 * Support extract timestamp from patterned datetime string in LAL.
+* Support output key parameters in the booting logs.
 
 #### UI
 
@@ -59,5 +60,7 @@
 * Add topology configuration in UI-Grafana doc.
 * Add missing metrics to the `OpenTelemetry Metrics` doc.
 * Polish docs of `Concepts and Designs`.
+* Update OAP setup and cluster coordinator docs to explain new booting parameters table in the logs, and how to setup
+  cluster mode.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/193?closed=1)

--- a/docs/en/setup/backend/backend-cluster.md
+++ b/docs/en/setup/backend/backend-cluster.md
@@ -25,6 +25,7 @@ There are various ways to manage the cluster in the backend. Choose the one that
 In the `application.yml` file, there are default configurations for the aforementioned coordinators under the
 section `cluster`. You can specify any of them in the `selector` property to enable it.
 
+# Cloud Native
 ## Kubernetes
 
 The required backend clusters are deployed inside Kubernetes. See the guides in [Deploy in kubernetes](backend-k8s.md).
@@ -54,6 +55,20 @@ containers:
 
 Read [the complete helm](https://github.com/apache/skywalking-helm/blob/476afd51d44589c77a4cbaac950272cd5d064ea9/chart/skywalking/templates/oap-deployment.yaml#L125) for more details.
 
+# Traditional Coordinator
+
+**NOTICE**
+In all the following coordinators, `oap.internal.comm.host`:`oap.internal.comm.port` is registered as the ID
+and address for the current OAP node. By default, because they are same in all OAP nodes, the registrations are conflicted,
+and (may) show as one registered node, which actually would be the node itself. **In this case, the cluster mode is NOT working.**
+
+Please check the registered nodes on your coordinator servers, to make the registration information unique for every node.
+You could have two options
+
+1. Change `core/gRPCHost`(`oap.internal.comm.host`) and `core/gRPCPort`(`oap.internal.comm.port`) for internal,
+   and [setup external communication channels](backend-expose.md) for data reporting and query.
+2. Use `internalComHost` and `internalComPort` in the config to provide a unique host and port for every OAP node. This
+   host name port should be accessible for other OAP nodes.
 
 ## Zookeeper coordinator
 
@@ -85,11 +100,11 @@ Note:
 - If you set `schema` as `digest`, the password of the expression is set in **clear text**.
 
 In some cases, the OAP default gRPC host and port in the core are not suitable for internal communication among the OAP
-nodes.
+nodes, such as the default host(`0.0.0.0`) should not be used in cluster mode.
 The following settings are provided to set the host and port manually, based on your own LAN env.
 
-- internalComHost: The registered host and other OAP nodes use this to communicate with the current node.
-- internalComPort: the registered port and other OAP nodes use this to communicate with the current node.
+- internalComHost: The exposed host name for other OAP nodes in the cluster internal communication.
+- internalComPort: the exposed port for other OAP nodes in the cluster internal communication.
 
 ```yaml
 zookeeper:
@@ -119,11 +134,11 @@ cluster:
 
 Same as the Zookeeper coordinator,
 in some cases, the OAP default gRPC host and port in the core are not suitable for internal communication among the OAP
-nodes.
+nodes, such as the default host(`0.0.0.0`) should not be used in cluster mode.
 The following settings are provided to set the host and port manually, based on your own LAN env.
 
-- internalComHost: The registered host and other OAP nodes use this to communicate with the current node.
-- internalComPort: The registered port and other OAP nodes use this to communicate with the current node.
+- internalComHost: The exposed host name for other OAP nodes in the cluster internal communication.
+- internalComPort: the exposed port for other OAP nodes in the cluster internal communication.
 
 ## Etcd
 
@@ -146,11 +161,11 @@ cluster:
 
 Same as the Zookeeper coordinator,
 in some cases, the OAP default gRPC host and port in the core are not suitable for internal communication among the OAP
-nodes.
+nodes, such as the default host(`0.0.0.0`) should not be used in cluster mode.
 The following settings are provided to set the host and port manually, based on your own LAN env.
 
-- internalComHost: The registered host and other OAP nodes use this to communicate with the current node.
-- internalComPort: The registered port and other OAP nodes use this to communicate with the current node.
+- internalComHost: The exposed host name for other OAP nodes in the cluster internal communication.
+- internalComPort: the exposed port for other OAP nodes in the cluster internal communication.
 
 ## Nacos
 
@@ -175,8 +190,8 @@ nacos:
 
 Same as the Zookeeper coordinator,
 in some cases, the OAP default gRPC host and port in the core are not suitable for internal communication among the OAP
-nodes.
+nodes, such as the default host(`0.0.0.0`) should not be used in cluster mode.
 The following settings are provided to set the host and port manually, based on your own LAN env.
 
-- internalComHost: The registered host and other OAP nodes use this to communicate with the current node.
-- internalComPort: The registered port and other OAP nodes use this to communicate with the current node.
+- internalComHost: The exposed host name for other OAP nodes in the cluster internal communication.
+- internalComPort: the exposed port for other OAP nodes in the cluster internal communication.

--- a/docs/en/setup/backend/backend-setup.md
+++ b/docs/en/setup/backend/backend-setup.md
@@ -43,6 +43,62 @@ The default startup scripts are `/bin/oapService.sh`(.bat).
 Read the [start up mode](backend-start-up-mode.md) document to learn other ways to start up the backend.
 
 
+### Key Parameters In The Booting Logs
+After the OAP booting process completed, you should be able to see all important parameters listed in the logs.
+
+```
+2023-11-06 21:10:45,988 org.apache.skywalking.oap.server.starter.OAPServerBootstrap 67 [main] INFO  [] - The key booting parameters of Apache SkyWalking OAP are listed as following.
+
+Running Mode                               |   null                  
+TTL.metrics                                |   7                     
+TTL.record                                 |   3                     
+Version                                    |   9.7.0-SNAPSHOT-92af797
+module.agent-analyzer.provider             |   default               
+module.ai-pipeline.provider                |   default               
+module.alarm.provider                      |   default               
+module.aws-firehose.provider               |   default               
+module.cluster.provider                    |   standalone            
+module.configuration-discovery.provider    |   default               
+module.configuration.provider              |   none                  
+module.core.provider                       |   default               
+module.envoy-metric.provider               |   default               
+module.event-analyzer.provider             |   default               
+module.log-analyzer.provider               |   default               
+module.logql.provider                      |   default               
+module.promql.provider                     |   default               
+module.query.provider                      |   graphql               
+module.receiver-browser.provider           |   default               
+module.receiver-clr.provider               |   default               
+module.receiver-ebpf.provider              |   default               
+module.receiver-event.provider             |   default               
+module.receiver-jvm.provider               |   default               
+module.receiver-log.provider               |   default               
+module.receiver-meter.provider             |   default               
+module.receiver-otel.provider              |   default               
+module.receiver-profile.provider           |   default               
+module.receiver-register.provider          |   default               
+module.receiver-sharing-server.provider    |   default               
+module.receiver-telegraf.provider          |   default               
+module.receiver-trace.provider             |   default               
+module.service-mesh.provider               |   default               
+module.storage.provider                    |   h2                    
+module.telemetry.provider                  |   none                  
+oap.external.grpc.host                     |   0.0.0.0               
+oap.external.grpc.port                     |   11800                 
+oap.external.http.host                     |   0.0.0.0               
+oap.external.http.port                     |   7788                  
+oap.internal.comm.host                     |   0.0.0.0               
+oap.internal.comm.port                     |   11800       
+```
+
+- `oap.external.grpc.host`:`oap.external.grpc.port` is for reporting telemetry data through gRPC channel, including
+  native agents, OTEL.
+- `oap.external.http.host`:`oap.external.http.port` is for reporting telemetry data through HTTP channel and query,
+  including native GraphQL(UI), PromQL, LogQL.
+- `oap.internal.comm.host`:`oap.internal.comm.port` is for OAP cluster internal communication via gRPC/HTTP2 protocol.
+  The default host(`0.0.0.0`) is not suitable for the cluster mode, unless in k8s deployment. Please
+  read [Cluster Doc](backend-cluster.md) to understand how to set up the SkyWalking backend in the cluster mode.
+  
 ## application.yml
 SkyWalking backend startup behaviours are driven by `config/application.yml`. Understanding the settings file will help you read this document.
 
@@ -107,14 +163,3 @@ For example, metrics time will be formatted like yyyyMMddHHmm in minute dimensio
 By default, SkyWalking's OAP backend chooses the **OS default timezone**.
 Please follow the Java and OS documents if you want to override the timezone.
 
-#### How to query the storage directly from a 3rd party tool?
-SkyWalking provides different options based on browser UI, CLI and GraphQL to support extensions. But some users may want to query data
-directly from the storage. For example, in the case of ElasticSearch, Kibana is a great tool for doing this.
-
-By default, SkyWalking saves based64-encoded ID(s) only in metrics entities to reduce memory, network and storage space usages.
-But these tools usually don't support nested queries and are not convenient to work with. For these exceptional reasons,
-SkyWalking provides a config to add all necessary name column(s) into the final metrics entities with ID as a trade-off.
-
-Take a look at `core/default/activeExtraModelColumns` config in the `application.yaml`, and set it as `true` to enable this feature.
-
-Note that this feature is simply for 3rd party integration and doesn't provide any new features to native SkyWalking use cases.

--- a/docs/en/setup/backend/backend-setup.md
+++ b/docs/en/setup/backend/backend-setup.md
@@ -86,7 +86,7 @@ module.telemetry.provider                  |   none
 oap.external.grpc.host                     |   0.0.0.0               
 oap.external.grpc.port                     |   11800                 
 oap.external.http.host                     |   0.0.0.0               
-oap.external.http.port                     |   7788                  
+oap.external.http.port                     |   12800                  
 oap.internal.comm.host                     |   0.0.0.0               
 oap.internal.comm.port                     |   11800       
 ```

--- a/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/src/test/java/org/apache/skywalking/oap/server/cluster/plugin/zookeeper/ClusterModuleZookeeperProviderFunctionalIT.java
+++ b/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/src/test/java/org/apache/skywalking/oap/server/cluster/plugin/zookeeper/ClusterModuleZookeeperProviderFunctionalIT.java
@@ -18,6 +18,9 @@
 
 package org.apache.skywalking.oap.server.cluster.plugin.zookeeper;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import lombok.Getter;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.skywalking.oap.server.core.cluster.ClusterCoordinator;
@@ -45,10 +48,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -73,7 +72,7 @@ public class ClusterModuleZookeeperProviderFunctionalIT {
     @BeforeEach
     public void init() {
         Mockito.when(telemetryProvider.getService(MetricsCreator.class))
-                .thenReturn(new MetricsCreatorNoop());
+               .thenReturn(new MetricsCreatorNoop());
         TelemetryModule telemetryModule = Mockito.spy(TelemetryModule.class);
         Whitebox.setInternalState(telemetryModule, "loadedProvider", telemetryProvider);
         Mockito.when(moduleManager.find(TelemetryModule.NAME)).thenReturn(telemetryModule);
@@ -229,7 +228,7 @@ public class ClusterModuleZookeeperProviderFunctionalIT {
     }
 
     private ClusterModuleZookeeperProvider createProvider(String namespace, String internalComHost,
-        int internalComPort) throws Exception {
+                                                          int internalComPort) throws Exception {
         ClusterModuleZookeeperProvider provider = new ClusterModuleZookeeperProvider();
         provider.setManager(moduleManager);
         ClusterModuleZookeeperConfig moduleConfig = new ClusterModuleZookeeperConfig();

--- a/oap-server/server-configuration/configuration-apollo/src/test/java/org/apache/skywalking/oap/server/configuration/apollo/ApolloConfigurationIT.java
+++ b/oap-server/server-configuration/configuration-apollo/src/test/java/org/apache/skywalking/oap/server/configuration/apollo/ApolloConfigurationIT.java
@@ -95,7 +95,7 @@ public class ApolloConfigurationIT {
         final ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
         loadConfig(applicationConfiguration);
 
-        final ModuleManager moduleManager = new ModuleManager();
+        final ModuleManager moduleManager = new ModuleManager("Test");
         moduleManager.init(applicationConfiguration);
 
         provider = (ApolloConfigurationTestProvider) moduleManager.find(ApolloConfigurationTestModule.NAME).provider();

--- a/oap-server/server-configuration/configuration-consul/src/test/java/org/apache/skywalking/oap/server/configuration/consul/ConsulConfigurationIT.java
+++ b/oap-server/server-configuration/configuration-consul/src/test/java/org/apache/skywalking/oap/server/configuration/consul/ConsulConfigurationIT.java
@@ -65,7 +65,7 @@ public class ConsulConfigurationIT {
         final ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
         loadConfig(applicationConfiguration);
 
-        final ModuleManager moduleManager = new ModuleManager();
+        final ModuleManager moduleManager = new ModuleManager("Test");
         moduleManager.init(applicationConfiguration);
 
         provider = (ConsulConfigurationTestProvider) moduleManager.find(ConsulConfigurationTestModule.NAME).provider();

--- a/oap-server/server-configuration/configuration-etcd/src/test/java/org/apache/skywalking/oap/server/configuration/etcd/EtcdConfigurationIT.java
+++ b/oap-server/server-configuration/configuration-etcd/src/test/java/org/apache/skywalking/oap/server/configuration/etcd/EtcdConfigurationIT.java
@@ -73,7 +73,7 @@ public class EtcdConfigurationIT {
         final ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
         loadConfig(applicationConfiguration);
 
-        final ModuleManager moduleManager = new ModuleManager();
+        final ModuleManager moduleManager = new ModuleManager("Test");
         moduleManager.init(applicationConfiguration);
 
         provider = (EtcdConfigurationTestProvider) moduleManager.find(EtcdConfigurationTestModule.NAME).provider();

--- a/oap-server/server-configuration/configuration-nacos/src/test/java/org/apache/skywalking/oap/server/configuration/nacos/NacosConfigurationIT.java
+++ b/oap-server/server-configuration/configuration-nacos/src/test/java/org/apache/skywalking/oap/server/configuration/nacos/NacosConfigurationIT.java
@@ -70,7 +70,7 @@ public class NacosConfigurationIT {
         final ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
         loadConfig(applicationConfiguration);
 
-        final ModuleManager moduleManager = new ModuleManager();
+        final ModuleManager moduleManager = new ModuleManager("Test");
         moduleManager.init(applicationConfiguration);
 
         provider = (NacosConfigurationTestProvider) moduleManager.find(NacosConfigurationTestModule.NAME).provider();

--- a/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/ZookeeperConfigurationIT.java
+++ b/oap-server/server-configuration/configuration-zookeeper/src/test/java/org/apache/skywalking/oap/server/configuration/zookeeper/it/ZookeeperConfigurationIT.java
@@ -71,7 +71,7 @@ public class ZookeeperConfigurationIT {
         final ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
         loadConfig(applicationConfiguration);
 
-        final ModuleManager moduleManager = new ModuleManager();
+        final ModuleManager moduleManager = new ModuleManager("Test");
         moduleManager.init(applicationConfiguration);
 
         provider = (MockZookeeperConfigurationProvider) moduleManager.find(MockZookeeperConfigurationModule.NAME)

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
@@ -219,6 +219,11 @@ public class CoreModuleProvider extends ModuleProvider {
         } else {
             grpcServer = new GRPCServer(moduleConfig.getGRPCHost(), moduleConfig.getGRPCPort());
         }
+        setBootingParameter("oap.internal.comm.host", moduleConfig.getGRPCHost());
+        setBootingParameter("oap.internal.comm.port", moduleConfig.getGRPCPort());
+        setBootingParameter("oap.external.grpc.host", moduleConfig.getGRPCHost());
+        setBootingParameter("oap.external.grpc.port", moduleConfig.getGRPCPort());
+
         if (moduleConfig.getMaxConcurrentCallsPerConnection() > 0) {
             grpcServer.setMaxConcurrentCallsPerConnection(moduleConfig.getMaxConcurrentCallsPerConnection());
         }
@@ -244,6 +249,8 @@ public class CoreModuleProvider extends ModuleProvider {
                                                             .maxRequestHeaderSize(
                                                                 moduleConfig.getHttpMaxRequestHeaderSize())
                                                             .build();
+        setBootingParameter("oap.external.http.host", moduleConfig.getRestHost());
+        setBootingParameter("oap.external.http.port", moduleConfig.getRestPort());
         httpServer = new HTTPServer(httpServerConfig);
         httpServer.initialize();
 
@@ -335,10 +342,12 @@ public class CoreModuleProvider extends ModuleProvider {
             throw new ModuleStartException(
                 "Metric TTL should be at least 2 days, current value is " + moduleConfig.getMetricsDataTTL());
         }
+        setBootingParameter("TTL.metrics", moduleConfig.getMetricsDataTTL());
         if (moduleConfig.getRecordDataTTL() < 2) {
             throw new ModuleStartException(
                 "Record TTL should be at least 2 days, current value is " + moduleConfig.getRecordDataTTL());
         }
+        setBootingParameter("TTL.record", moduleConfig.getRecordDataTTL());
 
         final MetricsStreamProcessor metricsStreamProcessor = MetricsStreamProcessor.getInstance();
         metricsStreamProcessor.setL1FlushPeriod(moduleConfig.getL1FlushPeriod());

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/MockModuleManager.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/MockModuleManager.java
@@ -28,6 +28,7 @@ public abstract class MockModuleManager extends ModuleManager {
     private final Map<String, ModuleProviderHolder> moduleProviderHolderMap = Maps.newHashMap();
 
     public MockModuleManager() {
+        super("Mock");
         init();
     }
 

--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/test/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/mock/MockModuleManager.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/test/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/mock/MockModuleManager.java
@@ -28,6 +28,7 @@ public abstract class MockModuleManager extends ModuleManager {
     private final Map<String, ModuleProviderHolder> moduleProviderHolderMap = Maps.newHashMap();
 
     public MockModuleManager() {
+        super("Test");
         init();
     }
 

--- a/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ApplicationConfiguration.java
+++ b/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ApplicationConfiguration.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Properties;
 
 /**
- * Modulization configurations. The {@link ModuleManager} is going to start, lookup, start modules based on this.
+ * Modularization configurations. The {@link ModuleManager} is going to start, lookup, start modules based on this.
  */
 public class ApplicationConfiguration {
     private HashMap<String, ModuleConfiguration> modules = new HashMap<>();

--- a/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ModuleDefine.java
+++ b/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ModuleDefine.java
@@ -23,7 +23,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.ServiceLoader;
-import org.apache.logging.log4j.core.util.Loader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ModuleDefine.java
+++ b/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ModuleDefine.java
@@ -23,6 +23,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.ServiceLoader;
+import org.apache.logging.log4j.core.util.Loader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,8 +61,11 @@ public abstract class ModuleDefine implements ModuleProviderHolder {
      * @param configuration of this module
      * @throws ProviderNotFoundException when even don't find a single one providers.
      */
-    void prepare(ModuleManager moduleManager, ApplicationConfiguration.ModuleConfiguration configuration,
-                 ServiceLoader<ModuleProvider> moduleProviderLoader) throws ProviderNotFoundException, ServiceNotProvidedException, ModuleConfigException, ModuleStartException {
+    void prepare(ModuleManager moduleManager,
+                 ApplicationConfiguration.ModuleConfiguration configuration,
+                 ServiceLoader<ModuleProvider> moduleProviderLoader,
+                 TerminalFriendlyTable bootingParameters)
+        throws ProviderNotFoundException, ServiceNotProvidedException, ModuleConfigException, ModuleStartException {
         for (ModuleProvider provider : moduleProviderLoader) {
             if (!configuration.has(provider.name())) {
                 continue;
@@ -72,6 +76,7 @@ public abstract class ModuleDefine implements ModuleProviderHolder {
                     loadedProvider = provider;
                     loadedProvider.setManager(moduleManager);
                     loadedProvider.setModuleDefine(this);
+                    loadedProvider.setBootingParameters(bootingParameters);
                 } else {
                     throw new DuplicateProviderException(
                         this.name() + " module has one " + loadedProvider.name() + "[" + loadedProvider

--- a/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ModuleProvider.java
+++ b/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ModuleProvider.java
@@ -29,7 +29,7 @@ import lombok.Setter;
  * And each moduleDefine can have one or more implementation, which depends on `application.yml`
  */
 public abstract class ModuleProvider implements ModuleServiceHolder {
-    @Setter(AccessLevel.PACKAGE)
+    @Setter
     private ModuleManager manager;
     @Setter(AccessLevel.PACKAGE)
     private ModuleDefine moduleDefine;

--- a/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ModuleProvider.java
+++ b/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/ModuleProvider.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.oap.server.library.module;
 
 import java.util.HashMap;
 import java.util.Map;
+import lombok.AccessLevel;
 import lombok.Setter;
 
 /**
@@ -28,10 +29,12 @@ import lombok.Setter;
  * And each moduleDefine can have one or more implementation, which depends on `application.yml`
  */
 public abstract class ModuleProvider implements ModuleServiceHolder {
-    @Setter
+    @Setter(AccessLevel.PACKAGE)
     private ModuleManager manager;
-    @Setter
+    @Setter(AccessLevel.PACKAGE)
     private ModuleDefine moduleDefine;
+    @Setter(AccessLevel.PACKAGE)
+    private TerminalFriendlyTable bootingParameters;
     private final Map<Class<? extends Service>, Service> services = new HashMap<>();
 
     public ModuleProvider() {
@@ -146,5 +149,13 @@ public abstract class ModuleProvider implements ModuleServiceHolder {
 
     String getModuleName() {
         return moduleDefine.name();
+    }
+
+    protected void setBootingParameter(String name, String value) {
+        bootingParameters.addRow(new TerminalFriendlyTable.Row(name, value));
+    }
+
+    protected void setBootingParameter(String name, long value) {
+        bootingParameters.addRow(new TerminalFriendlyTable.Row(name, String.valueOf(value)));
     }
 }

--- a/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/TerminalFriendlyTable.java
+++ b/oap-server/server-library/library-module/src/main/java/org/apache/skywalking/oap/server/library/module/TerminalFriendlyTable.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.library.module;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * TerminalFriendlyTable represents a two columns table, each column accepts the String type.
+ * It provides the {@link #toString()} to return two aligned column tables for the terminal output.
+ */
+@RequiredArgsConstructor
+public class TerminalFriendlyTable {
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
+
+    /**
+     * The description of the table.
+     */
+    private final String description;
+
+    /**
+     * Rows of the table.
+     */
+    private final List<Row> rows = new ArrayList<>(20);
+    private int maxLengthOfCol1 = 0;
+    private int maxLengthOfCol2 = 0;
+
+    public void addRow(Row row) {
+        boolean replaced = false;
+        for (int i = 0; i < rows.size(); i++) {
+            final Row e = rows.get(i);
+            if (e.col1.equals(row.col1)) {
+                e.col2 = row.col2;
+                replaced = true;
+                row = e;
+                break;
+            }
+        }
+        if (!replaced) {
+            rows.add(row);
+        }
+        if (row.col1.length() > maxLengthOfCol1) {
+            maxLengthOfCol1 = row.col1.length();
+        }
+        if (row.col2 != null && row.col2.length() > maxLengthOfCol2) {
+            maxLengthOfCol2 = row.col2.length();
+        }
+    }
+
+    @Override
+    public String toString() {
+        rows.sort(Comparator.comparing(a -> a.col1));
+        StringBuilder output = new StringBuilder(description).append(LINE_SEPARATOR).append(LINE_SEPARATOR);
+        String format = "%-" + (maxLengthOfCol1 + 3) + "s |   %-" + maxLengthOfCol2 + "s";
+        rows.forEach(row -> {
+            output.append(String.format(format, row.getCol1(), row.getCol2())).append(LINE_SEPARATOR);
+        });
+        return output.toString();
+    }
+
+    @Getter
+    public static final class Row {
+        private final String col1;
+        private String col2;
+
+        public Row(final String col1, final String col2) {
+            if (col1 == null) {
+                throw new IllegalArgumentException("Column 1 can't be null.");
+            }
+            this.col1 = col1;
+            this.col2 = col2;
+        }
+    }
+}

--- a/oap-server/server-library/library-module/src/test/java/org/apache/skywalking/oap/server/library/module/ModuleManagerTest.java
+++ b/oap-server/server-library/library-module/src/test/java/org/apache/skywalking/oap/server/library/module/ModuleManagerTest.java
@@ -33,7 +33,7 @@ public class ModuleManagerTest {
         configuration.addModule("BaseA").addProviderConfiguration("P-A", new Properties());
         configuration.addModule("BaseB").addProviderConfiguration("P-B", new Properties());
 
-        ModuleManager manager = new ModuleManager();
+        ModuleManager manager = new ModuleManager("Test");
         manager.init(configuration);
 
         BaseModuleA.ServiceABusiness1 serviceABusiness1 = manager.find("BaseA")
@@ -52,7 +52,7 @@ public class ModuleManagerTest {
         settings.put("attr4", true);
         configuration.addModule("BaseA").addProviderConfiguration("P-A", settings);
 
-        ModuleManager manager = new ModuleManager();
+        ModuleManager manager = new ModuleManager("Test");
         manager.init(configuration);
 
         final ModuleServiceHolder provider = manager.find("BaseA").provider();
@@ -72,7 +72,7 @@ public class ModuleManagerTest {
             configuration.addModule("BaseA").addProviderConfiguration("P-A", new Properties());
             configuration.addModule("BaseB").addProviderConfiguration("P-B2", new Properties());
 
-            ModuleManager manager = new ModuleManager();
+            ModuleManager manager = new ModuleManager("Test");
             manager.init(configuration);
         });
     }
@@ -84,7 +84,7 @@ public class ModuleManagerTest {
             configuration.addModule("BaseA").addProviderConfiguration("P-A2", new Properties());
             configuration.addModule("BaseB").addProviderConfiguration("P-B3", new Properties());
 
-            ModuleManager manager = new ModuleManager();
+            ModuleManager manager = new ModuleManager("Test");
             manager.init(configuration);
         });
     }

--- a/oap-server/server-receiver-plugin/otel-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricRequestProcessorTest.java
+++ b/oap-server/server-receiver-plugin/otel-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricRequestProcessorTest.java
@@ -48,7 +48,7 @@ public class OpenTelemetryMetricRequestProcessorTest {
 
     @BeforeEach
     public void setUp() {
-        manager = new ModuleManager();
+        manager = new ModuleManager("Test");
         config = new OtelMetricReceiverConfig();
         metricRequestProcessor = new OpenTelemetryMetricRequestProcessor(manager, config);
         nodeLabels = new HashMap<>();

--- a/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/sharing/server/SharingServerModuleProvider.java
+++ b/oap-server/server-receiver-plugin/skywalking-sharing-server-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/sharing/server/SharingServerModuleProvider.java
@@ -86,6 +86,9 @@ public class SharingServerModuleProvider extends ModuleProvider {
             httpServerConfig.setPort(config.getRestPort());
             httpServerConfig.setContextPath(config.getRestContextPath());
 
+            setBootingParameter("oap.external.http.host", config.getRestHost());
+            setBootingParameter("oap.external.http.port", config.getRestPort());
+
             httpServer = new HTTPServer(httpServerConfig);
             httpServer.initialize();
 
@@ -114,6 +117,8 @@ public class SharingServerModuleProvider extends ModuleProvider {
                     config.getGRPCPort()
                 );
             }
+            setBootingParameter("oap.external.grpc.host", config.getGRPCHost());
+            setBootingParameter("oap.external.grpc.port", config.getGRPCPort());
             if (config.getMaxMessageSize() > 0) {
                 grpcServer.setMaxMessageSize(config.getMaxMessageSize());
             }

--- a/oap-server/server-receiver-plugin/skywalking-telegraf-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/telegraf/mock/MockModuleManager.java
+++ b/oap-server/server-receiver-plugin/skywalking-telegraf-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/telegraf/mock/MockModuleManager.java
@@ -29,6 +29,7 @@ public abstract class MockModuleManager extends ModuleManager {
     private final Map<String, ModuleProviderHolder> moduleProviderHolderMap = Maps.newHashMap();
 
     public MockModuleManager() {
+        super("Test");
         init();
     }
 

--- a/oap-server/server-starter/src/main/java/org/apache/skywalking/oap/server/starter/OAPServerBootstrap.java
+++ b/oap-server/server-starter/src/main/java/org/apache/skywalking/oap/server/starter/OAPServerBootstrap.java
@@ -25,7 +25,10 @@ import org.apache.skywalking.oap.server.core.status.ServerStatusService;
 import org.apache.skywalking.oap.server.core.version.Version;
 import org.apache.skywalking.oap.server.library.module.ApplicationConfiguration;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
+import org.apache.skywalking.oap.server.library.module.TerminalFriendlyTable;
 import org.apache.skywalking.oap.server.starter.config.ApplicationConfigLoader;
+
+import static org.apache.skywalking.oap.server.library.module.TerminalFriendlyTable.Row;
 
 /**
  * Starter core. Load the core configuration file, and initialize the startup sequence through {@link ModuleManager}.
@@ -33,11 +36,17 @@ import org.apache.skywalking.oap.server.starter.config.ApplicationConfigLoader;
 @Slf4j
 public class OAPServerBootstrap {
     public static void start() {
+        ModuleManager manager = new ModuleManager("Apache SkyWalking OAP");
+        final TerminalFriendlyTable bootingParameters = manager.getBootingParameters();
+
         String mode = System.getProperty("mode");
         RunningMode.setMode(mode);
 
-        ApplicationConfigLoader configLoader = new ApplicationConfigLoader();
-        ModuleManager manager = new ModuleManager();
+        ApplicationConfigLoader configLoader = new ApplicationConfigLoader(bootingParameters);
+
+        bootingParameters.addRow(new Row("Running Mode", mode));
+        bootingParameters.addRow(new Row("Version", Version.CURRENT.toString()));
+
         try {
             ApplicationConfiguration applicationConfiguration = configLoader.load();
             manager.init(applicationConfiguration);
@@ -47,8 +56,6 @@ public class OAPServerBootstrap {
                    .getService(ServerStatusService.class)
                    .bootedNow(System.currentTimeMillis());
 
-            log.info("Version of OAP: {}", Version.CURRENT);
-
             if (RunningMode.isInitMode()) {
                 log.info("OAP starts up in init mode successfully, exit now...");
                 System.exit(0);
@@ -56,6 +63,8 @@ public class OAPServerBootstrap {
         } catch (Throwable t) {
             log.error(t.getMessage(), t);
             System.exit(1);
+        } finally {
+            log.info(bootingParameters.toString());
         }
     }
 }

--- a/oap-server/server-starter/src/main/java/org/apache/skywalking/oap/server/starter/config/ApplicationConfigLoader.java
+++ b/oap-server/server-starter/src/main/java/org/apache/skywalking/oap/server/starter/config/ApplicationConfigLoader.java
@@ -24,6 +24,7 @@ import org.apache.skywalking.oap.server.library.module.ProviderNotFoundException
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
 import org.apache.skywalking.oap.server.library.util.PropertyPlaceholderHelper;
 import org.apache.skywalking.oap.server.library.util.ResourceUtils;
+import org.apache.skywalking.oap.server.library.module.TerminalFriendlyTable;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.FileNotFoundException;
@@ -44,7 +45,13 @@ public class ApplicationConfigLoader implements ConfigLoader<ApplicationConfigur
     private static final String DISABLE_SELECTOR = "-";
     private static final String SELECTOR = "selector";
 
-    private final Yaml yaml = new Yaml();
+    private final TerminalFriendlyTable bootingParameters;
+    private final Yaml yaml;
+
+    public ApplicationConfigLoader(final TerminalFriendlyTable bootingParameters) {
+        this.bootingParameters = bootingParameters;
+        this.yaml = new Yaml();
+    }
 
     @Override
     public ApplicationConfiguration load() throws ConfigFileNotFoundException {
@@ -71,6 +78,7 @@ public class ApplicationConfigLoader implements ConfigLoader<ApplicationConfigur
                                 "Get a provider define belong to {} module, provider name: {}", moduleName,
                                 providerName
                             );
+                            bootingParameters.addRow(new TerminalFriendlyTable.Row("module." + moduleName + ".provider", providerName));
                             final Map<String, ?> propertiesConfig = (Map<String, ?>) config;
                             final Properties properties = new Properties();
                             if (propertiesConfig != null) {

--- a/oap-server/server-starter/src/test/java/org/apache/skywalking/oap/server/starter/config/ApplicationConfigLoaderTestCase.java
+++ b/oap-server/server-starter/src/test/java/org/apache/skywalking/oap/server/starter/config/ApplicationConfigLoaderTestCase.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.oap.server.starter.config;
 
 import org.apache.skywalking.oap.server.library.module.ApplicationConfiguration;
+import org.apache.skywalking.oap.server.library.module.TerminalFriendlyTable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +37,7 @@ public class ApplicationConfigLoaderTestCase {
         System.setProperty("SW_STORAGE", "mysql");
         System.setProperty("SW_RECEIVER_ZIPKIN", "default");
         System.setProperty("SW_DATA_SOURCE_PASSWORD", "!AI!3B");
-        ApplicationConfigLoader configLoader = new ApplicationConfigLoader();
+        ApplicationConfigLoader configLoader = new ApplicationConfigLoader(new TerminalFriendlyTable("test"));
         applicationConfiguration = configLoader.load();
     }
 

--- a/oap-server/server-testing/src/main/java/org/apache/skywalking/oap/server/testing/module/mock/MockModuleManager.java
+++ b/oap-server/server-testing/src/main/java/org/apache/skywalking/oap/server/testing/module/mock/MockModuleManager.java
@@ -28,7 +28,8 @@ import java.util.Map;
 public abstract class MockModuleManager extends ModuleManager {
     private final Map<String, ModuleProviderHolder> moduleProviderHolderMap = Maps.newHashMap();
 
-    public MockModuleManager() {
+    public MockModuleManager(String description) {
+        super(description);
         init();
     }
 

--- a/oap-server/server-tools/profile-exporter/tool-profile-snapshot-bootstrap/src/main/java/org/apache/skywalking/oap/server/tool/profile/exporter/ProfileSnapshotExporterBootstrap.java
+++ b/oap-server/server-tools/profile-exporter/tool-profile-snapshot-bootstrap/src/main/java/org/apache/skywalking/oap/server/tool/profile/exporter/ProfileSnapshotExporterBootstrap.java
@@ -33,7 +33,7 @@ public class ProfileSnapshotExporterBootstrap {
             = new TerminalFriendlyTable("The key booting parameters of Apache SkyWalking OAP are listed as following.");
 
         ApplicationConfigLoader configLoader = new ApplicationConfigLoader(bootingParameters);
-        ModuleManager manager = new ModuleManager();
+        ModuleManager manager = new ModuleManager("Apache SkyWalking OAP Exporter");
         try {
             // parse config and init
             ExporterConfig exporterConfig = ExporterConfig.parse(args);

--- a/oap-server/server-tools/profile-exporter/tool-profile-snapshot-bootstrap/src/main/java/org/apache/skywalking/oap/server/tool/profile/exporter/ProfileSnapshotExporterBootstrap.java
+++ b/oap-server/server-tools/profile-exporter/tool-profile-snapshot-bootstrap/src/main/java/org/apache/skywalking/oap/server/tool/profile/exporter/ProfileSnapshotExporterBootstrap.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.tool.profile.exporter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.library.module.ApplicationConfiguration;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
+import org.apache.skywalking.oap.server.library.module.TerminalFriendlyTable;
 import org.apache.skywalking.oap.server.starter.config.ApplicationConfigLoader;
 
 import java.io.File;
@@ -28,7 +29,10 @@ import java.io.File;
 @Slf4j
 public class ProfileSnapshotExporterBootstrap {
     public static void export(String[] args) {
-        ApplicationConfigLoader configLoader = new ApplicationConfigLoader();
+        TerminalFriendlyTable bootingParameters
+            = new TerminalFriendlyTable("The key booting parameters of Apache SkyWalking OAP are listed as following.");
+
+        ApplicationConfigLoader configLoader = new ApplicationConfigLoader(bootingParameters);
         ModuleManager manager = new ModuleManager();
         try {
             // parse config and init


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

There are many logs at the DEBUG level and few logs at the INFO level. The raw text hides many important booting parameters in the haystack. So, I am proposing this new implementation to unify selected key parameters in one place and log out after the booting is down. This should be better formatted and easier to find and report.