### PR TITLE
Fix wrong timeBucket in topN group key.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -24,6 +24,7 @@
 * Remove unnecessary annotations and functions from Meter Functions.
 * Add `max` and `min` functions for MAL down sampling.
 * Fix critical bug of uncontrolled memory cost of TopN statistics. Change topN group key from `StorageId` to `entityId + timeBucket`.
+* Fix wrong timeBucket in topN group key.
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -24,7 +24,6 @@
 * Remove unnecessary annotations and functions from Meter Functions.
 * Add `max` and `min` functions for MAL down sampling.
 * Fix critical bug of uncontrolled memory cost of TopN statistics. Change topN group key from `StorageId` to `entityId + timeBucket`.
-* Fix wrong timeBucket in topN group key.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedData.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedData.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.analysis.topn.TopN;
 
 /**
@@ -39,7 +40,7 @@ public class LimitedSizeBufferedData<STORAGE_DATA extends TopN> implements Buffe
 
     @Override
     public void accept(final STORAGE_DATA data) {
-        final String topGroupKey = data.getEntityId() + data.getTimeBucket();
+        final String topGroupKey = data.getEntityId() + TimeBucket.getMinuteTimeBucket(data.getTimestamp());
         LinkedList<STORAGE_DATA> storageDataList = this.data.get(topGroupKey);
         if (storageDataList == null) {
             storageDataList = new LinkedList<>();

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedDataTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/data/LimitedSizeBufferedDataTest.java
@@ -27,24 +27,27 @@ public class LimitedSizeBufferedDataTest {
     @Test
     public void testPut() {
         LimitedSizeBufferedData<MockStorageData> collection = new LimitedSizeBufferedData<>(5);
-        collection.accept(new MockStorageData(1, 202401161130L));
-        collection.accept(new MockStorageData(3, 202401161130L));
-        collection.accept(new MockStorageData(5, 202401161130L));
-        collection.accept(new MockStorageData(7, 202401161130L));
-        collection.accept(new MockStorageData(9, 202401161130L));
+        //2024-01-17 17:00:00
+        collection.accept(new MockStorageData(1, 1705482000000L));
+        collection.accept(new MockStorageData(3, 1705482000000L));
+        collection.accept(new MockStorageData(5, 1705482000000L));
+        collection.accept(new MockStorageData(7, 1705482000000L));
+        collection.accept(new MockStorageData(9, 1705482000000L));
 
-        MockStorageData income = new MockStorageData(4, 202401161130L);
-        MockStorageData incomeWithDifferentTimeBucket = new MockStorageData(4, 202401161131L);
+        //2024-01-17 17:00:00
+        MockStorageData income = new MockStorageData(4, 1705482000000L);
+        //2024-01-17 17:01:00
+        MockStorageData incomeWithDifferentTimeBucket = new MockStorageData(4, 1705482060000L);
 
         collection.accept(income);
         collection.accept(incomeWithDifferentTimeBucket);
         int[] expected = new int[] {
-            4,
             3,
             4,
             5,
             7,
-            9
+            9,
+            4
         };
         int i = 0;
         for (MockStorageData data : collection.read()) {
@@ -54,11 +57,11 @@ public class LimitedSizeBufferedDataTest {
 
     private class MockStorageData extends TopN {
         private long latency;
-        private long timeBucket;
+        private long timestamp;
 
-        public MockStorageData(long latency, long timeBucket) {
+        public MockStorageData(long latency, long timestamp) {
             this.latency = latency;
-            this.timeBucket = timeBucket;
+            this.timestamp = timestamp;
         }
 
         @Override
@@ -83,8 +86,8 @@ public class LimitedSizeBufferedDataTest {
         }
 
         @Override
-        public long getTimeBucket() {
-            return this.timeBucket;
+        public long getTimestamp() {
+            return timestamp;
         }
     }
 }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix wrong timeBucket in topN group key
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

TopN record' timeBucket is second level, we need minute level, it should calculate from timestamp.

![截图_选择区域_20240117163151](https://github.com/apache/skywalking/assets/16346644/4d9dab3f-ad27-4831-9d01-d60bfd112297)