### PR TITLE
Fix missing dashboard settings in Kubernetes Service

### DIFF
--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
@@ -2074,7 +2074,52 @@
       "layer": "K8S_SERVICE",
       "entity": "Service",
       "name": "K8S-Service-Service",
-      "id": "K8S-Service-Service"
+      "id": "K8S-Service-Service",
+      "isDefault": true,
+      "expressions": [
+        "latest(k8s_service_pod_total)",
+        "latest(k8s_service_cpu_cores_requests)",
+        "latest(k8s_service_cpu_cores_limits)",
+        "avg(kubernetes_service_write_package_size)/60",
+
+        "avg(kubernetes_service_read_package_size)/60",
+        "avg(kubernetes_service_http_call_cpm)",
+        "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm/1000000)",
+        "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
+      ],
+      "expressionsConfig": [
+        {
+          "label": "Pod Total"
+        },
+        {
+          "unit": "m",
+          "label": "CPU Requests"
+        },
+        {
+          "unit": "m",
+          "label": "CPU Limits"
+        },
+        {
+          "unit": "bytes / s",
+          "label": "Write"
+        },
+        {
+          "unit": "bytes / s",
+          "label": "Read"
+        },
+        {
+          "label": "HTTP Load",
+          "unit": "calls / min"
+        },
+        {
+          "label": "HTTP Latency",
+          "unit": "ms"
+        },
+        {
+          "label": "HTTP Success Rate",
+          "unit": "%"
+        }
+      ]
     }
   }
 ]


### PR DESCRIPTION
In https://github.com/apache/skywalking/pull/12018, I lost [some template configurations](https://github.com/apache/skywalking/pull/12018/files#diff-e0274854744e889f9733a23051ea6e16f1412f798d98ae0ee81e6fcd8f474768L1940-L1983) and fixed them in this PR.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
