### PR TITLE
Fix metrics tag in HTTP handler of browser receiver plugin.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -13,6 +13,7 @@
 * Support to query relation metrics through PromQL.
 * Support trace MQE query for debugging.
 * Add Component ID(158) for the Solon framework.
+* Fix metrics tag in HTTP handler of browser receiver plugin.
 
 #### UI
 

--- a/oap-server/server-receiver-plugin/skywalking-browser-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/browser/provider/handler/rest/BrowserPerfServiceHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-browser-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/browser/provider/handler/rest/BrowserPerfServiceHTTPHandler.java
@@ -74,7 +74,7 @@ public class BrowserPerfServiceHTTPHandler {
 
         errorLogHistogram = metricsCreator.createHistogramMetric(
             "browser_error_log_in_latency", "The process latency of browser error log", new MetricsTag.Keys("protocol"),
-            new MetricsTag.Values("grpc")
+            new MetricsTag.Values("http")
         );
         logErrorCounter = metricsCreator.createCounter(
             "browser_error_log_analysis_error_count", "The error number of browser error log analysis",


### PR DESCRIPTION
HTTP Handler metrics tag: `grpc -> http`

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
