### PR TITLE
Add `count` aggregation function for MAL

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -40,6 +40,7 @@
   - VIRTUAL_DATABASE -> POSTGRESQL
 * Add Golang as a supported language for AMQP.
 * Support available layers of service in the topology.
+* Add `count` aggregation function for MAL
 
 #### UI
 

--- a/docs/en/concepts-and-designs/mal.md
+++ b/docs/en/concepts-and-designs/mal.md
@@ -154,7 +154,7 @@ resulting in a new sample family having fewer samples (sometimes having just a s
  - min (select minimum over dimensions)
  - max (select maximum over dimensions)
  - avg (calculate the average over dimensions)
- - count (calculate the count over dimensions)
+ - count (calculate the count over dimensions, the last tag will be counted)
 
 These operations can be used to aggregate overall label dimensions or preserve distinct dimensions by inputting `by` parameter( the keyword `by` could be omitted)
 

--- a/docs/en/concepts-and-designs/mal.md
+++ b/docs/en/concepts-and-designs/mal.md
@@ -154,6 +154,7 @@ resulting in a new sample family having fewer samples (sometimes having just a s
  - min (select minimum over dimensions)
  - max (select maximum over dimensions)
  - avg (calculate the average over dimensions)
+ - count (calculate the count over dimensions)
 
 These operations can be used to aggregate overall label dimensions or preserve distinct dimensions by inputting `by` parameter( the keyword `by` could be omitted)
 

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.DoubleBinaryOperator;
 import java.util.function.Function;
@@ -248,14 +249,36 @@ public class SampleFamily {
             return EMPTY;
         }
         if (by == null) {
-            double result = Arrays.stream(samples).mapToDouble(Sample::getValue).average().orElse(0.0D);
+            long result = Arrays.stream(samples).count();
             return SampleFamily.build(
                     this.context, InternalOps.newSample(samples[0].name, ImmutableMap.of(), samples[0].timestamp, result));
         }
 
-        Stream<Map.Entry<ImmutableMap<String, String>, List<Sample>>> stream = Arrays.stream(samples)
-                .collect(groupingBy(it -> InternalOps.groupByRemainingLabels(by, it), mapping(identity(), toList())))
-                .entrySet().stream();
+        if (by.size() == 1) {
+            Set<String> set = Arrays
+                    .stream(samples)
+                    .map(sample -> sample.labels.get(by.get(0)))
+                    .filter(StringUtils::isNotBlank)
+                    .collect(Collectors.toSet());
+
+            return SampleFamily.build(
+                    this.context, InternalOps.newSample(samples[0].name, ImmutableMap.of(), samples[0].timestamp, set.size()));
+        }
+
+        Stream<Map.Entry<ImmutableMap<String, String>, List<Sample>>> stream = Arrays
+                .stream(samples)
+                .filter(sample -> sample.labels.keySet().containsAll(by))
+                .collect(groupingBy(it -> InternalOps.getLabels(by, it)))
+                .entrySet()
+                .stream()
+                .map(entry -> InternalOps.newSample(
+                        entry.getValue().get(0).getName(),
+                        entry.getKey(),
+                        entry.getValue().get(0).getTimestamp(),
+                        entry.getValue().size()))
+                .collect(groupingBy(it -> InternalOps.groupByExcludedLabel(by.get(by.size() - 1), it), mapping(identity(), toList())))
+                .entrySet()
+                .stream();
 
         Sample[] array = stream
                 .map(entry -> InternalOps.newSample(
@@ -833,13 +856,13 @@ public class SampleFamily {
                             ));
         }
 
-        private static ImmutableMap<String, String> groupByRemainingLabels(final List<String> labels, final Sample sample) {
-            Stream<Map.Entry<String, String>> stream = sample
+        private static ImmutableMap<String, String> groupByExcludedLabel(final String excludedLabelKey, final Sample sample) {
+            return sample
                     .labels
                     .entrySet()
                     .stream()
-                    .filter(v -> !labels.contains(v.getKey()));
-            return stream.collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+                    .filter(v -> !v.getKey().equals(excludedLabelKey))
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
         }
     }
 

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/dsl/SampleFamily.java
@@ -254,7 +254,7 @@ public class SampleFamily {
         }
 
         Stream<Map.Entry<ImmutableMap<String, String>, List<Sample>>> stream = Arrays.stream(samples)
-                .collect(groupingBy(it -> InternalOps.groupByExcludedLabels(by, it), mapping(identity(), toList())))
+                .collect(groupingBy(it -> InternalOps.groupByRemainingLabels(by, it), mapping(identity(), toList())))
                 .entrySet().stream();
 
         Sample[] array = stream
@@ -833,12 +833,12 @@ public class SampleFamily {
                             ));
         }
 
