### PR TITLE
Replace Metrics v2 protocol with MQE in UI Topology related templates

### DIFF
--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/general/general-endpoint.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/general/general-endpoint.json
@@ -287,47 +287,67 @@
                   "linkDashboard": "General-Endpoint-Relation",
                   "nodeDashboard": "General-Endpoint",
                   "linkServerMetrics": [
-                    "endpoint_relation_sla",
-                    "endpoint_relation_resp_time",
-                    "endpoint_relation_cpm"
+
                   ],
-                  "linkClientMetrics": [],
+                  "linkClientMetrics": [
+
+                  ],
                   "nodeMetrics": [
-                    "endpoint_sla",
-                    "endpoint_resp_time",
-                    "endpoint_cpm"
+
                   ],
-                  "legend": [],
-                  "description": {},
+                  "legend": [
+
+                  ],
+                  "description": {
+
+                  },
                   "linkServerMetricConfig": [
                     {
-                      "unit": "%",
                       "label": "Success Rate",
-                      "calculation": "percentage"
+                      "unit": "%"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Latency"
+                      "label": "Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "calls / min",
-                      "label": "Load"
+                      "label": "Load",
+                      "unit": "calls / min"
                     }
                   ],
                   "nodeMetricConfig": [
                     {
-                      "unit": "%",
                       "label": "Success Rate",
-                      "calculation": "percentage"
+                      "unit": "%"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Latency"
+                      "label": "Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "calls / min ",
-                      "label": "Load"
+                      "label": "Load",
+                      "unit": "calls / min"
                     }
+                  ],
+                  "linkServerExpressions": [
+                    "avg(endpoint_relation_sla/100)",
+                    "avg(endpoint_relation_resp_time)",
+                    "avg(endpoint_relation_cpm)"
+                  ],
+                  "linkClientExpressions": [
+
+                  ],
+                  "nodeExpressions": [
+                    "avg(endpoint_sla/100)",
+                    "avg(endpoint_resp_time)",
+                    "avg(endpoint_cpm)"
+                  ],
+                  "metricMode": "Expression",
+                  "legendMQE": {
+                    "expression": ""
+                  },
+                  "linkClientMetricConfig": [
+
                   ]
                 }
               ]

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/general/general-root.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/general/general-root.json
@@ -108,29 +108,16 @@
                     }
                   ],
                   "linkServerMetrics": [
-                    "service_relation_server_resp_time",
-                    "service_relation_server_cpm"
+
                   ],
                   "linkClientMetrics": [
-                    "service_relation_client_cpm",
-                    "service_relation_client_resp_time"
+
                   ],
                   "nodeMetrics": [
-                    "service_cpm",
-                    "service_sla",
-                    "service_resp_time"
+
                   ],
                   "legend": [
-                    {
-                      "name": "service_sla",
-                      "condition": "<",
-                      "value": "9500"
-                    },
-                    {
-                      "name": "service_cpm",
-                      "condition": ">",
-                      "value": "1"
-                    }
+
                   ],
                   "description": {
                     "healthy": "Healthy",
@@ -138,39 +125,55 @@
                   },
                   "nodeMetricConfig": [
                     {
-                      "unit": "calls / min",
-                      "label": "Load"
+                      "label": "Load",
+                      "unit": "calls / min"
                     },
                     {
-                      "calculation": "percentage",
                       "unit": "%",
                       "label": "Success Rate"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Latency"
+                      "label": "Latency",
+                      "unit": "ms"
                     }
                   ],
                   "linkServerMetricConfig": [
                     {
-                      "unit": "ms",
-                      "label": "Server Latency"
+                      "label": "Server Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "calls / min",
-                      "label": "Server Load"
+                      "label": "Server Load",
+                      "unit": "calls / min"
                     }
                   ],
                   "linkClientMetricConfig": [
                     {
-                      "unit": "calls / min",
-                      "label": "Client Load"
+                      "label": "Client Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Client Latency"
+                      "label": "Client Load",
+                      "unit": "calls / min"
                     }
-                  ]
+                  ],
+                  "linkServerExpressions": [
+                    "avg(service_relation_server_resp_time)",
+                    "avg(service_relation_server_cpm)"
+                  ],
+                  "linkClientExpressions": [
+                    "avg(service_relation_client_resp_time)",
+                    "avg(service_relation_client_cpm)"
+                  ],
+                  "nodeExpressions": [
+                    "avg(service_cpm)",
+                    "avg(service_sla/100)",
+                    "avg(service_resp_time)"
+                  ],
+                  "metricMode": "Expression",
+                  "legendMQE": {
+                    "expression": "avg(service_sla < 9500) and avg(service_cpm) > 1"
+                  }
                 }
               ]
             },

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/general/general-service-relation.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/general/general-service-relation.json
@@ -484,55 +484,71 @@
                   "linkDashboard": "General-Instance-Relation",
                   "nodeDashboard": "General-Instance",
                   "linkServerMetrics": [
-                    "service_instance_relation_server_resp_time",
-                    "service_instance_relation_server_cpm"
+
                   ],
                   "linkClientMetrics": [
-                    "service_instance_relation_client_resp_time",
-                    "service_instance_relation_client_cpm"
+
                   ],
                   "nodeMetrics": [
-                    "service_instance_sla",
-                    "service_instance_cpm",
-                    "service_instance_resp_time"
+
                   ],
