### PR TITLE
Revert "Add eclipse-temurin:21-jre as a new image runtime"

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -79,10 +79,5 @@ jobs:
           SW_OAP_BASE_IMAGE: eclipse-temurin:17-jre
           TAG: ${{ env.TAG }}-java17
         run: make build.all docker.push
-      - name: Build and push docker images based on Java 21
-        env:
-          SW_OAP_BASE_IMAGE: eclipse-temurin:21-jre
-          TAG: ${{ env.TAG }}-java21
-        run: make build.all docker.push
       - name: Build and push docker images
         run: make build.all docker.push

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -5,8 +5,6 @@
 * Add distribution/graal module to make preliminary preparations for supporting native-image.
 * Bump Java agent to 9.1-dev in the e2e tests.
 * Bump up netty to 4.1.100.
-* Add eclipse-temurin:21-jre as a new image runtime. Now, eclipse-temurin:11-jre as default. Both eclipse-temurin:17-jre
-  eclipse-temurin:21-jre are available for every commit and release.
 
 #### OAP Server
 


### PR DESCRIPTION
Reverts apache/skywalking#11464 according to https://github.com/apache/skywalking/pull/11514#issuecomment-1801923632