### PR TITLE
Fix log query by traceId in `JDBCLogQueryDAO`.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -18,6 +18,7 @@
 * Support Service Hierarchy auto matching.
 * Add `namespace` suffix for `K8S_SERVICE_NAME_RULE/ISTIO_SERVICE_NAME_RULE` and `metadata-service-mapping.yaml` as default.
 * Allow using a dedicated port for ALS receiver.
+* Fix log query by traceId in `JDBCLogQueryDAO`.
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCLogQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCLogQueryDAO.java
@@ -101,12 +101,17 @@ public class JDBCLogQueryDAO implements ILogQueryDAO {
                 tags.stream().map(Tag::getKey).filter(not(searchableTagKeys::contains)).collect(toSet()));
             return new Logs();
         }
+        List<String> tables;
+        if (nonNull(duration)) {
+            tables = tableHelper.getTablesForRead(
+                LogRecord.INDEX_NAME,
+                duration.getStartTimeBucket(),
+                duration.getEndTimeBucket()
+            );
+        } else {
+            tables = tableHelper.getTablesWithinTTL(LogRecord.INDEX_NAME);
+        }
 
-        final var tables = tableHelper.getTablesForRead(
-            LogRecord.INDEX_NAME,
-            duration.getStartTimeBucket(),
-            duration.getEndTimeBucket()
-        );
         final var logs = new ArrayList<Log>();
 
         for (final var table : tables) {


### PR DESCRIPTION
### Fix #11754
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it. -- get default table list by `tableHelper.getTablesWithinTTL` when duration is null in JDBCLogQueryDAO.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #11754.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