-        private static ImmutableMap<String, String> groupByExcludedLabels(final List<String> excludedLabelKeys, final Sample sample) {
+        private static ImmutableMap<String, String> groupByRemainingLabels(final List<String> labels, final Sample sample) {
             Stream<Map.Entry<String, String>> stream = sample
                     .labels
                     .entrySet()
                     .stream()
-                    .filter(v -> !excludedLabelKeys.contains(v.getKey()));
+                    .filter(v -> !labels.contains(v.getKey()));
             return stream.collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
         }
     }

--- a/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/AggregationTest.java
+++ b/oap-server/analyzer/meter-analyzer/src/test/java/org/apache/skywalking/oap/meter/analyzer/dsl/AggregationTest.java
@@ -147,6 +147,51 @@ public class AggregationTest {
                 ).build()),
                 false,
             },
+
+            {
+                "count",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t3")).value(100).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t2")).value(3).name("http_success_request").build()
+                ).build()),
+                "http_success_request.count()",
+                Result.success(SampleFamilyBuilder.newBuilder(Sample.builder().labels(ImmutableMap.of()).value(3).name("http_success_request").build()).build()),
+                false,
+            },
+            {
+                "count-by-one",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t1", "region", "cn", "instance", "10.0.0.1")).value(50).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t2", "region", "us", "instance", "10.0.0.2")).value(50).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.3")).value(100).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t2", "region", "cn", "instance", "10.0.0.3")).value(3).name("http_success_request").build()
+                ).build()),
+                "http_success_request.count(by = ['instance'])",
+                Result.success(SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(ImmutableMap.of()).value(3).name("http_success_request").build()
+                ).build()),
+                false,
+            },
+            {
+                "count-by-multi",
+                of("http_success_request", SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("idc", "t1")).value(50).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t1", "region", "cn", "instance", "10.0.0.1")).value(50).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t1", "region", "cn", "instance", "10.0.0.1")).value(50).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t2", "region", "us", "instance", "10.0.0.2")).value(50).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.3")).value(100).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t1", "region", "us", "instance", "10.0.0.4")).value(100).name("http_success_request").build(),
+                        Sample.builder().labels(of("idc", "t2", "region", "cn", "instance", "10.0.0.5")).value(3).name("http_success_request").build()
+                ).build()),
+                "http_success_request.count(by = ['region','instance'])",
+                Result.success(SampleFamilyBuilder.newBuilder(
+                        Sample.builder().labels(of("region", "us")).value(3).name("http_success_request").build(),
+                        Sample.builder().labels(of("region", "cn")).value(2).name("http_success_request").build()
+                ).build()),
+                false,
+            },
         });
     }
 


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

This is my scenario
In rocketmq different consumer group has a different consumer offset

```
rocketmq_consumer_offset{cluster="DefaultCluster",broker="broker-a",topic="topic1",group="group3",} 347.0
rocketmq_consumer_offset{cluster="DefaultCluster",broker="broker-a",topic="topic1",group="group2",} 601.0
rocketmq_consumer_offset{cluster="DefaultCluster",broker="broker-a",topic="topic1",group="group1",} 694.0
```

```
  - name: consumer_group_count
    exp: rocketmq_consumer_offset.sum(['cluster','topic','group']).count(['group'])
```

Then I can get the consumer group number to caculate the blacklog messages
