### PR TITLE
Fix wrong indices in the eBPF Profiling related models

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -4,7 +4,7 @@
 
 
 #### OAP Server
-* Fix wrong banyanDB indexes in the eBPF Profiling related models.
+* Fix wrong indices in the eBPF Profiling related models.
 
 
 #### UI

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -4,6 +4,7 @@
 
 
 #### OAP Server
+* Fix wrong banyanDB indexes in the eBPF Profiling related models.
 
 
 #### UI

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -11,7 +11,7 @@
 
 
 #### Documentation
-
+* Update the version description supported by zabbix receiver.
 
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/205?closed=1)

--- a/docs/en/setup/backend/backend-zabbix.md
+++ b/docs/en/setup/backend/backend-zabbix.md
@@ -1,6 +1,6 @@
 # Zabbix Receiver
 The Zabbix receiver accepts metrics of [Zabbix Agent Active Checks protocol](https://www.zabbix.com/documentation/current/manual/appendix/items/activepassive#active_checks) format into the [Meter System](./../../concepts-and-designs/meter.md).
-Zabbix Agent is based on GPL-2.0 License.
+Zabbix Agent is based on GPL-2.0 License, only version `6.x` and below are supported.
 
 ## Module definition
 ```yaml

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/EBPFProfilingQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/EBPFProfilingQueryService.java
@@ -190,7 +190,7 @@ public class EBPFProfilingQueryService implements Service {
         final List<EBPFProfilingTaskRecord> tasks = getTaskDAO().queryTasksByTargets(serviceId, serviceInstanceId, targets, triggerType, startTime, endTime);
         // combine same id tasks
         final Map<String, EBPFProfilingTaskRecord> records = tasks.stream().collect(Collectors.toMap(EBPFProfilingTaskRecord::getLogicalId, Function.identity(), EBPFProfilingTaskRecord::combine));
-        return records.values().stream().map(this::parseTask).collect(Collectors.toList());
+        return records.values().stream().map(this::parseTask).sorted((o1, o2) -> -Long.compare(o1.getCreateTime(), o2.getCreateTime())).collect(Collectors.toList());
     }
 
     private EBPFProfilingTask parseTask(EBPFProfilingTaskRecord record) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/storage/EBPFProfilingDataRecord.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/storage/EBPFProfilingDataRecord.java
@@ -51,8 +51,8 @@ public class EBPFProfilingDataRecord extends Record {
     public static final String UPLOAD_TIME = "upload_time";
 
     @Column(name = TASK_ID)
-    @BanyanDB.SeriesID(index = 0)
     private String taskId;
+    @BanyanDB.SeriesID(index = 0)
     @Column(name = SCHEDULE_ID)
     private String scheduleId;
     @Column(name = STACK_ID_LIST)

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/storage/EBPFProfilingScheduleRecord.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/profiling/ebpf/storage/EBPFProfilingScheduleRecord.java
@@ -60,6 +60,7 @@ public class EBPFProfilingScheduleRecord extends Metrics {
     public static final String EBPF_PROFILING_SCHEDULE_ID = "ebpf_profiling_schedule_id";
 
     @Column(name = TASK_ID)
+    @BanyanDB.SeriesID(index = 0)
     private String taskId;
     @Column(name = PROCESS_ID, length = 600)
     private String processId;
@@ -68,7 +69,7 @@ public class EBPFProfilingScheduleRecord extends Metrics {
     @Column(name = END_TIME)
     private long endTime;
     @Column(name = EBPF_PROFILING_SCHEDULE_ID)
-    @BanyanDB.SeriesID(index = 0)
+    @BanyanDB.SeriesID(index = 1)
     private String scheduleId;
 
     @Override
@@ -96,7 +97,7 @@ public class EBPFProfilingScheduleRecord extends Metrics {
 
     @Override
     protected StorageID id0() {
-        return new StorageID().append(EBPF_PROFILING_SCHEDULE_ID, scheduleId);
+        return new StorageID().append(TASK_ID, taskId).append(EBPF_PROFILING_SCHEDULE_ID, scheduleId);
     }
 
     @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/ProcessTopologyBuilder.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/ProcessTopologyBuilder.java
@@ -69,7 +69,7 @@ public class ProcessTopologyBuilder {
 
     ProcessTopology build(List<Call.CallDetail> clientCalls,
                           List<Call.CallDetail> serverCalls) throws Exception {
-        log.info("building process topology, total found client calls: {}, total found server calls: {}",
+        log.debug("building process topology, total found client calls: {}, total found server calls: {}",
             clientCalls.size(), serverCalls.size());
         List<Call> calls = new LinkedList<>();
         HashMap<String, Call> callMap = new HashMap<>();
@@ -126,7 +126,7 @@ public class ProcessTopologyBuilder {
         ProcessTopology topology = new ProcessTopology();
         topology.getCalls().addAll(calls);
         topology.getNodes().addAll(nodes.values());
-        log.info("process topology built, total calls: {}, total nodes: {}", appendCallCount, nodes.size());
+        log.debug("process topology built, total calls: {}, total nodes: {}", appendCallCount, nodes.size());
         return topology;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/ProcessTopologyBuilder.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/ProcessTopologyBuilder.java
@@ -69,6 +69,8 @@ public class ProcessTopologyBuilder {
 
     ProcessTopology build(List<Call.CallDetail> clientCalls,
                           List<Call.CallDetail> serverCalls) throws Exception {
+        log.info("building process topology, total found client calls: {}, total found server calls: {}",
+            clientCalls.size(), serverCalls.size());
         List<Call> calls = new LinkedList<>();
         HashMap<String, Call> callMap = new HashMap<>();
 
@@ -88,6 +90,7 @@ public class ProcessTopologyBuilder {
             .map(t -> (ProcessTraffic) t)
             .collect(Collectors.toMap(m -> m.id().build(), this::buildNode));
 
+        int appendCallCount = 0;
         for (Call.CallDetail clientCall : clientCalls) {
             if (!callMap.containsKey(clientCall.getId())) {
                 Call call = new Call();
@@ -99,6 +102,7 @@ public class ProcessTopologyBuilder {
                 call.addDetectPoint(DetectPoint.CLIENT);
                 call.addSourceComponent(componentLibraryCatalogService.getComponentName(clientCall.getComponentId()));
                 calls.add(call);
+                appendCallCount++;
             }
         }
 
@@ -113,6 +117,7 @@ public class ProcessTopologyBuilder {
                 call.setTarget(serverCall.getTarget());
                 call.setId(serverCall.getId());
                 calls.add(call);
+                appendCallCount++;
             }
             call.addDetectPoint(DetectPoint.SERVER);
             call.addTargetComponent(componentLibraryCatalogService.getComponentName(serverCall.getComponentId()));
@@ -121,6 +126,7 @@ public class ProcessTopologyBuilder {
         ProcessTopology topology = new ProcessTopology();
         topology.getCalls().addAll(calls);
         topology.getNodes().addAll(nodes.values());
+        log.info("process topology built, total calls: {}, total nodes: {}", appendCallCount, nodes.size());
         return topology;
     }
 

--- a/test/e2e-v2/cases/vm/zabbix/docker-compose.yml
+++ b/test/e2e-v2/cases/vm/zabbix/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - 12800
 
   zabbix-client:
-    image: zabbix/zabbix-agent:alpine-latest
+    image: zabbix/zabbix-agent:alpine-6.4.15
     networks:
       - e2e
     volumes:


### PR DESCRIPTION
When using BanyanDB to query eBPF CPU Profiling, there can be slow queries and timeouts. This PR fixes the incorrect index in the model.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
