### PR TITLE
Change the string field in Elasticsearch storage from **keyword** type to *text* if they appoint size more than `32766`

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -13,6 +13,8 @@
 * Set up the length of source and dest IDs in relation entities of service, instance, endpoint, and process to 250(was
   200).
 * Support build Service/Instance Hierarchy and query.
+* Change the string field in Elasticsearch storage from **keyword** type to **text** type if it set more than `32766` length.
+* [Break Change] Change the configuration field of `ui_template` and `ui_menu` in Elasticsearch storage from **keyword** type to **text**.
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ColumnTypeEsMapping.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ColumnTypeEsMapping.java
@@ -28,13 +28,15 @@ import org.apache.skywalking.oap.server.core.storage.type.StorageDataComplexObje
 
 public class ColumnTypeEsMapping {
 
-    public String transform(Class<?> type, Type genericType, final ElasticSearchExtension elasticSearchExtension) {
+    public String transform(Class<?> type, Type genericType, int length, final ElasticSearchExtension elasticSearchExtension) {
         if (Integer.class.equals(type) || int.class.equals(type) || Layer.class.equals(type)) {
             return "integer";
         } else if (Long.class.equals(type) || long.class.equals(type)) {
             return "long";
         } else if (Double.class.equals(type) || double.class.equals(type)) {
             return "double";
+        } else if (String.class.equals(type) && length > 32766) {   // 32766 is the max length of a keywords field in ES
+            return "text";
         } else if (String.class.equals(type) || elasticSearchExtension.isKeyword()) {
             return "keyword";
         } else if (StorageDataComplexObject.class.isAssignableFrom(type)) {
@@ -45,7 +47,7 @@ public class ColumnTypeEsMapping {
             return "text";
         } else if (List.class.isAssignableFrom(type)) {
             final Type elementType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
-            return transform((Class<?>) elementType, elementType, elasticSearchExtension);
+            return transform((Class<?>) elementType, elementType, length, elasticSearchExtension);
         } else {
             throw new IllegalArgumentException("Unsupported data type: " + type.getName());
         }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ColumnTypeEsMapping.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ColumnTypeEsMapping.java
@@ -28,14 +28,14 @@ import org.apache.skywalking.oap.server.core.storage.type.StorageDataComplexObje
 
 public class ColumnTypeEsMapping {
 
-    public String transform(Class<?> type, Type genericType, int length, final ElasticSearchExtension elasticSearchExtension) {
+    public String transform(Class<?> type, Type genericType, int length, boolean storageOnly, final ElasticSearchExtension elasticSearchExtension) {
         if (Integer.class.equals(type) || int.class.equals(type) || Layer.class.equals(type)) {
             return "integer";
         } else if (Long.class.equals(type) || long.class.equals(type)) {
             return "long";
         } else if (Double.class.equals(type) || double.class.equals(type)) {
             return "double";
-        } else if (String.class.equals(type) && length > 32766) {   // 32766 is the max length of a keywords field in ES
+        } else if (String.class.equals(type) && storageOnly && length > 32766) {   // 32766 is the max length of a keywords field in ES
             return "text";
         } else if (String.class.equals(type) || elasticSearchExtension.isKeyword()) {
             return "keyword";
@@ -47,7 +47,7 @@ public class ColumnTypeEsMapping {
             return "text";
         } else if (List.class.isAssignableFrom(type)) {
             final Type elementType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
-            return transform((Class<?>) elementType, elementType, length, elasticSearchExtension);
+            return transform((Class<?>) elementType, elementType, length, storageOnly, elasticSearchExtension);
         } else {
             throw new IllegalArgumentException("Unsupported data type: " + type.getName());
         }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
@@ -110,7 +110,7 @@ public class StorageEsInstaller extends ModelInstaller {
 
         if ((templateExists && template.isEmpty()) || (!templateExists && template.isPresent())) {
             throw new Error("[Bug warning] ElasticSearch client query template result is not consistent. " +
-                                "Please file an issue to Apache SkyWalking.(https://github.com/apache/skywalking/issues)");
+                "Please file an issue to Apache SkyWalking.(https://github.com/apache/skywalking/issues)");
         }
 
         boolean exist = templateExists;
@@ -153,15 +153,15 @@ public class StorageEsInstaller extends ModelInstaller {
             }
         } else {
             Mappings historyMapping = esClient.getIndex(tableName)
-                                              .map(Index::getMappings)
-                                              .orElseGet(Mappings::new);
+                .map(Index::getMappings)
+                .orElseGet(Mappings::new);
             structures.putStructure(tableName, mapping, settings);
             Mappings appendMapping = structures.diffMappings(tableName, historyMapping);
             //update mapping
             if (appendMapping.getProperties() != null && !appendMapping.getProperties().isEmpty()) {
                 boolean isAcknowledged = esClient.updateIndexMapping(tableName, appendMapping);
                 log.info("update {} index mapping finished, isAcknowledged: {}, append mapping: {}", tableName,
-                         isAcknowledged, appendMapping
+                    isAcknowledged, appendMapping
                 );
                 if (!isAcknowledged) {
                     throw new StorageException("update " + tableName + " index mapping failure");
@@ -200,14 +200,14 @@ public class StorageEsInstaller extends ModelInstaller {
 
             if (esClient.isExistsIndex(indexName)) {
                 Mappings historyMapping = esClient.getIndex(indexName)
-                                                  .map(Index::getMappings)
-                                                  .orElseGet(Mappings::new);
+                    .map(Index::getMappings)
+                    .orElseGet(Mappings::new);
                 Mappings appendMapping = structures.diffMappings(tableName, historyMapping);
                 //update mapping
                 if (appendMapping.getProperties() != null && !appendMapping.getProperties().isEmpty()) {
                     boolean isAcknowledged = esClient.updateIndexMapping(indexName, appendMapping);
                     log.info("update {} index finished, isAcknowledged: {}, append mappings: {}", indexName,
-                             isAcknowledged, appendMapping
+                        isAcknowledged, appendMapping
                     );
                     if (!isAcknowledged) {
                         throw new StorageException("update " + indexName + " time series index failure");
@@ -255,7 +255,7 @@ public class StorageEsInstaller extends ModelInstaller {
         if (!CollectionUtils.isEmpty(specificSettings)) {
             indexSettings.putAll(specificSettings);
         }
-        
+
         return setting;
     }
 
@@ -286,9 +286,9 @@ public class StorageEsInstaller extends ModelInstaller {
                 continue;
             }
             AnalyzerSetting setting = AnalyzerSetting.Generator.getGenerator(
-                                                         column.getElasticSearchExtension().getAnalyzer())
-                                                               .getGenerateFunc()
-                                                               .generate(config);
+                    column.getElasticSearchExtension().getAnalyzer())
+                .getGenerateFunc()
+                .generate(config);
             analyzerSetting.combine(setting);
         }
         return gson.fromJson(gson.toJson(analyzerSetting), Map.class);
@@ -297,9 +297,9 @@ public class StorageEsInstaller extends ModelInstaller {
     //Indexes `metrics-all and records-all` are required `OAP_ANALYZER`
     private Map getAnalyzerSetting4MergedIndex(Model model) throws StorageException {
         AnalyzerSetting setting = AnalyzerSetting.Generator.getGenerator(
-                                                     ElasticSearch.MatchQuery.AnalyzerType.OAP_ANALYZER)
-                                                           .getGenerateFunc()
-                                                           .generate(config);
+                ElasticSearch.MatchQuery.AnalyzerType.OAP_ANALYZER)
+            .getGenerateFunc()
+            .generate(config);
 
         return gson.fromJson(gson.toJson(setting), Map.class);
     }
@@ -308,7 +308,8 @@ public class StorageEsInstaller extends ModelInstaller {
         Map<String, Object> properties = new HashMap<>();
         Mappings.Source source = new Mappings.Source();
         for (ModelColumn columnDefine : model.getColumns()) {
-            final String type = columnTypeEsMapping.transform(columnDefine.getType(), columnDefine.getGenericType(), columnDefine.getElasticSearchExtension());
+            final String type = columnTypeEsMapping.transform(columnDefine.getType(), columnDefine.getGenericType(), columnDefine.getLength(),
+                columnDefine.getElasticSearchExtension());
             String columnName = columnDefine.getColumnName().getName();
             String legacyName = columnDefine.getElasticSearchExtension().getLegacyColumnName();
             if (config.isLogicSharding() && !Strings.isNullOrEmpty(legacyName)) {
@@ -359,10 +360,10 @@ public class StorageEsInstaller extends ModelInstaller {
             properties.put(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME, column);
         }
         Mappings mappings = Mappings.builder()
-                                    .type("type")
-                                    .properties(properties)
-                                    .source(source)
-                                    .build();
+            .type("type")
+            .properties(properties)
+            .source(source)
+            .build();
         log.debug("elasticsearch index template setting: {}", mappings.toString());
 
         return mappings;

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
@@ -110,7 +110,7 @@ public class StorageEsInstaller extends ModelInstaller {
 
         if ((templateExists && template.isEmpty()) || (!templateExists && template.isPresent())) {
             throw new Error("[Bug warning] ElasticSearch client query template result is not consistent. " +
-                "Please file an issue to Apache SkyWalking.(https://github.com/apache/skywalking/issues)");
+                                "Please file an issue to Apache SkyWalking.(https://github.com/apache/skywalking/issues)");
         }
 
         boolean exist = templateExists;
@@ -153,15 +153,15 @@ public class StorageEsInstaller extends ModelInstaller {
             }
         } else {
             Mappings historyMapping = esClient.getIndex(tableName)
-                .map(Index::getMappings)
-                .orElseGet(Mappings::new);
+                                              .map(Index::getMappings)
+                                              .orElseGet(Mappings::new);
             structures.putStructure(tableName, mapping, settings);
             Mappings appendMapping = structures.diffMappings(tableName, historyMapping);
             //update mapping
             if (appendMapping.getProperties() != null && !appendMapping.getProperties().isEmpty()) {
                 boolean isAcknowledged = esClient.updateIndexMapping(tableName, appendMapping);
                 log.info("update {} index mapping finished, isAcknowledged: {}, append mapping: {}", tableName,
-                    isAcknowledged, appendMapping
+                         isAcknowledged, appendMapping
                 );
                 if (!isAcknowledged) {
                     throw new StorageException("update " + tableName + " index mapping failure");
@@ -200,14 +200,14 @@ public class StorageEsInstaller extends ModelInstaller {
 
             if (esClient.isExistsIndex(indexName)) {
                 Mappings historyMapping = esClient.getIndex(indexName)
-                    .map(Index::getMappings)
-                    .orElseGet(Mappings::new);
+                                                  .map(Index::getMappings)
+                                                  .orElseGet(Mappings::new);
                 Mappings appendMapping = structures.diffMappings(tableName, historyMapping);
                 //update mapping
                 if (appendMapping.getProperties() != null && !appendMapping.getProperties().isEmpty()) {
                     boolean isAcknowledged = esClient.updateIndexMapping(indexName, appendMapping);
                     log.info("update {} index finished, isAcknowledged: {}, append mappings: {}", indexName,
-                        isAcknowledged, appendMapping
+                             isAcknowledged, appendMapping
                     );
                     if (!isAcknowledged) {
                         throw new StorageException("update " + indexName + " time series index failure");
@@ -286,9 +286,9 @@ public class StorageEsInstaller extends ModelInstaller {
                 continue;
             }
             AnalyzerSetting setting = AnalyzerSetting.Generator.getGenerator(
-                    column.getElasticSearchExtension().getAnalyzer())
-                .getGenerateFunc()
-                .generate(config);
+                                                         column.getElasticSearchExtension().getAnalyzer())
+                                                               .getGenerateFunc()
+                                                               .generate(config);
             analyzerSetting.combine(setting);
         }
         return gson.fromJson(gson.toJson(analyzerSetting), Map.class);
@@ -297,9 +297,9 @@ public class StorageEsInstaller extends ModelInstaller {
     //Indexes `metrics-all and records-all` are required `OAP_ANALYZER`
     private Map getAnalyzerSetting4MergedIndex(Model model) throws StorageException {
         AnalyzerSetting setting = AnalyzerSetting.Generator.getGenerator(
-                ElasticSearch.MatchQuery.AnalyzerType.OAP_ANALYZER)
-            .getGenerateFunc()
-            .generate(config);
+                                                     ElasticSearch.MatchQuery.AnalyzerType.OAP_ANALYZER)
+                                                           .getGenerateFunc()
+                                                           .generate(config);
 
         return gson.fromJson(gson.toJson(setting), Map.class);
     }
@@ -361,10 +361,10 @@ public class StorageEsInstaller extends ModelInstaller {
             properties.put(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME, column);
         }
         Mappings mappings = Mappings.builder()
-            .type("type")
-            .properties(properties)
-            .source(source)
-            .build();
+                                    .type("type")
+                                    .properties(properties)
+                                    .source(source)
+                                    .build();
         log.debug("elasticsearch index template setting: {}", mappings.toString());
 
         return mappings;

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/StorageEsInstaller.java
@@ -308,7 +308,8 @@ public class StorageEsInstaller extends ModelInstaller {
         Map<String, Object> properties = new HashMap<>();
         Mappings.Source source = new Mappings.Source();
         for (ModelColumn columnDefine : model.getColumns()) {
-            final String type = columnTypeEsMapping.transform(columnDefine.getType(), columnDefine.getGenericType(), columnDefine.getLength(),
+            final String type = columnTypeEsMapping.transform(columnDefine.getType(), columnDefine.getGenericType(),
+                columnDefine.getLength(), columnDefine.isStorageOnly(),
                 columnDefine.getElasticSearchExtension());
             String columnName = columnDefine.getColumnName().getName();
             String legacyName = columnDefine.getElasticSearchExtension().getLegacyColumnName();

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ElasticSearchColumnTypeMappingTestCase.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ElasticSearchColumnTypeMappingTestCase.java
@@ -33,27 +33,29 @@ public class ElasticSearchColumnTypeMappingTestCase {
     public void test() throws NoSuchFieldException {
         ColumnTypeEsMapping mapping = new ColumnTypeEsMapping();
         int defaultLength = 200;
+        boolean defaultStorageOnly = false;
 
-        Assertions.assertEquals("integer", mapping.transform(int.class, int.class, defaultLength, null));
-        Assertions.assertEquals("integer", mapping.transform(Integer.class, Integer.class, defaultLength, null));
+        Assertions.assertEquals("integer", mapping.transform(int.class, int.class, defaultLength, defaultStorageOnly, null));
+        Assertions.assertEquals("integer", mapping.transform(Integer.class, Integer.class, defaultLength, defaultStorageOnly, null));
 
-        Assertions.assertEquals("long", mapping.transform(long.class, long.class, defaultLength, null));
-        Assertions.assertEquals("long", mapping.transform(Long.class, Long.class, defaultLength, null));
+        Assertions.assertEquals("long", mapping.transform(long.class, long.class, defaultLength, defaultStorageOnly, null));
+        Assertions.assertEquals("long", mapping.transform(Long.class, Long.class, defaultLength, defaultStorageOnly, null));
 
-        Assertions.assertEquals("double", mapping.transform(double.class, double.class, defaultLength, null));
-        Assertions.assertEquals("double", mapping.transform(Double.class, Double.class, defaultLength, null));
+        Assertions.assertEquals("double", mapping.transform(double.class, double.class, defaultLength, defaultStorageOnly, null));
+        Assertions.assertEquals("double", mapping.transform(Double.class, Double.class, defaultLength, defaultStorageOnly, null));
 
-        Assertions.assertEquals("keyword", mapping.transform(String.class, String.class, defaultLength, null));
-        Assertions.assertEquals("text", mapping.transform(String.class, String.class, 100_000, null));
+        Assertions.assertEquals("keyword", mapping.transform(String.class, String.class, defaultLength, defaultStorageOnly, null));
+        Assertions.assertEquals("keyword", mapping.transform(String.class, String.class, 100_000, defaultStorageOnly, null));
+        Assertions.assertEquals("text", mapping.transform(String.class, String.class, 100_000, true, null));
 
         final Type listFieldType = this.getClass().getField("a").getGenericType();
-        Assertions.assertEquals("keyword", mapping.transform(List.class, listFieldType, defaultLength,
+        Assertions.assertEquals("keyword", mapping.transform(List.class, listFieldType, defaultLength, defaultStorageOnly,
             new ElasticSearchExtension(null, null, false, false)
         ));
 
-        Assertions.assertEquals("keyword", mapping.transform(IntList.class, int.class, defaultLength,
+        Assertions.assertEquals("keyword", mapping.transform(IntList.class, int.class, defaultLength, defaultStorageOnly,
             new ElasticSearchExtension(null, null, true, false)));
-        Assertions.assertEquals("text", mapping.transform(IntList.class, int.class, defaultLength,
+        Assertions.assertEquals("text", mapping.transform(IntList.class, int.class, defaultLength, defaultStorageOnly,
             new ElasticSearchExtension(null, null, false, false)));
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ElasticSearchColumnTypeMappingTestCase.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ElasticSearchColumnTypeMappingTestCase.java
@@ -32,26 +32,28 @@ public class ElasticSearchColumnTypeMappingTestCase {
     @Test
     public void test() throws NoSuchFieldException {
         ColumnTypeEsMapping mapping = new ColumnTypeEsMapping();
+        int defaultLength = 200;
 
-        Assertions.assertEquals("integer", mapping.transform(int.class, int.class, null));
-        Assertions.assertEquals("integer", mapping.transform(Integer.class, Integer.class, null));
+        Assertions.assertEquals("integer", mapping.transform(int.class, int.class, defaultLength, null));
+        Assertions.assertEquals("integer", mapping.transform(Integer.class, Integer.class, defaultLength, null));
 
-        Assertions.assertEquals("long", mapping.transform(long.class, long.class, null));
-        Assertions.assertEquals("long", mapping.transform(Long.class, Long.class, null));
+        Assertions.assertEquals("long", mapping.transform(long.class, long.class, defaultLength, null));
+        Assertions.assertEquals("long", mapping.transform(Long.class, Long.class, defaultLength, null));
 
-        Assertions.assertEquals("double", mapping.transform(double.class, double.class, null));
-        Assertions.assertEquals("double", mapping.transform(Double.class, Double.class, null));
+        Assertions.assertEquals("double", mapping.transform(double.class, double.class, defaultLength, null));
+        Assertions.assertEquals("double", mapping.transform(Double.class, Double.class, defaultLength, null));
 
-        Assertions.assertEquals("keyword", mapping.transform(String.class, String.class, null));
+        Assertions.assertEquals("keyword", mapping.transform(String.class, String.class, defaultLength, null));
+        Assertions.assertEquals("text", mapping.transform(String.class, String.class, 100_000, null));
 
         final Type listFieldType = this.getClass().getField("a").getGenericType();
-        Assertions.assertEquals("keyword", mapping.transform(List.class, listFieldType,
-                                                         new ElasticSearchExtension(null, null, false, false)
+        Assertions.assertEquals("keyword", mapping.transform(List.class, listFieldType, defaultLength,
+            new ElasticSearchExtension(null, null, false, false)
         ));
 
-        Assertions.assertEquals("keyword", mapping.transform(IntList.class, int.class,
-                                                         new ElasticSearchExtension(null, null, true, false)));
-        Assertions.assertEquals("text", mapping.transform(IntList.class, int.class,
-                                                         new ElasticSearchExtension(null, null, false, false)));
+        Assertions.assertEquals("keyword", mapping.transform(IntList.class, int.class, defaultLength,
+            new ElasticSearchExtension(null, null, true, false)));
+        Assertions.assertEquals("text", mapping.transform(IntList.class, int.class, defaultLength,
+            new ElasticSearchExtension(null, null, false, false)));
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ElasticSearchColumnTypeMappingTestCase.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/ElasticSearchColumnTypeMappingTestCase.java
@@ -50,12 +50,12 @@ public class ElasticSearchColumnTypeMappingTestCase {
 
         final Type listFieldType = this.getClass().getField("a").getGenericType();
         Assertions.assertEquals("keyword", mapping.transform(List.class, listFieldType, defaultLength, defaultStorageOnly,
-            new ElasticSearchExtension(null, null, false, false)
+                                                         new ElasticSearchExtension(null, null, false, false)
         ));
 
         Assertions.assertEquals("keyword", mapping.transform(IntList.class, int.class, defaultLength, defaultStorageOnly,
-            new ElasticSearchExtension(null, null, true, false)));
+                                                         new ElasticSearchExtension(null, null, true, false)));
         Assertions.assertEquals("text", mapping.transform(IntList.class, int.class, defaultLength, defaultStorageOnly,
-            new ElasticSearchExtension(null, null, false, false)));
+                                                         new ElasticSearchExtension(null, null, false, false)));
     }
 }


### PR DESCRIPTION
While updating UI templates, I noticed that if the UI template configuration in Elasticsearch exceeds `32766` characters, it fails to save. This is because the keyword type in Elasticsearch supports only up to `32766` characters. The configuration field in the UI template was exceeding this limit. I've changed the **keyword** field to **text** type to successfully update the templates.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