-                  "legend": [],
-                  "description": {},
+                  "legend": [
+
+                  ],
+                  "description": {
+
+                  },
                   "nodeMetricConfig": [
                     {
-                      "unit": "%",
-                      "calculation": "percentage",
-                      "label": "Success Rate"
+                      "label": "Success Rate",
+                      "unit": "%"
                     },
                     {
-                      "unit": "calls / min",
-                      "label": "Load"
+                      "label": "Load",
+                      "unit": "calls / min"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Latency"
+                      "label": "Latency",
+                      "unit": "ms"
                     }
                   ],
                   "linkServerMetricConfig": [
                     {
-                      "unit": "ms",
-                      "label": "Server Latency"
+                      "label": "Server Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "calls / min ",
-                      "label": "Server Load"
+                      "label": "Server Load",
+                      "unit": "calls / min"
                     }
                   ],
                   "linkClientMetricConfig": [
                     {
-                      "unit": "ms",
-                      "label": "Client Latency"
+                      "label": "Client Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "calls / min",
-                      "label": "Client Load"
+                      "label": "Client Load",
+                      "unit": "calls / min"
                     }
-                  ]
+                  ],
+                  "linkServerExpressions": [
+                    "avg(service_instance_relation_server_resp_time)",
+                    "avg(service_instance_relation_server_cpm)"
+                  ],
+                  "linkClientExpressions": [
+                    "avg(service_instance_relation_client_resp_time)",
+                    "avg(service_instance_relation_client_cpm)"
+                  ],
+                  "nodeExpressions": [
+                    "avg(service_instance_sla/100)",
+                    "avg(service_instance_cpm)",
+                    "avg(service_instance_resp_time)"
+                  ],
+                  "metricMode": "Expression",
+                  "legendMQE": {
+                    "expression": ""
+                  }
                 }
               ]
             }

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/mesh/mesh-root.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/mesh/mesh-root.json
@@ -97,29 +97,16 @@
                     }
                   ],
                   "linkServerMetrics": [
-                    "service_relation_server_resp_time",
-                    "service_relation_server_cpm"
+
                   ],
                   "linkClientMetrics": [
-                    "service_relation_client_cpm",
-                    "service_relation_client_resp_time"
+
                   ],
                   "nodeMetrics": [
-                    "service_cpm",
-                    "service_sla",
-                    "service_resp_time"
+
                   ],
                   "legend": [
-                    {
-                      "name": "service_sla",
-                      "condition": "<",
-                      "value": "9500"
-                    },
-                    {
-                      "name": "service_cpm",
-                      "condition": ">",
-                      "value": "1"
-                    }
+
                   ],
                   "description": {
                     "healthy": "Healthy",
@@ -127,39 +114,55 @@
                   },
                   "nodeMetricConfig": [
                     {
-                      "unit": "calls or packets / min",
-                      "label": "Load"
+                      "label": "Load",
+                      "unit": "calls or packets / min"
                     },
                     {
-                      "calculation": "percentage",
-                      "unit": "%",
-                      "label": "Success Rate"
+                      "label": "Success Rate",
+                      "unit": "%"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Latency"
+                      "label": "Latency",
+                      "unit": "ms"
                     }
                   ],
                   "linkServerMetricConfig": [
                     {
-                      "unit": "ms",
-                      "label": "Server Latency"
+                      "label": "Server Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "calls or packets / min",
-                      "label": "Server Load"
+                      "label": "Server Load",
+                      "unit": "calls or packets / min"
                     }
                   ],
                   "linkClientMetricConfig": [
                     {
-                      "unit": "calls or packets / min",
-                      "label": "Client Load"
+                      "label": "Client Load",
+                      "unit": "calls or packets / min"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Client Latency"
+                      "label": "Client Latency",
+                      "unit": "ms"
                     }
-                  ]
+                  ],
+                  "linkServerExpressions": [
+                    "avg(service_relation_server_resp_time)",
+                    "avg(service_relation_server_cpm)"
+                  ],
+                  "linkClientExpressions": [
+                    "avg(service_relation_client_cpm)",
+                    "avg(service_relation_client_resp_time)"
+                  ],
+                  "nodeExpressions": [
+                    "avg(service_cpm)",
+                    "avg(service_sla/100)",
+                    "avg(service_resp_time)"
+                  ],
+                  "metricMode": "Expression",
+                  "legendMQE": {
+                    "expression": "avg(service_sla/100) > 9500 and avg(service_cpm) > 1"
+                  }
                 }
               ]
             },

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/mesh/mesh-service-relation.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/mesh/mesh-service-relation.json
@@ -702,55 +702,71 @@
                   "linkDashboard": "Mesh-Instance-Relation",
                   "nodeDashboard": "Mesh-Instance",
                   "linkServerMetrics": [
-                    "service_instance_relation_server_resp_time",
-                    "service_instance_relation_server_cpm"
+
                   ],
                   "linkClientMetrics": [
-                    "service_instance_relation_client_resp_time",
-                    "service_instance_relation_client_cpm"
+
                   ],
                   "nodeMetrics": [
-                    "service_instance_sla",
-                    "service_instance_cpm",
-                    "service_instance_resp_time"
+
                   ],
