### PR TITLE
MQE query: make metadata not return `null`, and labeled metrics Binary Operation return empty value if the labels not match, rather than report error.

### DIFF
--- a/docs/en/api/metrics-query-expression.md
+++ b/docs/en/api/metrics-query-expression.md
@@ -82,7 +82,8 @@ For the result type of the expression, please refer to the following table.
 ### Binary Operation Rules
 The following table lists if the different result types of the input expressions could do this operation and the result type after the operation.
 The expression could be on the left or right side of the operator. 
-**Note**: If the expressions on both sides of the operator are the `TIME_SERIES_VALUES with labels`, they should have the same labels for calculation.
+**Note**: If the expressions result on both sides of the operator are `with labels`, they should have the same labels for calculation.
+If the labels match, will reserve left expression result labels and the calculated value. Otherwise, will return empty value.
 
 | Expression              | Expression                | Yes/No | ExpressionResultType     |
 |-------------------------|---------------------------|--------|--------------------------|

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -111,6 +111,8 @@
 * Add Service Hierarchy auto matching layer relationships (upper -> lower) as following:
   - ACTIVEMQ -> K8S_SERVICE
 * Calculate Nginx service HTTP Latency by MQE.
+* MQE query: make metadata not return `null`.
+* MQE labeled metrics Binary Operation: return empty value if the labels not match rather than report error.
 
 #### UI
 

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/MQEVisitorBase.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/MQEVisitorBase.java
@@ -149,6 +149,7 @@ public abstract class MQEVisitorBase extends MQEParserBaseVisitor<ExpressionResu
             MQEParser.LabelNameListContext labelNameListContext = ctx.aggregateLabelsFunc().labelNameList();
             if (null != labelNameListContext) {
                 for (MQEParser.LabelNameContext labelNameContext : labelNameListContext.labelName()) {
+                    // ignore the label name that does not exist in the result
                     if (expResult.getResults()
                                  .get(0)
                                  .getMetric()
@@ -156,10 +157,6 @@ public abstract class MQEVisitorBase extends MQEParserBaseVisitor<ExpressionResu
                                  .stream()
                                  .anyMatch(label -> label.getKey().equals(labelNameContext.getText()))) {
                         labelNames.add(labelNameContext.getText());
-                    } else {
-                        expResult.setError(
-                            "The label [" + labelNameContext.getText() + "] does not exist in the result.");
-                        return expResult;
                     }
                 }
             }
@@ -221,11 +218,6 @@ public abstract class MQEVisitorBase extends MQEParserBaseVisitor<ExpressionResu
         }
         KeyValue targetLabel = buildLabel(ctx.label());
         KeyValue replaceLabel = buildLabel(ctx.replaceLabel().label());
-
-//        if (!targetLabel.getKey().equals(replaceLabel.getKey())) {
-//            result.setError("The target label name and replace label name must be the same.");
-//            return result;
-//        }
         List<KeyValue> targetLabels = parseLabelValue(targetLabel, Const.COMMA);
         List<KeyValue> replaceLabels = parseLabelValue(replaceLabel, Const.COMMA);
 

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/AggregateLabelsOp.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/AggregateLabelsOp.java
@@ -31,7 +31,6 @@ import org.apache.skywalking.mqe.rt.operation.aggregatelabels.AvgAggregateLabels
 import org.apache.skywalking.mqe.rt.operation.aggregatelabels.MaxAggregateLabelsFunc;
 import org.apache.skywalking.mqe.rt.operation.aggregatelabels.MinAggregateLabelsFunc;
 import org.apache.skywalking.mqe.rt.operation.aggregatelabels.SumAggregateLabelsFunc;
-import org.apache.skywalking.mqe.rt.type.Metadata;
 import org.apache.skywalking.oap.server.core.query.type.KeyValue;
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
 
@@ -98,9 +97,7 @@ public class AggregateLabelsOp {
                 }
             }
             MQEValues mqeValues = new MQEValues();
-            Metadata metadata = new Metadata();
-            metadata.setLabels(labels);
-            mqeValues.setMetric(metadata);
+            mqeValues.getMetric().setLabels(labels);
             mqeValues.setValues(combineTo);
             expResult.getResults().add(mqeValues);
         });
