### PR TITLE
Make more proper histogram buckets in PersistenceTimer.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -17,6 +17,8 @@
 * Increase `alarm_record#message` column length to 2000 from 200.
 * Remove `alarm_record#message` column indexing.
 * Add Python as a supported language for Pulsar.
+* Make more proper histogram buckets for the `persistence_timer_bulk_prepare_latency`,
+  `persistence_timer_bulk_execute_latency` and `persistence_timer_bulk_all_latency` metrics in PersistenceTimer.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/PersistenceTimer.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/PersistenceTimer.java
@@ -70,16 +70,23 @@ public enum PersistenceTimer {
         prepareLatency = metricsCreator.createHistogramMetric(
             "persistence_timer_bulk_prepare_latency",
             "Latency of the prepare stage in persistence timer",
-            MetricsTag.EMPTY_KEY, MetricsTag.EMPTY_VALUE
+            MetricsTag.EMPTY_KEY, MetricsTag.EMPTY_VALUE,
+            // 50ms -> 30s should be a proper range for the persistence timer prepare stage
+            .05, .075, .1, .25, .5, .75, 1, 3, 5, 10, 30
         );
         executeLatency = metricsCreator.createHistogramMetric(
             "persistence_timer_bulk_execute_latency",
             "Latency of the execute stage in persistence timer",
-            MetricsTag.EMPTY_KEY, MetricsTag.EMPTY_VALUE
+            MetricsTag.EMPTY_KEY, MetricsTag.EMPTY_VALUE,
+            // 500ms -> 2min should be a proper range for the persistence timer execute stage
+            // 0.5s, 1s, 3s, 5s, 10s, 15s, 20s, 25s, 50s, 120s, Inf+
+            0.5, 1, 3, 5, 10, 15, 20, 25, 50, 120
         );
         allLatency = metricsCreator.createHistogramMetric(
             "persistence_timer_bulk_all_latency", "Latency of the all stage in persistence timer",
-            MetricsTag.EMPTY_KEY, MetricsTag.EMPTY_VALUE
+            MetricsTag.EMPTY_KEY, MetricsTag.EMPTY_VALUE,
+            // 500ms -> 2min should be a proper range for the persistence timer
+            0.5, 1, 3, 5, 10, 15, 20, 25, 50, 120
         );
 
         prepareExecutorService = Executors.newFixedThreadPool(moduleConfig.getPrepareThreads());


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

![image](https://github.com/apache/skywalking/assets/5441976/a9cc506a-fe96-4e9a-b60a-effc97477a0a)

The default buckets are too small, that can't indicate the latency clearly.
We will always see Inf+ which is pointless.

<img width="1367" alt="image" src="https://github.com/apache/skywalking/assets/5441976/e377b3fe-5d12-4625-808d-a9a40eaea861">