-                  "legend": [],
-                  "description": {},
+                  "legend": [
+
+                  ],
+                  "description": {
+
+                  },
                   "nodeMetricConfig": [
                     {
-                      "unit": "%",
-                      "calculation": "percentage",
-                      "label": "Success Rate"
+                      "label": "Success Rate",
+                      "unit": "%"
                     },
                     {
-                      "unit": "calls or packets / min",
-                      "label": "Load"
+                      "label": "Load",
+                      "unit": "calls or packets / min"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Latency"
+                      "label": "Latency",
+                      "unit": "ms"
                     }
                   ],
                   "linkServerMetricConfig": [
                     {
-                      "unit": "ms",
-                      "label": "Server Latency"
+                      "label": "Server Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "calls or packets / min ",
-                      "label": "Server Load"
+                      "label": "Server Load",
+                      "unit": "calls or packets / min"
                     }
                   ],
                   "linkClientMetricConfig": [
                     {
-                      "unit": "ms",
-                      "label": "Client Latency"
+                      "label": "Client Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "calls or packets / min",
-                      "label": "Client Load"
+                      "label": "Client Load",
+                      "unit": "calls or packets / min"
                     }
-                  ]
+                  ],
+                  "linkServerExpressions": [
+                    "avg(service_instance_relation_server_resp_time)",
+                    "avg(service_instance_relation_server_cpm)"
+                  ],
+                  "linkClientExpressions": [
+                    "avg(service_instance_relation_client_resp_time)",
+                    "avg(service_instance_relation_client_cpm)"
+                  ],
+                  "nodeExpressions": [
+                    "avg(service_instance_sla/100)",
+                    "avg(service_instance_cpm)",
+                    "avg(service_instance_resp_time)"
+                  ],
+                  "metricMode": "Expression",
+                  "legendMQE": {
+                    "expression": ""
+                  }
                 }
               ]
             },

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/mesh/mesh-service.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/mesh/mesh-service.json
@@ -662,29 +662,16 @@
                     }
                   ],
                   "linkServerMetrics": [
-                    "service_relation_server_resp_time",
-                    "service_relation_server_cpm"
+
                   ],
                   "linkClientMetrics": [
-                    "service_relation_client_cpm",
-                    "service_relation_client_resp_time"
+
                   ],
                   "nodeMetrics": [
-                    "service_cpm",
-                    "service_sla",
-                    "service_resp_time"
+
                   ],
                   "legend": [
-                    {
-                      "name": "service_sla",
-                      "condition": "<",
-                      "value": "9500"
-                    },
-                    {
-                      "name": "service_cpm",
-                      "condition": ">",
-                      "value": "1"
-                    }
+
                   ],
                   "description": {
                     "healthy": "Healthy",
@@ -692,39 +679,55 @@
                   },
                   "nodeMetricConfig": [
                     {
-                      "unit": "calls or packets / min",
-                      "label": "Load"
+                      "label": "Load",
+                      "unit": "calls or packets / min"
                     },
                     {
-                      "calculation": "percentage",
-                      "unit": "%",
-                      "label": "Success Rate"
+                      "label": "Success Rate",
+                      "unit": "%"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Latency"
+                      "label": "Latency",
+                      "unit": "ms"
                     }
                   ],
                   "linkServerMetricConfig": [
                     {
-                      "unit": "ms",
-                      "label": "Server Latency"
+                      "label": "Server Latency",
+                      "unit": "ms"
                     },
                     {
-                      "unit": "calls or packets / min",
-                      "label": "Server Load"
+                      "label": "Server Load",
+                      "unit": "calls or packets / min"
                     }
                   ],
                   "linkClientMetricConfig": [
                     {
-                      "unit": "calls or packets / min",
-                      "label": "Client Load"
+                      "label": "Client Load",
+                      "unit": "calls or packets / min"
                     },
                     {
-                      "unit": "ms",
-                      "label": "Client Latency"
+                      "label": "Client Latency",
+                      "unit": "ms"
                     }
-                  ]
+                  ],
+                  "linkServerExpressions": [
+                    "avg(service_relation_server_resp_time)",
+                    "avg(service_relation_server_cpm)"
+                  ],
+                  "linkClientExpressions": [
+                    "avg(service_relation_client_cpm)",
+                    "avg(service_relation_client_resp_time)"
+                  ],
+                  "nodeExpressions": [
+                    "avg(service_cpm)",
+                    "avg(service_sla/100)",
+                    "avg(service_resp_time)"
+                  ],
+                  "metricMode": "Expression",
+                  "legendMQE": {
+                    "expression": "avg(service_sla/100) > 9500 and avg(service_cpm) > 1"
+                  }
                 }
               ]
             },


### PR DESCRIPTION
Following https://github.com/apache/skywalking/pull/11575, fix missing topology-related UI templates 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
