### PR TITLE
Fix value too long for type character varying (#12352)

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/Event.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/Event.java
@@ -100,7 +100,7 @@ public class Event extends Metrics {
     @Column(name = TYPE)
     private String type;
 
-    @Column(name = MESSAGE)
+    @Column(name = MESSAGE, length = 2000)
     private String message;
 
     @Column(name = PARAMETERS, storageOnly = true, length = PARAMETER_MAX_LENGTH)


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <value too long for type character varying>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
it's auto collect by agent-java, when dubbo invoke more 1 second, the length of the message content is more than 200, so error is happend, the agent collect message content as below:

Response time of endpoint relation POST:/databoard/sets/v2/save_config in test::x-big-data|uat| to cn.mashang.terminal.modules.vscreen.IVScreenOpenService.freshBigData(Long,String) in test::m-terminal-center|uat| is more than 1000ms in 2 minutes of last 10 minutes

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue 12352>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
