### PR TITLE
Adding more access log metrics into k8s dashboards

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -99,6 +99,7 @@
 * Enhance VNode logic and support multiple Trace IDs in span's ref.
 * Add the layers filed and associate layers dashboards for the service topology nodes.
 * Fix `Nginx-Instance` metrics to instance level.
+* Update tabs of the Kubernetes service page. 
 
 #### Documentation
 

--- a/oap-server/server-starter/src/main/resources/oal/ebpf.oal
+++ b/oap-server/server-starter/src/main/resources/oal/ebpf.oal
@@ -115,6 +115,7 @@ kubernetes_service_instance_read_netfilter_duration = from(K8SServiceInstance.re
 
 kubernetes_service_instance_http_call_cpm = from(K8SServiceInstance.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").cpm();
 kubernetes_service_instance_http_call_duration = from(K8SServiceInstance.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_instance_http_call_success_count = from(K8SServiceInstance.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.success == true).cpm();
 kubernetes_service_instance_http_req_header_size = from(K8SServiceInstance.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
 kubernetes_service_instance_http_req_body_size = from(K8SServiceInstance.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
 kubernetes_service_instance_http_resp_header_size = from(K8SServiceInstance.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-root.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-root.json
@@ -49,12 +49,16 @@
                   "typesOfMQE": [
                     "TIME_SERIES_VALUES",
                     "TIME_SERIES_VALUES",
+                    "TIME_SERIES_VALUES",
+                    "TIME_SERIES_VALUES",
                     "TIME_SERIES_VALUES"
                   ],
                   "expressions": [
                     "latest(k8s_service_pod_total)",
                     "latest(k8s_service_cpu_cores_requests)",
-                    "latest(k8s_service_cpu_cores_limits)"
+                    "latest(k8s_service_cpu_cores_limits)",
+                    "latest(kubernetes_service_http_call_cpm)",
+                    "latest(kubernetes_service_http_call_success_count/kubernetes_service_http_call_cpm*100)"
                   ],
                   "graph": {
                     "type": "ServiceList",
@@ -75,6 +79,14 @@
                     {
                       "label": "CPU Limits",
                       "unit": "m"
+                    },
+                    {
+                      "label": "HTTP Load",
+                      "unit": "calls / min"
+                    },
+                    {
+                      "label": "HTTP Success Rate",
+                      "unit": "%"
                     }
                   ]
                 }

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
@@ -236,51 +236,106 @@
               ]
             },
             {
-              "name": "eBPF Profiling",
+              "name": "Topology",
               "children": [
                 {
                   "x": 0,
-                  "y": 2,
+                  "y": 0,
                   "w": 24,
-                  "h": 47,
+                  "h": 41,
                   "i": "0",
-                  "type": "Ebpf"
-                },
-                {
-                  "x": 0,
-                  "y": 0,
-                  "w": 24,
-                  "h": 2,
-                  "i": "2",
-                  "type": "Text",
+                  "type": "Topology",
                   "graph": {
-                    "fontColor": "theme",
-                    "backgroundColor": "theme",
-                    "content": "eBPF Profiling support services written in C, C++, Golang, and Rust. SkyWalking Rover provides this profiling capability. ",
-                    "fontSize": 14,
-                    "textAlign": "left",
-                    "url": "https://skywalking.apache.org/docs/skywalking-rover/next/readme/"
-                  }
-                }
-              ]
-            },
-            {
-              "name": "Pods",
-              "children": [
-                {
-                  "x": 0,
-                  "y": 0,
-                  "w": 24,
-                  "h": 31,
-                  "i": "1",
-                  "type": "Widget",
-                  "graph": {
-                    "type": "InstanceList",
-                    "dashboardName": "K8S-Service-Pods",
-                    "fontSize": 12
+                    "showDepth": true
                   },
                   "metricMode": "Expression",
-                  "metricConfig": [
+                  "linkDashboard": "K8S-Service-Relation",
+                  "nodeDashboard": [
+
+                  ],
+                  "linkServerMetrics": [
+
+                  ],
+                  "linkClientMetrics": [
+
+                  ],
+                  "nodeMetrics": [
+
+                  ],
+                  "linkServerExpressions": [
+                    "avg(kubernetes_service_relation_server_write_package_size)/60",
+                    "avg(kubernetes_service_relation_server_read_package_size)/60",
+                    "avg(kubernetes_service_relation_server_http_call_cpm)/60",
+                    "avg(kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_client_http_call_cpm)/1000000"
+                  ],
+                  "linkClientExpressions": [
+                    "avg(kubernetes_service_relation_client_write_package_size)/60",
+                    "avg(kubernetes_service_relation_client_read_package_size)/60",
+                    "avg(kubernetes_service_relation_client_http_call_cpm)/60",
+                    "avg(kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_server_http_call_cpm)/1000000"
+                  ],
+                  "nodeExpressions": [
+                    "avg(kubernetes_service_write_package_size)/60",
+                    "avg(kubernetes_service_read_package_size)/60",
+                    "avg(kubernetes_service_http_call_cpm)",
+                    "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)/1000000",
+                    "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
+                  ],
+                  "legend": [
+
+                  ],
+                  "legendMQE": {
+                    "expression": "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100) < 95 and avg(kubernetes_service_http_call_cpm) > 1"
+                  },
+                  "description": {
+                    "healthy": "Healthy",
+                    "unhealthy": "HTTP Success Rate < 95% and HTTP Traffic > 1 calls / min"
+                  },
+                  "linkServerMetricConfig": [
+                    {
+                      "label": "Server Write",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Server Read",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Server HTTP Load",
+                      "unit": "calls / min"
+                    },
+                    {
+                      "label": "Server HTTP Latency",
+                      "unit": "ms"
+                    }
+                  ],
+                  "linkClientMetricConfig": [
+                    {
+                      "label": "Client Write",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Client Read",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Client HTTP Load",
+                      "unit": "calls / min"
+                    },
+                    {
+                      "label": "Client HTTP Latency",
+                      "unit": "ms"
+                    }
+                  ],
+                  "nodeMetricConfig": [
+                    {
+                      "label": "Write",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Read",
+                      "unit": "bytes / s"
+                    },
                     {
                       "label": "HTTP Load",
                       "unit": "calls / min"
@@ -293,69 +348,6 @@
                       "label": "HTTP Success Rate",
                       "unit": "%"
                     }
-                  ],
-                  "expressions": [
-                    "latest(kubernetes_service_instance_http_call_cpm)",
-                    "latest(kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm)/1000000",
-                    "latest(kubernetes_service_instance_http_call_success_count/kubernetes_service_instance_http_call_cpm*100)"
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "Endpoint",
-              "children": [
-                {
-                  "x": 0,
-                  "y": 0,
-                  "w": 24,
-                  "h": 49,
-                  "i": "0",
-                  "type": "Widget",
-                  "graph": {
-                    "type": "EndpointList",
-                    "dashboardName": "K8S-Endpoint",
-                    "fontSize": 12,
-                    "showXAxis": false,
-                    "showYAxis": false
-                  },
-                  "metricConfig": [
-                    {
-                      "label": "Load",
-                      "detailLabel": "load",
-                      "unit": "calls / min"
-                    },
-                    {
-                      "label": "Success Rate",
-                      "detailLabel": "success_rate",
-                      "unit": "%"
-                    },
-                    {
-                      "label": "Latency",
-                      "detailLabel": "latency",
-                      "unit": "ms"
-                    }
-                  ],
-                  "metricMode": "Expression",
-                  "expressions": [
-                    "avg(kubernetes_service_endpoint_call_cpm)",
-                    "avg(kubernetes_service_endpoint_call_success_cpm/kubernetes_service_endpoint_call_cpm*100)",
-                    "avg(kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm/1000000)"
-                  ],
-                  "subExpressions": [
-                    "kubernetes_service_endpoint_call_cpm",
-                    "kubernetes_service_endpoint_call_success_cpm/kubernetes_service_endpoint_call_cpm*100",
-                    "kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm/1000000"
-                  ],
-                  "subTypesOfMQE": [
-                    "",
-                    "",
-                    ""
-                  ],
-                  "typesOfMQE": [
-                    "",
-                    "",
-                    ""
                   ]
                 }
               ]
@@ -1952,106 +1944,22 @@
               ]
             },
             {
-              "name": "Topology",
+              "name": "Pods",
               "children": [
                 {
                   "x": 0,
                   "y": 0,
                   "w": 24,
-                  "h": 41,
-                  "i": "0",
-                  "type": "Topology",
+                  "h": 31,
+                  "i": "1",
+                  "type": "Widget",
                   "graph": {
-                    "showDepth": true
+                    "type": "InstanceList",
+                    "dashboardName": "K8S-Service-Pods",
+                    "fontSize": 12
                   },
                   "metricMode": "Expression",
-                  "linkDashboard": "K8S-Service-Relation",
-                  "nodeDashboard": [
-
-                  ],
-                  "linkServerMetrics": [
-
-                  ],
-                  "linkClientMetrics": [
-
-                  ],
-                  "nodeMetrics": [
-
-                  ],
-                  "linkServerExpressions": [
-                    "avg(kubernetes_service_relation_server_write_package_size)/60",
-                    "avg(kubernetes_service_relation_server_read_package_size)/60",
-                    "avg(kubernetes_service_relation_server_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_client_http_call_cpm)/1000000"
-                  ],
-                  "linkClientExpressions": [
-                    "avg(kubernetes_service_relation_client_write_package_size)/60",
-                    "avg(kubernetes_service_relation_client_read_package_size)/60",
-                    "avg(kubernetes_service_relation_client_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_server_http_call_cpm)/1000000"
-                  ],
-                  "nodeExpressions": [
-                    "avg(kubernetes_service_write_package_size)/60",
-                    "avg(kubernetes_service_read_package_size)/60",
-                    "avg(kubernetes_service_http_call_cpm)",
-                    "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)/1000000",
-                    "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
-                  ],
-                  "legend": [
-
-                  ],
-                  "legendMQE": {
-                    "expression": "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100) < 95 and avg(kubernetes_service_http_call_cpm) > 1"
-                  },
-                  "description": {
-                    "healthy": "Healthy",
-                    "unhealthy": "HTTP Success Rate < 95% and HTTP Traffic > 1 calls / min"
-                  },
-                  "linkServerMetricConfig": [
-                    {
-                      "label": "Server Write",
-                      "unit": "bytes / s"
-                    },
-                    {
-                      "label": "Server Read",
-                      "unit": "bytes / s"
-                    },
-                    {
-                      "label": "Server HTTP Load",
-                      "unit": "calls / min"
-                    },
-                    {
-                      "label": "Server HTTP Latency",
-                      "unit": "ms"
-                    }
-                  ],
-                  "linkClientMetricConfig": [
-                    {
-                      "label": "Client Write",
-                      "unit": "bytes / s"
-                    },
-                    {
-                      "label": "Client Read",
-                      "unit": "bytes / s"
-                    },
-                    {
-                      "label": "Client HTTP Load",
-                      "unit": "calls / min"
-                    },
-                    {
-                      "label": "Client HTTP Latency",
-                      "unit": "ms"
-                    }
-                  ],
-                  "nodeMetricConfig": [
-                    {
-                      "label": "Write",
-                      "unit": "bytes / s"
-                    },
-                    {
-                      "label": "Read",
-                      "unit": "bytes / s"
-                    },
+                  "metricConfig": [
                     {
                       "label": "HTTP Load",
                       "unit": "calls / min"
@@ -2064,7 +1972,99 @@
                       "label": "HTTP Success Rate",
                       "unit": "%"
                     }
+                  ],
+                  "expressions": [
+                    "latest(kubernetes_service_instance_http_call_cpm)",
+                    "latest(kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm)/1000000",
+                    "latest(kubernetes_service_instance_http_call_success_count/kubernetes_service_instance_http_call_cpm*100)"
                   ]
+                }
+              ]
+            },
+            {
+              "name": "Endpoint",
+              "children": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "w": 24,
+                  "h": 49,
+                  "i": "0",
+                  "type": "Widget",
+                  "graph": {
+                    "type": "EndpointList",
+                    "dashboardName": "K8S-Endpoint",
+                    "fontSize": 12,
+                    "showXAxis": false,
+                    "showYAxis": false
+                  },
+                  "metricConfig": [
+                    {
+                      "label": "Load",
+                      "detailLabel": "load",
+                      "unit": "calls / min"
+                    },
+                    {
+                      "label": "Success Rate",
+                      "detailLabel": "success_rate",
+                      "unit": "%"
+                    },
+                    {
+                      "label": "Latency",
+                      "detailLabel": "latency",
+                      "unit": "ms"
+                    }
+                  ],
+                  "metricMode": "Expression",
+                  "expressions": [
+                    "avg(kubernetes_service_endpoint_call_cpm)",
+                    "avg(kubernetes_service_endpoint_call_success_cpm/kubernetes_service_endpoint_call_cpm*100)",
+                    "avg(kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm/1000000)"
+                  ],
+                  "subExpressions": [
+                    "kubernetes_service_endpoint_call_cpm",
+                    "kubernetes_service_endpoint_call_success_cpm/kubernetes_service_endpoint_call_cpm*100",
+                    "kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm/1000000"
+                  ],
+                  "subTypesOfMQE": [
+                    "",
+                    "",
+                    ""
+                  ],
+                  "typesOfMQE": [
+                    "",
+                    "",
+                    ""
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "eBPF Profiling",
+              "children": [
+                {
+                  "x": 0,
+                  "y": 2,
+                  "w": 24,
+                  "h": 47,
+                  "i": "0",
+                  "type": "Ebpf"
+                },
+                {
+                  "x": 0,
+                  "y": 0,
+                  "w": 24,
+                  "h": 2,
+                  "i": "2",
+                  "type": "Text",
+                  "graph": {
+                    "fontColor": "theme",
+                    "backgroundColor": "theme",
+                    "content": "eBPF Profiling support services written in C, C++, Golang, and Rust. SkyWalking Rover provides this profiling capability. ",
+                    "fontSize": 14,
+                    "textAlign": "left",
+                    "url": "https://skywalking.apache.org/docs/skywalking-rover/next/readme/"
+                  }
                 }
               ]
             }

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
@@ -278,7 +278,27 @@
                     "type": "InstanceList",
                     "dashboardName": "K8S-Service-Pods",
                     "fontSize": 12
-                  }
+                  },
+                  "metricMode": "Expression",
+                  "metricConfig": [
+                    {
+                      "label": "HTTP Load",
+                      "unit": "calls / min"
+                    },
+                    {
+                      "label": "HTTP Latency",
+                      "unit": "ms"
+                    },
+                    {
+                      "label": "HTTP Success Rate",
+                      "unit": "%"
+                    }
+                  ],
+                  "expressions": [
+                    "latest(kubernetes_service_instance_http_call_cpm)",
+                    "latest(kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm)/1000000",
+                    "latest(kubernetes_service_instance_http_call_success_count/kubernetes_service_instance_http_call_cpm*100)"
+                  ]
                 }
               ]
             },
@@ -1930,6 +1950,123 @@
                   ]
                 }
               ]
