### PR TITLE
Fix `AvgHistogramPercentileFunction` legacy name.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -79,6 +79,7 @@
 * Add Golang as a supported language for Kafka.
 * Support displaying the port services listen to from OAP and UI during server start.
 * Refactor data-generator to support generating metrics.
+* Fix `AvgHistogramPercentileFunction` legacy name.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgHistogramPercentileFunction.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/meter/function/avg/AvgHistogramPercentileFunction.java
@@ -81,7 +81,7 @@ public abstract class AvgHistogramPercentileFunction extends Meter implements Ac
     @Getter
     @Setter
     @Column(name = VALUE, dataType = Column.ValueDataType.LABELED_VALUE, storageOnly = true)
-    @ElasticSearch.Column(legacyName = "name")
+    @ElasticSearch.Column(legacyName = "value")
     @BanyanDB.MeasureField
     private DataTable percentileValues = new DataTable(10);
     @Getter


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

I think the legacy name was and should be `value`.