### PR TITLE
fix violations of Sonarqube rule java:S2184

### DIFF
--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/TrendOp.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/TrendOp.java
@@ -82,13 +82,13 @@ public class TrendOp {
                 rangeSeconds = trendRange;
                 break;
             case MINUTE:
-                rangeSeconds = trendRange * 60;
+                rangeSeconds = trendRange * 60L;
                 break;
             case HOUR:
-                rangeSeconds = trendRange * 3600;
+                rangeSeconds = trendRange * 3600L;
                 break;
             case DAY:
-                rangeSeconds = trendRange * 86400;
+                rangeSeconds = trendRange * 86400L;
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported step: " + step);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/TimeBucket.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/TimeBucket.java
@@ -144,7 +144,7 @@ public class TimeBucket {
         calendar.setTimeInMillis(timestamp);
 
         long year = calendar.get(Calendar.YEAR);
-        long month = calendar.get(Calendar.MONTH) + 1;
+        long month = calendar.get(Calendar.MONTH) + 1L;
         long day = calendar.get(Calendar.DAY_OF_MONTH);
         long hour = calendar.get(Calendar.HOUR_OF_DAY);
         long minute = calendar.get(Calendar.MINUTE);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/Metrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/Metrics.java
@@ -126,7 +126,7 @@ public abstract class Metrics extends StreamData implements StorageData {
         } else if (isHourBucket()) {
             return 60;
         } else if (isDayBucket()) {
-            return 24 * 60;
+            return 24L * 60;
         }
         throw new IllegalStateException("Time bucket (" + timeBucket + ") can't be recognized.");
     }

--- a/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricRequestProcessor.java
+++ b/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricRequestProcessor.java
@@ -195,7 +195,7 @@ public class OpenTelemetryMetricRequestProcessor implements Service {
         }
         double upperBound;
         for (int i = 0; i < negativeBucketCounts.size(); i++) {
-            upperBound = -Math.pow(base, negativeOffset + i);
+            upperBound = -Math.pow(base, (double) negativeOffset + i);
             if (upperBound == Double.NEGATIVE_INFINITY) {
                 log.warn("Receive and reject out-of-range ExponentialHistogram data");
                 return new HashMap<>();
@@ -203,7 +203,7 @@ public class OpenTelemetryMetricRequestProcessor implements Service {
             result.put(upperBound, negativeBucketCounts.get(i));
         }
         for (int i = 0; i < positiveBucketCounts.size() - 1; i++) {
-            upperBound = Math.pow(base, positiveOffset + i + 1);
+            upperBound = Math.pow(base, positiveOffset + i + 1D);
             if (upperBound == Double.POSITIVE_INFINITY) {
                 log.warn("Receive and reject out-of-range ExponentialHistogram data");
                 return new HashMap<>();

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/MetricsEsDAO.java
@@ -127,7 +127,7 @@ public class MetricsEsDAO extends EsDAO implements IMetricsDAO {
             cachedValue.getTimeBucket(), model.getDownsampling());
         // Fast fail check. If the duration is still less than TTL - 1 days(absolute)
         // the cache should not be expired.
-        if (currentTimeMillis - metricTimestamp < TimeUnit.DAYS.toMillis(ttl - 1)) {
+        if (currentTimeMillis - metricTimestamp < TimeUnit.DAYS.toMillis(ttl - 1L)) {
             return false;
         }
         final long deadline = Long.parseLong(new DateTime(currentTimeMillis).plusDays(-ttl).toString("yyyyMMdd"));


### PR DESCRIPTION
Hello,

This PR fixes 8 violations of Sonarqube Rule java:S2184 : ['Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184).
For more details, please see
[MITRE, CWE-190](http://cwe.mitre.org/data/definitions/190) - Integer Overflow or Wraparound
[CERT, NUM50-J.](https://wiki.sei.cmu.edu/confluence/x/AjdGBQ)- Convert integers to floating point for floating-point operations
[CERT, INT18-C.](https://wiki.sei.cmu.edu/confluence/x/I9cxBQ) - Evaluate integer expressions in a larger size before comparing or assigning to that size

The patch was automatically generated using the ViolationFixer tool.