### PR TITLE
Adding go agent into bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -61,6 +61,7 @@ body:
         - "NodeJS Client Side Agent (apache/skywalking-client-js)"
         - "Nginx Lua Agent (apache/skywalking-nginx-lua)"
         - "Kong Agent (apache/skywalking-kong)"
+        - "Go Agent (apache/skywalking-go)"
         - "PHP (apache/skywalking-php)"
         - "Rust (apache/skywalking-rust)"
         - "Satellite (apache/skywalking-satellite)"


### PR DESCRIPTION
Currently, when reporting an issue, it is cannot to select the Go agent component for issue reporting.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
