### PR TITLE
Adding eBPF Access Log Feature E2E and support exclude specific namespaces traffic

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -531,6 +531,14 @@ jobs:
               file: Dockerfile.sqrt
               name: test/continuous:test
 
+          # eBPF Access Log
+          - name: eBPF Access Log BanyanDB
+            config: test/e2e-v2/cases/profiling/ebpf/access_log/banyandb/e2e.yaml
+          - name: eBPF Access Log ES
+            config: test/e2e-v2/cases/profiling/ebpf/access_log/es/e2e.yaml
+          - name: eBPF Access Log ES Sharding
+            config: test/e2e-v2/cases/profiling/ebpf/access_log/es/es-sharding/e2e.yaml
+
           - name: Kafka Basic
             config: test/e2e-v2/cases/kafka/simple-so11y/e2e.yaml
           - name: Kafka Profiling

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ BUILD_ARGS := $(BUILD_ARGS) --build-arg DIST=$(DIST)
 
 docker.%: PLATFORMS =
 docker.%: LOAD_OR_PUSH = --load
-push.%: PLATFORMS = --platform linux/amd64,linux/arm64
+push.%: PLATFORMS = --platform linux/amd64
 push.%: LOAD_OR_PUSH = --push
 
 docker.% push.docker.%: $(CONTEXT)/$(DIST) $(SW_ROOT)/docker/%/*

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ BUILD_ARGS := $(BUILD_ARGS) --build-arg DIST=$(DIST)
 
 docker.%: PLATFORMS =
 docker.%: LOAD_OR_PUSH = --load
-push.%: PLATFORMS = --platform linux/amd64
+push.%: PLATFORMS = --platform linux/amd64,linux/arm64
 push.%: LOAD_OR_PUSH = --push
 
 docker.% push.docker.%: $(CONTEXT)/$(DIST) $(SW_ROOT)/docker/%/*

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -5,6 +5,7 @@
 
 #### OAP Server
 * Fix wrong indices in the eBPF Profiling related models.
+* Support exclude the specific namespaces traffic in the eBPF Access Log receiver.
 
 
 #### UI

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/ProcessTopologyBuilder.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/ProcessTopologyBuilder.java
@@ -34,6 +34,7 @@ import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.model.Model;
 import org.apache.skywalking.oap.server.core.storage.model.StorageModels;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
+import org.apache.skywalking.oap.server.library.util.CollectionUtils;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -71,6 +72,9 @@ public class ProcessTopologyBuilder {
                           List<Call.CallDetail> serverCalls) throws Exception {
         log.debug("building process topology, total found client calls: {}, total found server calls: {}",
             clientCalls.size(), serverCalls.size());
+        if (CollectionUtils.isEmpty(clientCalls) && CollectionUtils.isEmpty(serverCalls)) {
+            return new ProcessTopology();
+        }
         List<Call> calls = new LinkedList<>();
         HashMap<String, Call> callMap = new HashMap<>();
 
@@ -88,7 +92,7 @@ public class ProcessTopologyBuilder {
                     return p;
                 }).collect(Collectors.toList())).stream()
             .map(t -> (ProcessTraffic) t)
-            .collect(Collectors.toMap(m -> m.id().build(), this::buildNode));
+            .collect(Collectors.toMap(m -> m.id().build(), this::buildNode, (t1, t2) -> t1));
 
         int appendCallCount = 0;
         for (Call.CallDetail clientCall : clientCalls) {

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/accesslog-cases.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/accesslog-cases.yaml
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used to show how to write configuration files and can be used to test.
+
+cases:
+  # service list
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql service ls
+    expected: expected/service.yml
+  # service instance list
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance list --service-name=productpage.default
+    expected: expected/service-instance.yml
+
+  # service topology
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql dependency global --layer=K8S_SERVICE
+    expected: expected/dependency-services.yml
+  # service instance topology
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql dependency instance --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/dependency-instance.yml
+  # service endpoints
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql endpoint list --service-name=details.default
+    expected: expected/service-endpoint-reviews.yml
+  # endpoints topology
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql dependency endpoint --service-name=details.default --endpoint-name=/details/0
+    expected: expected/dependency-endpoint-reviews.yml
+
+  # service level metrics
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_connect_cpm --service-name=productpage.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_accept_cpm --service-name=reviews.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_write_cpm --service-name=productpage.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_read_cpm --service-name=productpage.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_write_l4_duration --service-name=productpage.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_read_l4_duration --service-name=productpage.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_write_package_cpm --service-name=productpage.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_read_package_cpm --service-name=productpage.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_http_call_cpm --service-name=reviews.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_http_call_duration --service-name=reviews.default
+    expected: expected/metrics-has-value.yml
+
+  # service instance level metrics
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_connect_cpm --service-name=productpage.default --instance-name=$instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_write_cpm --service-name=productpage.default --instance-name=$instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_write_l4_duration --service-name=productpage.default --instance-name=$instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_write_package_cpm --service-name=productpage.default --instance-name=$instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_read_cpm --service-name=productpage.default --instance-name=$instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_read_l4_duration --service-name=productpage.default --instance-name=$instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_read_package_cpm --service-name=productpage.default --instance-name=$instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name reviews.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_http_call_cpm --service-name=reviews.default --instance-name=$instance_name
+    expected: expected/metrics-has-value.yml
+
+  # service endpoint level metrics
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_endpoint_call_cpm --service-name=details.default --endpoint-name=/details/0
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_endpoint_http_call_cpm --service-name=details.default --endpoint-name=/details/0
+    expected: expected/metrics-has-value.yml
+
+  # service relation metrics
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_relation_connect_cpm --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_relation_server_write_cpm --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_relation_server_write_package_cpm --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_relation_server_read_cpm --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_relation_server_read_package_cpm --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_relation_client_write_cpm --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_relation_client_write_package_cpm --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_relation_client_read_cpm --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/metrics-has-value.yml
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_relation_client_read_package_cpm --service-name=productpage.default --dest-service-name=details.default
+    expected: expected/metrics-has-value.yml
+
+  # service instance relation metrics
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      dest_instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name details.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_relation_connect_cpm --service-name=productpage.default --instance-name=$instance_name --dest-service-name=details.default --dest-instance-name=$dest_instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      dest_instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name details.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_relation_server_write_cpm --service-name=productpage.default --instance-name=$instance_name --dest-service-name=details.default --dest-instance-name=$dest_instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      dest_instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name details.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_relation_server_write_package_cpm --service-name=productpage.default --instance-name=$instance_name --dest-service-name=details.default --dest-instance-name=$dest_instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      dest_instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name details.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_relation_server_read_cpm --service-name=productpage.default --instance-name=$instance_name --dest-service-name=details.default --dest-instance-name=$dest_instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      dest_instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name details.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_relation_server_read_package_cpm --service-name=productpage.default --instance-name=$instance_name --dest-service-name=details.default --dest-instance-name=$dest_instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      dest_instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name details.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_relation_client_write_cpm --service-name=productpage.default --instance-name=$instance_name --dest-service-name=details.default --dest-instance-name=$dest_instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      dest_instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name details.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_relation_client_write_package_cpm --service-name=productpage.default --instance-name=$instance_name --dest-service-name=details.default --dest-instance-name=$dest_instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      dest_instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name details.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_relation_client_read_cpm --service-name=productpage.default --instance-name=$instance_name --dest-service-name=details.default --dest-instance-name=$dest_instance_name
+    expected: expected/metrics-has-value.yml
+  - query: |
+      instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
+      dest_instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name details.default | yq '.[0].name' -)
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_relation_client_read_package_cpm --service-name=productpage.default --instance-name=$instance_name --dest-service-name=details.default --dest-instance-name=$dest_instance_name
+    expected: expected/metrics-has-value.yml

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/banyandb/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/banyandb/e2e.yaml
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: kind
+  file: ../../kind.yaml
+  init-system-environment: ../../../../../script/env
+  kind:
+    import-images:
+      - skywalking/ui:latest
+      - skywalking/oap:latest
+    expose-ports:
+      - namespace: istio-system
+        resource: service/skywalking-ui
+        port: 80
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+    - name: install kubectl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh kubectl
+    - name: Install helm
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh helm
+    - name: Install kubectl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh kubectl
+    - name: Install SkyWalking
+      command: |
+        kubectl create namespace istio-system
+        helm -n istio-system install skywalking \
+          oci://ghcr.io/apache/skywalking-helm/skywalking-helm \
+          --version "0.0.0-${SW_KUBERNETES_COMMIT_SHA}" \
+          --set fullnameOverride=skywalking \
+          --set elasticsearch.enabled=false \
+          --set banyandb.enabled=true \
+          --set banyandb.standalone.image.tag=${SW_BANYANDB_COMMIT} \
+          --set oap.replicas=1 \
+          --set ui.image.repository=skywalking/ui \
+          --set ui.image.tag=latest \
+          --set oap.image.tag=latest \
+          --set oap.image.repository=skywalking/oap \
+          --set oap.storageType=banyandb \
+          -f test/e2e-v2/cases/profiling/ebpf/kubernetes-values.yaml
+      wait:
+        - namespace: istio-system
+          resource: deployments/skywalking-oap
+          for: condition=available
+    - name: Deploy rover services
+      command: |
+        kubectl apply -f https://raw.githubusercontent.com/istio/istio/1.18.0/samples/bookinfo/platform/kube/bookinfo.yaml
+        envsubst < test/e2e-v2/cases/profiling/ebpf/access_log/rover.yaml | kubectl apply -f -
+      wait:
+        - namespace: default
+          resource: pod
+          for: condition=Ready
+    - name: Generate traffic
+      path: ../traffic-gen.yaml
+      wait:
+        - namespace: default
+          resource: pod
+          for: condition=Ready
+  timeout: 25m
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../accesslog-cases.yaml

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/es/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/es/e2e.yaml
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: kind
+  file: ../../kind.yaml
+  init-system-environment: ../../../../../script/env
+  kind:
+    import-images:
+      - skywalking/ui:latest
+      - skywalking/oap:latest
+    expose-ports:
+      - namespace: istio-system
+        resource: service/skywalking-ui
+        port: 80
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+    - name: install kubectl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh kubectl
+    - name: Install helm
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh helm
+    - name: Install kubectl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh kubectl
+    - name: Install SkyWalking
+      command: |
+        kubectl create namespace istio-system
+        helm -n istio-system install skywalking \
+          oci://ghcr.io/apache/skywalking-helm/skywalking-helm \
+          --version "0.0.0-${SW_KUBERNETES_COMMIT_SHA}" \
+          --set fullnameOverride=skywalking \
+          --set elasticsearch.replicas=1 \
+          --set elasticsearch.minimumMasterNodes=1 \
+          --set oap.replicas=1 \
+          --set ui.image.repository=skywalking/ui \
+          --set ui.image.tag=latest \
+          --set oap.image.tag=latest \
+          --set oap.image.repository=skywalking/oap \
+          --set oap.storageType=elasticsearch \
+          -f test/e2e-v2/cases/profiling/ebpf/kubernetes-values.yaml
+      wait:
+        - namespace: istio-system
+          resource: deployments/skywalking-oap
+          for: condition=available
+    - name: Deploy services
+      command: |
+        kubectl apply -f https://raw.githubusercontent.com/istio/istio/1.18.0/samples/bookinfo/platform/kube/bookinfo.yaml
+        envsubst < test/e2e-v2/cases/profiling/ebpf/access_log/rover.yaml | kubectl apply -f -
+      wait:
+        - namespace: default
+          resource: pod
+          for: condition=Ready
+    - name: Generate traffic
+      path: ../traffic-gen.yaml
+      wait:
+        - namespace: default
+          resource: pod
+          for: condition=Ready
+  timeout: 25m
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../accesslog-cases.yaml

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/es/es-sharding/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/es/es-sharding/e2e.yaml
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: kind
+  file: ../../../kind.yaml
+  init-system-environment: ../../../../../../script/env
+  kind:
+    import-images:
+      - skywalking/ui:latest
+      - skywalking/oap:latest
+    expose-ports:
+      - namespace: istio-system
+        resource: service/skywalking-ui
+        port: 80
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+    - name: install kubectl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh kubectl
+    - name: Install helm
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh helm
+    - name: Install kubectl
+      command: bash test/e2e-v2/script/prepare/setup-e2e-shell/install.sh kubectl
+    - name: Install SkyWalking
+      command: |
+        kubectl create namespace istio-system
+        helm -n istio-system install skywalking \
+          oci://ghcr.io/apache/skywalking-helm/skywalking-helm \
+          --version "0.0.0-${SW_KUBERNETES_COMMIT_SHA}" \
+          --set fullnameOverride=skywalking \
+          --set elasticsearch.replicas=1 \
+          --set elasticsearch.minimumMasterNodes=1 \
+          --set oap.replicas=1 \
+          --set ui.image.repository=skywalking/ui \
+          --set ui.image.tag=latest \
+          --set oap.image.tag=latest \
+          --set oap.image.repository=skywalking/oap \
+          --set oap.storageType=elasticsearch \
+          --set oap.env.SW_STORAGE_ES_LOGIC_SHARDING=true \
+          -f test/e2e-v2/cases/profiling/ebpf/kubernetes-values.yaml
+      wait:
+        - namespace: istio-system
+          resource: deployments/skywalking-oap
+          for: condition=available
+    - name: Deploy services
+      command: |
+        kubectl apply -f https://raw.githubusercontent.com/istio/istio/1.18.0/samples/bookinfo/platform/kube/bookinfo.yaml
+        envsubst < test/e2e-v2/cases/profiling/ebpf/access_log/rover.yaml | kubectl apply -f -
+      wait:
+        - namespace: default
+          resource: pod
+          for: condition=Ready
+    - name: Generate traffic
+      path: ../../traffic-gen.yaml
+      wait:
+        - namespace: default
+          resource: pod
+          for: condition=Ready
+  timeout: 25m
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../../accesslog-cases.yaml

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-endpoint-reviews.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-endpoint-reviews.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nodes:
+{{- contains .nodes }}
+- id: {{ b64enc "productpage.default" }}.1_{{ b64enc "/details/0" }}
+  name: /details/0
+  serviceid: {{ b64enc "productpage.default" }}.1
+  servicename: productpage.default
+  type: ""
+  isreal: true
+- id: {{ b64enc "details.default" }}.1_{{ b64enc "/details/0" }}
+  name: /details/0
+  serviceid: {{ b64enc "details.default" }}.1
+  servicename: details.default
+  type: ""
+  isreal: true
+{{- end }}
+calls:
+{{- contains .calls }}
+- source: {{ b64enc "productpage.default" }}.1_{{ b64enc "/details/0" }}
+  sourcecomponents: []
+  target: {{ b64enc "details.default" }}.1_{{ b64enc "/details/0" }}
+  targetcomponents: []
+  id: {{ b64enc "productpage.default" }}.1-{{ b64enc "/details/0" }}-{{ b64enc "details.default" }}.1-{{ b64enc "/details/0" }}
+  detectpoints:
+    - SERVER
+{{- end }}

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-instance.yml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nodes:
+{{- contains .nodes }}
+- id: {{ notEmpty .id }}
+  name: {{ notEmpty .name }}
+  serviceid: {{ b64enc "productpage.default" }}.1
+  servicename: productpage.default
+  type: ""
+  isreal: true
+- id: {{ notEmpty .id }}
+  name: {{ notEmpty .name }}
+  serviceid: {{ b64enc "details.default" }}.1
+  servicename: details.default
+  type: ""
+  isreal: true
+{{- end }}
+calls:
+{{- contains .calls }}
+- source: {{ notEmpty .source }}
+  sourcecomponents: []
+  target: {{ notEmpty .target }}
+  targetcomponents: []
+  id: {{ notEmpty .id }}
+  detectpoints:
+    - CLIENT
+    - SERVER
+{{- end }}

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-services.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-services.yml
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nodes:
+{{- contains .nodes }}
+- id: {{ b64enc "productpage.default"}}.1
+  name: productpage.default
+  type: null
+  isreal: true
+- id: {{ b64enc "details.default"}}.1
+  name: details.default
+  type: http
+  isreal: true
+- id: {{ b64enc "ratings.default" }}.1
+  name: ratings.default
+  type: http
+  isreal: true
+- id: {{ b64enc "reviews.default" }}.1
+  name: reviews.default
+  type: http
+  isreal: true
+{{- end }}
+calls:
+{{- contains .calls }}
+- source: {{ b64enc "productpage.default"}}.1
+  sourcecomponents:
+  {{- contains .sourcecomponents }}
+  - http
+  {{- end }}
+  target: {{ b64enc "details.default"}}.1
+  targetcomponents:
+  {{- contains .targetcomponents }}
+    - http
+  {{- end }}
+  id: {{ b64enc "productpage.default"}}.1-{{ b64enc "details.default"}}.1
+  detectpoints:
+    - CLIENT
+    - SERVER
+- source: {{ b64enc "productpage.default"}}.1
+  sourcecomponents:
+  {{- contains .sourcecomponents }}
+  - http
+  {{- end }}
+  target: {{ b64enc "reviews.default"}}.1
+  targetcomponents:
+  {{- contains .targetcomponents }}
+  - http
+  {{- end }}
+  id: {{ b64enc "productpage.default"}}.1-{{ b64enc "reviews.default"}}.1
+  detectpoints:
+    - CLIENT
+    - SERVER
+- source: {{ b64enc "reviews.default" }}.1
+  sourcecomponents:
+    {{- contains .sourcecomponents }}
+    - http
+    {{- end }}
+  target: {{ b64enc "ratings.default"}}.1
+  targetcomponents:
+  {{- contains .targetcomponents }}
+    - http
+  {{- end }}
+  id: {{ b64enc "reviews.default" }}.1-{{ b64enc "ratings.default"}}.1
+  detectpoints:
+    - CLIENT
+    - SERVER
+{{- end }}

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/metrics-has-value.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/metrics-has-value.yml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: TIME_SERIES_VALUES
+results:
+  {{- contains .results }}
+  - metric:
+      labels: []
+    values:
+      {{- contains .values }}
+      - id: {{ notEmpty .id }}
+        value: {{ .value }}
+        traceid: null
+      - id: {{ notEmpty .id }}
+        value: null
+        traceid: null
+      {{- end}}
+  {{- end}}
+error: null

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/service-endpoint-reviews.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/service-endpoint-reviews.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- contains . }}
+- id: {{ b64enc "details.default" }}.1_{{ b64enc "/details/0" }}
+  name: /details/0
+{{- end }}

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/service-instance.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/service-instance.yml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- contains . }}
+- id: {{ notEmpty .id }}
+  name: {{ notEmpty .name }}
+  attributes: []
+  language: UNKNOWN
+  instanceuuid: {{ notEmpty .instanceuuid }}
+{{- end }}

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/service.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/service.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- contains . }}
+- id: {{ b64enc "details.default" }}.1
+  name: details.default
+  group: ""
+  shortname: details.default
+  layers:
+    - K8S_SERVICE
+  normal: true
+- id: {{ b64enc "reviews.default" }}.1
+  name: reviews.default
+  group: ""
+  shortname: reviews.default
+  layers:
+    - K8S_SERVICE
+  normal: true
+- id: {{ b64enc "productpage.default" }}.1
+  name: productpage.default
+  group: ""
+  shortname: productpage.default
+  layers:
+    - K8S_SERVICE
+  normal: true
+- id: {{ b64enc "ratings.default" }}.1
+  name: ratings.default
+  group: ""
+  shortname: ratings.default
+  layers:
+    - K8S_SERVICE
+  normal: true
+{{- end }}

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/rover.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/rover.yaml
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skywalking-rover
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: skywalking-rover
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: skywalking-rover
+subjects:
+  - kind: ServiceAccount
+    name: skywalking-rover
+    namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: skywalking-rover
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "services"]
+    verbs: ["get", "watch", "list"]
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: skywalking-rover
+spec:
+  selector:
+    matchLabels:
+      name: skywalking-rover
+  template:
+    metadata:
+      labels:
+        name: skywalking-rover
+    spec:
+      serviceAccountName: skywalking-rover
+      serviceAccount: skywalking-rover
+      containers:
+        - name: skywalking-rover
+          # SkyWalking Rover image path
+          image: ghcr.io/apache/skywalking-rover/skywalking-rover:29ef115f29d5597f64d3745e7b191d57cc853848
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - SYS_PTRACE
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - name: host
+              mountPath: /host
+              readOnly: true
+            - name: host-sys
+              mountPath: /sys
+              readOnly: true
+          env:
+            - name: ROVER_PROCESS_DISCOVERY_KUBERNETES_ACTIVE
+              value: "true"
+            - name: ROVER_LOGGER_LEVEL
+              value: "DEBUG"
+            - name: ROVER_PROCESS_DISCOVERY_KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: ROVER_BACKEND_ADDR
+              # backend OAP address
+              value: skywalking-oap.istio-system:11800
+            - name: ROVER_PROCESS_DISCOVERY_KUBERNETES_ANALYZER_ISTIO_ENVOY_ACTIVE
+              value: "false"
+            - name: ROVER_PROCESS_DISCOVERY_KUBERNETES_ANALYZER_ISTIO_APPLICATION_ACTIVE
+              value: "false"
+            - name: ROVER_HOST_MAPPING
+              value: /host
+            - name: ROVER_ACCESS_LOG_ACTIVE
+              value: "true"
+            - name: ROVER_ACCESS_LOG_FLUSH_PERIOD
+              value: 1s
+      hostPID: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      volumes:
+        - name: host
+          hostPath:
+            path: /host
+            type: Directory
+        - name: host-sys
+          hostPath:
+            path: /host/sys
+            type: Directory

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/traffic-gen.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/traffic-gen.yaml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trafficgenerator
+  labels:
+    app: trafficgenerator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: trafficgenerator
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: trafficgenerator
+    spec:
+      containers:
+        - name: trafficgenerator
+          image: elswork/wrk
+          command: ["wrk", "-t1", "-c1", "-d20m", "http://productpage:9080/productpage"]
+          resources:
+            requests:
+              cpu: 0.1


### PR DESCRIPTION
1. Support excluding specific namespace traffic in the eBPF Access Log Receiver. 
2. Adding eBPF Access Log E2E Test between ES and BanyanDB.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