+            },
+            {
+              "name": "Topology",
+              "children": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "w": 24,
+                  "h": 41,
+                  "i": "0",
+                  "type": "Topology",
+                  "graph": {
+                    "showDepth": true
+                  },
+                  "metricMode": "Expression",
+                  "linkDashboard": "K8S-Service-Relation",
+                  "nodeDashboard": [
+
+                  ],
+                  "linkServerMetrics": [
+
+                  ],
+                  "linkClientMetrics": [
+
+                  ],
+                  "nodeMetrics": [
+
+                  ],
+                  "linkServerExpressions": [
+                    "avg(kubernetes_service_relation_server_write_package_size)/60",
+                    "avg(kubernetes_service_relation_server_read_package_size)/60",
+                    "avg(kubernetes_service_relation_server_http_call_cpm)/60",
+                    "avg(kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_client_http_call_cpm)/1000000"
+                  ],
+                  "linkClientExpressions": [
+                    "avg(kubernetes_service_relation_client_write_package_size)/60",
+                    "avg(kubernetes_service_relation_client_read_package_size)/60",
+                    "avg(kubernetes_service_relation_client_http_call_cpm)/60",
+                    "avg(kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_server_http_call_cpm)/1000000"
+                  ],
+                  "nodeExpressions": [
+                    "avg(kubernetes_service_write_package_size)/60",
+                    "avg(kubernetes_service_read_package_size)/60",
+                    "avg(kubernetes_service_http_call_cpm)",
+                    "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)/1000000",
+                    "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
+                  ],
+                  "legend": [
+
+                  ],
+                  "legendMQE": {
+                    "expression": "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100) < 95 and avg(kubernetes_service_http_call_cpm) > 1"
+                  },
+                  "description": {
+                    "healthy": "Healthy",
+                    "unhealthy": "HTTP Success Rate < 95% and HTTP Traffic > 1 calls / min"
+                  },
+                  "linkServerMetricConfig": [
+                    {
+                      "label": "Server Write",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Server Read",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Server HTTP Load",
+                      "unit": "calls / min"
+                    },
+                    {
+                      "label": "Server HTTP Latency",
+                      "unit": "ms"
+                    }
+                  ],
+                  "linkClientMetricConfig": [
+                    {
+                      "label": "Client Write",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Client Read",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Client HTTP Load",
+                      "unit": "calls / min"
+                    },
+                    {
+                      "label": "Client HTTP Latency",
+                      "unit": "ms"
+                    }
+                  ],
+                  "nodeMetricConfig": [
+                    {
+                      "label": "Write",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "Read",
+                      "unit": "bytes / s"
+                    },
+                    {
+                      "label": "HTTP Load",
+                      "unit": "calls / min"
+                    },
+                    {
+                      "label": "HTTP Latency",
+                      "unit": "ms"
+                    },
+                    {
+                      "label": "HTTP Success Rate",
+                      "unit": "%"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
@@ -1937,50 +2074,7 @@
       "layer": "K8S_SERVICE",
       "entity": "Service",
       "name": "K8S-Service-Service",
-      "isDefault": true,
-      "expressions": [
-        "latest(k8s_service_pod_total)",
-        "latest(k8s_service_cpu_cores_requests)",
-        "latest(k8s_service_cpu_cores_limits)",
-        "avg(kubernetes_service_write_package_size)/60",
-        "avg(kubernetes_service_read_package_size)/60",
-        "avg(kubernetes_service_http_call_cpm)",
-        "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm/1000000)",
-        "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
-      ],
-      "expressionsConfig": [
-        {
-          "label": "Pod Total"
-        },
-        {
-          "unit": "m",
-          "label": "CPU Requests"
-        },
-        {
-          "unit": "m",
-          "label": "CPU Limits"
-        },
-        {
-          "unit": "bytes / s",
-          "label": "Write"
-        },
-        {
-          "unit": "bytes / s",
-          "label": "Read"
-        },
-        {
-          "label": "HTTP Load",
-          "unit": "calls / min"
-        },
-        {
-          "label": "HTTP Latency",
-          "unit": "ms"
-        },
-        {
-          "label": "HTTP Success Rate",
-          "unit": "%"
-        }
-      ]
+      "id": "K8S-Service-Service"
     }
   }
 ]


### PR DESCRIPTION
1. Adding HTTP metrics into the Kubernetes services table
![image](https://github.com/apache/skywalking/assets/3417650/96c85781-2ede-49ea-bcca-3e7622f18746)

2. Adding HTTP metrics into the Kubernetes pods table
![image](https://github.com/apache/skywalking/assets/3417650/892f0125-ff5b-4213-899a-c44ad7c230d5)

3. Adding service topology into the Kubernetes service tab
![image](https://github.com/apache/skywalking/assets/3417650/da8b5c2f-d13f-49bb-a35a-d81bb0114ab6)

Because the UI templates changes already existing in the CHANGES.md, so no needs to be update. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