@@ -108,10 +105,8 @@ public class AggregateLabelsOp {
     }
 
     private static List<KeyValue> getLabels(final List<String> labelNames, final MQEValues mqeValues) {
-        List<KeyValue> a =
-         labelNames.stream().map(labelName -> mqeValues.getMetric().getLabels().stream().filter(label -> labelName.equals(label.getKey()))
+         return labelNames.stream().map(labelName -> mqeValues.getMetric().getLabels().stream().filter(label -> labelName.equals(label.getKey()))
                                                            .findAny().orElseGet(() -> new KeyValue(labelName, ""))).collect(toList());
-        return a;
     }
 
 }

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/LogicalFunctionOp.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/LogicalFunctionOp.java
@@ -25,7 +25,6 @@ import org.apache.skywalking.mqe.rt.type.ExpressionResult;
 import org.apache.skywalking.mqe.rt.type.ExpressionResultType;
 import org.apache.skywalking.mqe.rt.type.MQEValue;
 import org.apache.skywalking.mqe.rt.type.MQEValues;
-import org.apache.skywalking.mqe.rt.type.Metadata;
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
 
 import java.util.Objects;
@@ -85,7 +84,6 @@ public class LogicalFunctionOp {
 
         MQEValue mqeValue = new MQEValue();
         MQEValues mqeValues = new MQEValues();
-        mqeValues.setMetric(new Metadata());
         mqeValues.getValues().add(mqeValue);
         result.getResults().add(mqeValues);
         mqeValue.setDoubleValue(present ? 1 : 0);

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/type/MQEValues.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/type/MQEValues.java
@@ -25,7 +25,7 @@ import lombok.Data;
 
 @Data
 public class MQEValues {
-    private Metadata metric;
+    private Metadata metric = new Metadata();
 
     private List<MQEValue> values = new ArrayList<>();
 }

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/type/Metadata.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/type/Metadata.java
@@ -20,6 +20,7 @@
 package org.apache.skywalking.mqe.rt.type;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import lombok.Data;
 import org.apache.skywalking.oap.server.core.query.type.KeyValue;
@@ -27,4 +28,8 @@ import org.apache.skywalking.oap.server.core.query.type.KeyValue;
 @Data
 public class Metadata {
     private List<KeyValue> labels  = new ArrayList<>();
+
+    public void sortLabelsByKey(Comparator<String> comparator) {
+        labels.sort(Comparator.comparing(KeyValue::getKey, comparator));
+    }
 }

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/expr/rt/AlarmMQEVerifyVisitor.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/expr/rt/AlarmMQEVerifyVisitor.java
@@ -18,9 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.alarm.provider.expr.rt;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import lombok.Getter;
@@ -31,14 +29,9 @@ import org.apache.skywalking.mqe.rt.type.ExpressionResult;
 import org.apache.skywalking.mqe.rt.type.ExpressionResultType;
 import org.apache.skywalking.mqe.rt.type.MQEValue;
 import org.apache.skywalking.mqe.rt.type.MQEValues;
-import org.apache.skywalking.mqe.rt.type.Metadata;
 import org.apache.skywalking.oap.server.core.query.enumeration.Step;
-import org.apache.skywalking.oap.server.core.query.type.KeyValue;
 import org.apache.skywalking.oap.server.core.storage.annotation.Column;
 import org.apache.skywalking.oap.server.core.storage.annotation.ValueColumnMetadata;
-import org.apache.skywalking.oap.server.library.util.CollectionUtils;
-
-import static org.apache.skywalking.oap.server.core.analysis.metrics.DataLabel.GENERAL_LABEL_NAME;
 
 /**
  * Used for verify the alarm expression and get the metrics name when read the alarm rules.
@@ -78,29 +71,11 @@ public class AlarmMQEVerifyVisitor extends MQEVisitorBase {
         MQEValue mqeValue = new MQEValue();
         mqeValue.setEmptyValue(true);
         mockMqeValues.getValues().add(mqeValue);
+        result.getResults().add(mockMqeValues);
+        result.setType(ExpressionResultType.TIME_SERIES_VALUES);
         if (dataType == Column.ValueDataType.COMMON_VALUE) {
-            result.getResults().add(mockMqeValues);
-            result.setType(ExpressionResultType.TIME_SERIES_VALUES);
             return result;
         } else if (dataType == Column.ValueDataType.LABELED_VALUE) {
-            List<KeyValue> queryLabels = buildLabels(ctx.labelList());
-            ArrayList<MQEValues> mqeValuesList = new ArrayList<>();
-            if (CollectionUtils.isEmpty(queryLabels)) {
-                KeyValue label = new KeyValue(GENERAL_LABEL_NAME, GENERAL_LABEL_NAME);
-                Metadata metadata = new Metadata();
-                metadata.getLabels().add(label);
-                mockMqeValues.setMetric(metadata);
-                mqeValuesList.add(mockMqeValues);
-            } else {
-                for (KeyValue queryLabel : queryLabels) {
-                    Metadata metadata = new Metadata();
-                    metadata.getLabels().add(queryLabel);
-                    mockMqeValues.setMetric(metadata);
-                    mqeValuesList.add(mockMqeValues);
-                }
-            }
-            result.setType(ExpressionResultType.TIME_SERIES_VALUES);
-            result.setResults(mqeValuesList);
             result.setLabeledResult(true);
             return result;
         } else {

--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/mqe/rt/MQEVisitor.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/mqe/rt/MQEVisitor.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.oap.query.graphql.mqe.rt;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,7 +29,6 @@ import org.apache.skywalking.mqe.rt.exception.IllegalExpressionException;
 import org.apache.skywalking.mqe.rt.grammar.MQEParser;
 import org.apache.skywalking.mqe.rt.type.MQEValue;
 import org.apache.skywalking.mqe.rt.type.MQEValues;
-import org.apache.skywalking.mqe.rt.type.Metadata;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.analysis.metrics.DataLabel;
 import org.apache.skywalking.oap.server.core.query.AggregationQueryService;
@@ -195,10 +195,8 @@ public class MQEVisitor extends MQEVisitorBase {
             mqeValue.setDoubleValue(Double.parseDouble(selectedRecord.getValue()));
             mqeValueList.add(mqeValue);
         });
-        Metadata metadata = new Metadata();
         MQEValues mqeValues = new MQEValues();
         mqeValues.setValues(mqeValueList);
-        mqeValues.setMetric(metadata);
         result.getResults().add(mqeValues);
         result.setType(ExpressionResultType.SORTED_LIST);
     }
@@ -220,10 +218,8 @@ public class MQEVisitor extends MQEVisitorBase {
             mqeValue.setTraceID(record.getRefId());
             mqeValueList.add(mqeValue);
         });
-        Metadata metadata = new Metadata();
         MQEValues mqeValues = new MQEValues();
         mqeValues.setValues(mqeValueList);
-        mqeValues.setMetric(metadata);
         result.getResults().add(mqeValues);
         result.setType(ExpressionResultType.RECORD_LIST);
     }
@@ -250,10 +246,8 @@ public class MQEVisitor extends MQEVisitorBase {
             mqeValue.setDoubleValue(kvInt.getValue());
             mqeValueList.add(mqeValue);
         }
-        Metadata metadata = new Metadata();
         MQEValues mqeValues = new MQEValues();
         mqeValues.setValues(mqeValueList);
-        mqeValues.setMetric(metadata);
         result.getResults().add(mqeValues);
         result.setType(ExpressionResultType.TIME_SERIES_VALUES);
     }
@@ -288,15 +282,15 @@ public class MQEVisitor extends MQEVisitorBase {
                 }
             }
 
-            Metadata metadata = new Metadata();
+            MQEValues mqeValues = new MQEValues();
             DataLabel dataLabel = new DataLabel();
             dataLabel.put(metricsValues.getLabel());
             for (Map.Entry<String, String> label : dataLabel.entrySet()) {
-                metadata.getLabels().add(new KeyValue(label.getKey(), label.getValue()));
+                mqeValues.getMetric().getLabels().add(new KeyValue(label.getKey(), label.getValue()));
             }
-            MQEValues mqeValues = new MQEValues();
+            //Sort labels by key in natural order by default
+            mqeValues.getMetric().sortLabelsByKey(Comparator.naturalOrder());
             mqeValues.setValues(mqeValueList);
-            mqeValues.setMetric(metadata);
             result.getResults().add(mqeValues);
         });
         result.setType(ExpressionResultType.TIME_SERIES_VALUES);


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
