### PR TITLE
Fix Service Layer when building Events in the EventHookCallback.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -55,6 +55,7 @@
 * Fix table exists check in the JDBC Storage Plugin.
 * Fix day-based table rolling time range strategy in JDBC storage.
 * Add `maxInboundMessageSize (SW_DCS_MAX_INBOUND_MESSAGE_SIZE)` configuration to change the max inbound message size of DCS.
+* Fix Service Layer when building Events in the EventHookCallback.
 
 #### UI
 

--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/EventHookCallbackTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/EventHookCallbackTest.java
@@ -67,7 +67,8 @@ public class EventHookCallbackTest {
         when(moduleServiceHolder.getService(EventAnalyzerService.class)).thenReturn(mockEventAnalyzerService);
         when(moduleManager.find(CoreModule.NAME)).thenReturn(moduleProviderHolder);
         when(moduleServiceHolder.getService(MetadataQueryService.class)).thenReturn(metadataQueryService);
-        when(metadataQueryService.getService(any())).thenReturn(mockService());
+        Service service = mockService();
+        when(metadataQueryService.getService(service.getId())).thenReturn(service);
         //make sure current service be called.
         callback.doAlarm(msgs);
         verify(mockEventAnalyzerService).analyze(any(Event.class));
@@ -83,6 +84,7 @@ public class EventHookCallbackTest {
         assertEquals("Alarm", value.getName());
         assertEquals(msg.getAlarmMessage(), value.getMessage());
         assertEquals(msg.getPeriod(), (value.getEndTime() - value.getStartTime()) / 1000 / 60);
+        assertEquals(service.getLayers().iterator().next(), value.getLayer());
 
     }
 
@@ -95,7 +97,8 @@ public class EventHookCallbackTest {
         when(moduleServiceHolder.getService(EventAnalyzerService.class)).thenReturn(eventAnalyzerService);
         when(moduleManager.find(CoreModule.NAME)).thenReturn(moduleProviderHolder);
         when(moduleServiceHolder.getService(MetadataQueryService.class)).thenReturn(metadataQueryService);
-        when(metadataQueryService.getService(any())).thenReturn(mockService());
+        Service service = mockService();
+        when(metadataQueryService.getService(service.getId())).thenReturn(service);
         callback.doAlarm(msgs);
 
         ArgumentCaptor<Event> argument = ArgumentCaptor.forClass(Event.class);
@@ -109,6 +112,8 @@ public class EventHookCallbackTest {
         assertEquals((sourceEvent.getEndTime() - sourceEvent.getStartTime()) / 1000 / 60, msg.getPeriod());
         assertEquals(destEvent.getSource().getService(), IDManager.ServiceID.analysisId(msg.getId1()).getName());
         assertEquals((destEvent.getEndTime() - destEvent.getStartTime()) / 1000 / 60, msg.getPeriod());
+        assertEquals(service.getLayers().iterator().next(), sourceEvent.getLayer());
+        assertEquals(Layer.UNDEFINED.name(), destEvent.getLayer());
     }
 
     private List<AlarmMessage> mockAlarmMessagesHasSingleElement() {
@@ -127,7 +132,7 @@ public class EventHookCallbackTest {
         msg.setScopeId(DefaultScopeDefine.SERVICE_RELATION);
         msg.setScope("");
         msg.setName("test-skywalking");
-        msg.setId0(IDManager.ServiceID.buildId("sourceIdStr", true));
+        msg.setId0(IDManager.ServiceID.buildId("test-skywalking", true));
         msg.setId1(IDManager.ServiceID.buildId("destIdStr", true));
         msg.setAlarmMessage("Alarm caused by Rule service_resp_time_rule");
         msg.setPeriod(5);
@@ -137,6 +142,7 @@ public class EventHookCallbackTest {
     private Service mockService() {
         Service service = new Service();
         service.setName("test-skywalking");
+        service.setId(IDManager.ServiceID.buildId(service.getName(), true));
         service.getLayers().add(Layer.GENERAL.name());
         return service;
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/ServiceTopologyBuilder.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/ServiceTopologyBuilder.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.IDManager;
+import org.apache.skywalking.oap.server.core.analysis.Layer;
 import org.apache.skywalking.oap.server.core.analysis.manual.networkalias.NetworkAddressAlias;
 import org.apache.skywalking.oap.server.core.cache.NetworkAddressAliasCache;
 import org.apache.skywalking.oap.server.core.config.IComponentLibraryCatalogService;
@@ -216,6 +217,8 @@ class ServiceTopologyBuilder {
         Service service = getMetadataQueryService().getService(sourceId);
         if (service != null) {
             serviceNode.getLayers().addAll(service.getLayers());
+        } else {
+            serviceNode.getLayers().add(Layer.UNDEFINED.name());
         }
         return serviceNode;
     }


### PR DESCRIPTION
- When building events from the alarm msg and can't find service set the Layer to `UNDEFINED`.
- Set source and dest events layer separately.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
