### PR TITLE
Change topN group key from `StorageId` to `entityId + timeBucket`.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -23,6 +23,7 @@
 * Fix SumPerMinFunctionTest error function.
 * Remove unnecessary annotations and functions from Meter Functions.
 * Add `max` and `min` functions for MAL down sampling.
+* Change topN group key from `StorageId` to `entityId + timeBucket`.
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -23,7 +23,7 @@
 * Fix SumPerMinFunctionTest error function.
 * Remove unnecessary annotations and functions from Meter Functions.
 * Add `max` and `min` functions for MAL down sampling.
-* Change topN group key from `StorageId` to `entityId + timeBucket`.
+* Fix critical bug of uncontrolled memory cost of TopN statistics. Change topN group key from `StorageId` to `entityId + timeBucket`.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedData.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedData.java
@@ -22,16 +22,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.skywalking.oap.server.core.storage.ComparableStorageData;
-import org.apache.skywalking.oap.server.core.storage.StorageData;
-import org.apache.skywalking.oap.server.core.storage.StorageID;
+import org.apache.skywalking.oap.server.core.analysis.topn.TopN;
 
 /**
  * LimitedSizeBufferedData is a thread no safe implementation of {@link BufferedData}. It collects limited records of
- * each {@link StorageData#id()}.
+ * each {@link TopN} which grouped by entityId and timeBucket.
  */
-public class LimitedSizeBufferedData<STORAGE_DATA extends ComparableStorageData & StorageData> implements BufferedData<STORAGE_DATA> {
-    private final HashMap<StorageID, LinkedList<STORAGE_DATA>> data;
+public class LimitedSizeBufferedData<STORAGE_DATA extends TopN> implements BufferedData<STORAGE_DATA> {
+    private final HashMap<String, LinkedList<STORAGE_DATA>> data;
     private final int limitedSize;
 
     public LimitedSizeBufferedData(int limitedSize) {
@@ -41,11 +39,11 @@ public class LimitedSizeBufferedData<STORAGE_DATA extends ComparableStorageData 
 
     @Override
     public void accept(final STORAGE_DATA data) {
-        final StorageID id = data.id();
-        LinkedList<STORAGE_DATA> storageDataList = this.data.get(id);
+        final String topGroupKey = data.getEntityId() + data.getTimeBucket();
+        LinkedList<STORAGE_DATA> storageDataList = this.data.get(topGroupKey);
         if (storageDataList == null) {
             storageDataList = new LinkedList<>();
-            this.data.put(id, storageDataList);
+            this.data.put(topGroupKey, storageDataList);
         }
 
         if (storageDataList.size() < limitedSize) {


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix topN record calculation
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

In `LimitedSizeBufferedData`, it uses `HashMap<StorageId, LinkedList<STORAGE_DATA>>` to stash records. 
With data storage as topN group key, topN records have no chance to compare with each other, so every record will be stashed into the map and finally persistent into db. In addition, continuous record stash in a topN period will bring pressure to oap memory.

So I change topN group key to `entityId + timeBucket`, then stash map can only reserve topN of every entity(db, cache) in the minute level.
