### PR TITLE
Fix cannot query zipkin traces with `annotationQuery` parameter in the JDBC related storage

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -37,6 +37,7 @@
 * Correct the file format and fix typos in the filenames for monitoring Kafka's e2e tests.
 * Support extract timestamp from patterned datetime string in LAL.
 * Support output key parameters in the booting logs.
+* Fix cannot query zipkin traces with `annotationQuery` parameter in the JDBC related storage.
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCZipkinQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCZipkinQueryDAO.java
@@ -253,7 +253,7 @@ public class JDBCZipkinQueryDAO implements IZipkinQueryDAO {
                     }
                 }
             }
-            sql.append(" group by ").append(ZipkinSpanRecord.TRACE_ID);
+            sql.append(" group by ").append(table).append(".").append(ZipkinSpanRecord.TRACE_ID);
             sql.append(" order by min(").append(ZipkinSpanRecord.TIMESTAMP_MILLIS).append(") desc");
             sql.append(" limit ").append(request.limit());
             h2Client.executeQuery(sql.toString(), resultSet -> {

--- a/test/e2e-v2/cases/zipkin/zipkin-cases.yaml
+++ b/test/e2e-v2/cases/zipkin/zipkin-cases.yaml
@@ -24,7 +24,7 @@ cases:
   - query: curl http://${oap_host}:${oap_9412}/zipkin/api/v2/spans?serviceName=frontend
     expected: expected/span-name.yml
   # traces
-  - query: curl http://${oap_host}:${oap_9412}/zipkin/api/v2/traces?serviceName=frontend&remoteServiceName=backend&spanName=get&limit=1
+  - query: curl http://${oap_host}:${oap_9412}/zipkin/api/v2/traces?serviceName=frontend&remoteServiceName=backend&spanName=get&annotationQuery=wr&limit=1
     expected: expected/traces.yml
   # autocomplete
   - query: curl http://${oap_host}:${oap_9412}/zipkin/api/v2/autocompleteValues?key=http.method


### PR DESCRIPTION
When I use JDBC-related storage, such as PostgreSQL, and execute `/zipkin/api/v2/traces?annotationQuery=error` with zipkin-query plugin, it prompts an SQL error.

![1681699414761_ pic](https://github.com/apache/skywalking/assets/3417650/9d559fee-3ff1-4725-a499-8bb3f78b2141)


- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
