### PR TITLE
Add `is_present` function in MQE for check if the list metrics has value or not

### DIFF
--- a/docs/en/api/metrics-query-expression.md
+++ b/docs/en/api/metrics-query-expression.md
@@ -293,6 +293,9 @@ The following example would return the content of the **service_cpm** metric.
 view_as_seq(not_existing, service_cpm)
 ```
 
+#### Result Type
+The result type is determined by the type of selected not-null metric expression.
+
 ### IsPresent Operation
 IsPresent operation represents that in a list of metrics, if any expression has a value, it would return `1` in the result; otherwise, it would return `0`.
 
@@ -305,11 +308,11 @@ For example:
 When the meter does not exist or the metrics has no value, it would return `0`. 
 However, if the metrics list contains meter with values, it would return `1`.
 ```text
-is_present(not_existing, existing_without_value, exiting_with_value)
+is_present(not_existing, existing_without_value, existing_with_value)
 ```
 
 #### Result Type
-The result type is determined by the type of selected not-null metric expression.
+The result type is `SINGLE_VALUE`, and the result(`1` or `0`) in the first result.
 
 ## Trend Operation
 Trend Operation takes an expression and performs a trend calculation on its results.

--- a/docs/en/api/metrics-query-expression.md
+++ b/docs/en/api/metrics-query-expression.md
@@ -293,6 +293,21 @@ The following example would return the content of the **service_cpm** metric.
 view_as_seq(not_existing, service_cpm)
 ```
 
+### IsPresent Operation
+IsPresent operation represents that in a list of metrics, if any expression has a value, it would return `1` in the result; otherwise, it would return `0`.
+
+Expression:
+```text
+is_present([<expression_1>, <expression_2>, ...])
+```
+
+For example:
+When the meter does not exist or the metrics has no value, it would return `0`. 
+However, if the metrics list contains meter with values, it would return `1`.
+```text
+is_present(not_existing, existing_without_value, exiting_with_value)
+```
+
 #### Result Type
 The result type is determined by the type of selected not-null metric expression.
 

--- a/docs/en/api/metrics-query-expression.md
+++ b/docs/en/api/metrics-query-expression.md
@@ -312,7 +312,7 @@ is_present(not_existing, existing_without_value, existing_with_value)
 ```
 
 #### Result Type
-The result type is `SINGLE_VALUE`, and the result(`1` or `0`) in the first result.
+The result type is `SINGLE_VALUE`, and the result(`1` or `0`) in the first value.
 
 ## Trend Operation
 Trend Operation takes an expression and performs a trend calculation on its results.

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -5,6 +5,7 @@
 
 #### OAP Server
 * Add `layer` parameter to the global topology graphQL query.
+* Add `is_present` function in MQE for check if the list metrics has a value or not.
 
 #### UI
 

--- a/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQELexer.g4
+++ b/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQELexer.g4
@@ -68,6 +68,9 @@ TOP_N:        'top_n';
 // ViewAsSeq
 VIEW_AS_SEQ: 'view_as_seq';
 
+// IsPresent
+IS_PRESENT: 'is_present';
+
 // Relabels
 RELABELS:     'relabels';
 

--- a/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQEParser.g4
+++ b/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQEParser.g4
@@ -76,7 +76,7 @@ trend:
 topN: TOP_N;
 
 logical_operator:
-    VIEW_AS_SEQ;
+    VIEW_AS_SEQ | IS_PRESENT;
 
 relabels: RELABELS;
 

--- a/test/e2e-v2/cases/mqe/expected/isPresent-OP-false.yml
+++ b/test/e2e-v2/cases/mqe/expected/isPresent-OP-false.yml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: SINGLE_VALUE
+results:
+  - metric:
+      labels: []
+    values:
+      - id: null
+        value: "0"
+        traceid: null
+error: null

--- a/test/e2e-v2/cases/mqe/expected/isPresent-OP-true.yml
+++ b/test/e2e-v2/cases/mqe/expected/isPresent-OP-true.yml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: SINGLE_VALUE
+results:
+  - metric:
+      labels: []
+    values:
+      - id: null
+        value: "1"
+        traceid: null
+error: null

--- a/test/e2e-v2/cases/mqe/mqe-cases.yaml
+++ b/test/e2e-v2/cases/mqe/mqe-cases.yaml
@@ -68,6 +68,12 @@ cases:
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="view_as_seq(mq_service_consume_sla,service_sla)" --service-name=e2e-service-provider
     expected: expected/viewAsSeq-OP.yml
 
+  # isPresent-OP
+  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="is_present(service_sla)" --service-name=e2e-service-provider
+    expected: expected/isPresent-OP-true.yml
+  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="is_present(not_exist_meter,mq_service_consume_cpm)" --service-name=e2e-service-provider
+    expected: expected/isPresent-OP-false.yml
+
   # trend-OP
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="increase(service_resp_time,2)" --service-name=e2e-service-provider
     expected: expected/trend-OP.yml


### PR DESCRIPTION
Following https://github.com/apache/skywalking/issues/11625, I think we need an MQE function to check whether the expression contains a value or not. If contains a value(meter value is `1` means has value), then we should show the tab. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
