### PR TITLE
Fix BanyanDB metrics query: used the wrong `Downsampling` type to find the schema

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -21,6 +21,7 @@
   `persistence_timer_bulk_execute_latency` and `persistence_timer_bulk_all_latency` metrics in PersistenceTimer.
 * [Break Change] Update Nacos version to 2.3.2. Nacos 1.x server can't serve as cluster coordinator and configuration server.
 * Support tracing trace query(SkyWalking and Zipkin) for debugging.
+* Fix BanyanDB metrics query: used the wrong `Downsampling` type to find the schema.
 
 #### UI
 

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBAggregationQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBAggregationQueryDAO.java
@@ -75,7 +75,7 @@ public class BanyanDBAggregationQueryDAO extends AbstractBanyanDBDAO implements 
             }
         }
 
-        return directMetricsTopN(condition, valueColumnName, spec, timestampRange, additionalConditions);
+        return directMetricsTopN(condition, schema, valueColumnName, spec, timestampRange, additionalConditions);
     }
 
     List<SelectedRecord> serverSideTopN(TopNCondition condition, MetadataRegistry.Schema schema, MetadataRegistry.ColumnSpec valueColumnSpec,
@@ -103,9 +103,9 @@ public class BanyanDBAggregationQueryDAO extends AbstractBanyanDBDAO implements 
         return topNList;
     }
 
-    List<SelectedRecord> directMetricsTopN(TopNCondition condition, String valueColumnName, MetadataRegistry.ColumnSpec valueColumnSpec,
+    List<SelectedRecord> directMetricsTopN(TopNCondition condition, MetadataRegistry.Schema schema, String valueColumnName, MetadataRegistry.ColumnSpec valueColumnSpec,
                                            TimestampRange timestampRange, List<KeyValue> additionalConditions) throws IOException {
-        MeasureQueryResponse resp = queryDebuggable(condition.getName(), TAGS, Collections.singleton(valueColumnName),
+        MeasureQueryResponse resp = queryDebuggable(schema, TAGS, Collections.singleton(valueColumnName),
                 timestampRange, new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBZipkinQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBZipkinQueryDAO.java
@@ -36,6 +36,7 @@ import org.apache.skywalking.banyandb.v1.client.RowEntity;
 import org.apache.skywalking.banyandb.v1.client.StreamQuery;
 import org.apache.skywalking.banyandb.v1.client.StreamQueryResponse;
 import org.apache.skywalking.banyandb.v1.client.TimestampRange;
+import org.apache.skywalking.oap.server.core.analysis.DownSampling;
 import org.apache.skywalking.oap.server.core.query.input.Duration;
 import org.apache.skywalking.oap.server.core.storage.query.IZipkinQueryDAO;
 import org.apache.skywalking.oap.server.core.zipkin.ZipkinServiceRelationTraffic;
@@ -84,10 +85,11 @@ public class BanyanDBZipkinQueryDAO extends AbstractBanyanDBDAO implements IZipk
 
     @Override
     public List<String> getServiceNames() throws IOException {
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ZipkinServiceTraffic.INDEX_NAME, DownSampling.Minute);
         MeasureQueryResponse resp =
-            query(ZipkinServiceTraffic.INDEX_NAME,
+            query(schema,
                   SERVICE_TRAFFIC_TAGS,
-                  Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
+                  Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
 
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -104,10 +106,11 @@ public class BanyanDBZipkinQueryDAO extends AbstractBanyanDBDAO implements IZipk
 
     @Override
     public List<String> getRemoteServiceNames(final String serviceName) throws IOException {
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ZipkinServiceRelationTraffic.INDEX_NAME, DownSampling.Minute);
         MeasureQueryResponse resp =
-            query(ZipkinServiceRelationTraffic.INDEX_NAME,
+            query(schema,
                   REMOTE_SERVICE_TRAFFIC_TAGS,
-                  Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
+                  Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
 
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -127,10 +130,11 @@ public class BanyanDBZipkinQueryDAO extends AbstractBanyanDBDAO implements IZipk
 
     @Override
     public List<String> getSpanNames(final String serviceName) throws IOException {
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ZipkinServiceSpanTraffic.INDEX_NAME, DownSampling.Minute);
         MeasureQueryResponse resp =
-            query(ZipkinServiceSpanTraffic.INDEX_NAME,
+            query(schema,
                   SPAN_TRAFFIC_TAGS,
-                  Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
+                  Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
 
                     @Override
                     protected void apply(MeasureQuery query) {

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBZipkinQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/BanyanDBZipkinQueryDAO.java
@@ -89,7 +89,7 @@ public class BanyanDBZipkinQueryDAO extends AbstractBanyanDBDAO implements IZipk
         MeasureQueryResponse resp =
             query(schema,
                   SERVICE_TRAFFIC_TAGS,
-                  Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
+                  Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
 
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -110,7 +110,7 @@ public class BanyanDBZipkinQueryDAO extends AbstractBanyanDBDAO implements IZipk
         MeasureQueryResponse resp =
             query(schema,
                   REMOTE_SERVICE_TRAFFIC_TAGS,
-                  Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
+                  Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
 
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -134,7 +134,7 @@ public class BanyanDBZipkinQueryDAO extends AbstractBanyanDBDAO implements IZipk
         MeasureQueryResponse resp =
             query(schema,
                   SPAN_TRAFFIC_TAGS,
-                  Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
+                  Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
 
                     @Override
                     protected void apply(MeasureQuery query) {

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBEBPFProfilingScheduleQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBEBPFProfilingScheduleQueryDAO.java
@@ -24,11 +24,13 @@ import org.apache.skywalking.banyandb.v1.client.AbstractQuery;
 import org.apache.skywalking.banyandb.v1.client.DataPoint;
 import org.apache.skywalking.banyandb.v1.client.MeasureQuery;
 import org.apache.skywalking.banyandb.v1.client.MeasureQueryResponse;
-import org.apache.skywalking.oap.server.core.profiling.ebpf.storage.EBPFProfilingScheduleRecord;
+ import org.apache.skywalking.oap.server.core.analysis.DownSampling;
+ import org.apache.skywalking.oap.server.core.profiling.ebpf.storage.EBPFProfilingScheduleRecord;
 import org.apache.skywalking.oap.server.core.query.type.EBPFProfilingSchedule;
 import org.apache.skywalking.oap.server.core.storage.profiling.ebpf.IEBPFProfilingScheduleDAO;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageClient;
-import org.apache.skywalking.oap.server.storage.plugin.banyandb.stream.AbstractBanyanDBDAO;
+ import org.apache.skywalking.oap.server.storage.plugin.banyandb.MetadataRegistry;
+ import org.apache.skywalking.oap.server.storage.plugin.banyandb.stream.AbstractBanyanDBDAO;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -50,9 +52,10 @@ import java.util.stream.Collectors;
 
      @Override
      public List<EBPFProfilingSchedule> querySchedules(String taskId) throws IOException {
-         MeasureQueryResponse resp = query(EBPFProfilingScheduleRecord.INDEX_NAME,
+         MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(EBPFProfilingScheduleRecord.INDEX_NAME, DownSampling.Minute);
+         MeasureQueryResponse resp = query(schema,
                  TAGS,
-                 Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
+                 Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
                      @Override
                      protected void apply(MeasureQuery query) {
                          query.and(eq(EBPFProfilingScheduleRecord.TASK_ID, taskId));

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBEBPFProfilingScheduleQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBEBPFProfilingScheduleQueryDAO.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
          MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(EBPFProfilingScheduleRecord.INDEX_NAME, DownSampling.Minute);
          MeasureQueryResponse resp = query(schema,
                  TAGS,
-                 Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
+                 Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
                      @Override
                      protected void apply(MeasureQuery query) {
                          query.and(eq(EBPFProfilingScheduleRecord.TASK_ID, taskId));

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBEventQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBEventQueryDAO.java
@@ -60,7 +60,7 @@ public class BanyanDBEventQueryDAO extends AbstractBanyanDBDAO implements IEvent
     public Events queryEvents(EventQueryCondition condition) throws Exception {
         MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(Event.INDEX_NAME, DownSampling.Minute);
         MeasureQueryResponse resp = query(schema, TAGS,
-                Collections.emptySet(), null, buildQuery(Collections.singletonList(condition)));
+                Collections.emptySet(), buildQuery(Collections.singletonList(condition)));
         Events events = new Events();
         if (resp.size() == 0) {
             return events;
@@ -75,7 +75,7 @@ public class BanyanDBEventQueryDAO extends AbstractBanyanDBDAO implements IEvent
     public Events queryEvents(List<EventQueryCondition> conditionList) throws Exception {
         MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(Event.INDEX_NAME, DownSampling.Minute);
         MeasureQueryResponse resp = query(schema, TAGS,
-                Collections.emptySet(), null, buildQuery(conditionList));
+                Collections.emptySet(), buildQuery(conditionList));
         Events events = new Events();
         if (resp.size() == 0) {
             return events;

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBEventQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBEventQueryDAO.java
@@ -29,6 +29,7 @@ import org.apache.skywalking.banyandb.v1.client.DataPoint;
 import org.apache.skywalking.banyandb.v1.client.MeasureQuery;
 import org.apache.skywalking.banyandb.v1.client.MeasureQueryResponse;
 import org.apache.skywalking.banyandb.v1.client.PairQueryCondition;
+import org.apache.skywalking.oap.server.core.analysis.DownSampling;
 import org.apache.skywalking.oap.server.core.analysis.Layer;
 import org.apache.skywalking.oap.server.core.query.PaginationUtils;
 import org.apache.skywalking.oap.server.core.query.enumeration.Order;
@@ -40,6 +41,7 @@ import org.apache.skywalking.oap.server.core.query.type.event.Source;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Event;
 import org.apache.skywalking.oap.server.core.storage.query.IEventQueryDAO;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageClient;
+import org.apache.skywalking.oap.server.storage.plugin.banyandb.MetadataRegistry;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.stream.AbstractBanyanDBDAO;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -56,8 +58,9 @@ public class BanyanDBEventQueryDAO extends AbstractBanyanDBDAO implements IEvent
 
     @Override
     public Events queryEvents(EventQueryCondition condition) throws Exception {
-        MeasureQueryResponse resp = query(Event.INDEX_NAME, TAGS,
-                Collections.emptySet(), buildQuery(Collections.singletonList(condition)));
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(Event.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema, TAGS,
+                Collections.emptySet(), null, buildQuery(Collections.singletonList(condition)));
         Events events = new Events();
         if (resp.size() == 0) {
             return events;
@@ -70,8 +73,9 @@ public class BanyanDBEventQueryDAO extends AbstractBanyanDBDAO implements IEvent
 
     @Override
     public Events queryEvents(List<EventQueryCondition> conditionList) throws Exception {
-        MeasureQueryResponse resp = query(Event.INDEX_NAME, TAGS,
-                Collections.emptySet(), buildQuery(conditionList));
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(Event.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema, TAGS,
+                Collections.emptySet(), null, buildQuery(conditionList));
         Events events = new Events();
         if (resp.size() == 0) {
             return events;

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBHierarchyQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBHierarchyQueryDAO.java
@@ -62,7 +62,7 @@ public class BanyanDBHierarchyQueryDAO extends AbstractBanyanDBDAO implements IH
         MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ServiceHierarchyRelationTraffic.INDEX_NAME, DownSampling.Minute);
         MeasureQueryResponse resp = query(schema,
                                           SERVICE_HIERARCHY_RELATION_TAGS,
-                                          Collections.emptySet(), null, new QueryBuilder<>() {
+                                          Collections.emptySet(), new QueryBuilder<>() {
                 @Override
                 protected void apply(MeasureQuery query) {
                 }
@@ -85,7 +85,7 @@ public class BanyanDBHierarchyQueryDAO extends AbstractBanyanDBDAO implements IH
         MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ServiceHierarchyRelationTraffic.INDEX_NAME, DownSampling.Minute);
         MeasureQueryResponse resp = query(schema,
                                               INSTANCE_HIERARCHY_RELATION_TAGS,
-                                          Collections.emptySet(), null, buildInstanceRelationsQuery(instanceId, layer)
+                                          Collections.emptySet(), buildInstanceRelationsQuery(instanceId, layer)
         );
 
         List<InstanceHierarchyRelationTraffic> relations = new ArrayList<>();

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBHierarchyQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBHierarchyQueryDAO.java
@@ -59,9 +59,10 @@ public class BanyanDBHierarchyQueryDAO extends AbstractBanyanDBDAO implements IH
 
     @Override
     public List<ServiceHierarchyRelationTraffic> readAllServiceHierarchyRelations() throws Exception {
-        MeasureQueryResponse resp = query(ServiceHierarchyRelationTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ServiceHierarchyRelationTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                                           SERVICE_HIERARCHY_RELATION_TAGS,
-                                          Collections.emptySet(), new QueryBuilder<>() {
+                                          Collections.emptySet(), null, new QueryBuilder<>() {
                 @Override
                 protected void apply(MeasureQuery query) {
                 }
@@ -69,8 +70,6 @@ public class BanyanDBHierarchyQueryDAO extends AbstractBanyanDBDAO implements IH
         );
 
         final List<ServiceHierarchyRelationTraffic> relations = new ArrayList<>();
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(
-            ServiceHierarchyRelationTraffic.INDEX_NAME, DownSampling.Minute);
 
         for (final DataPoint dataPoint : resp.getDataPoints()) {
             relations.add(new ServiceHierarchyRelationTraffic.Builder().storage2Entity(
@@ -83,14 +82,13 @@ public class BanyanDBHierarchyQueryDAO extends AbstractBanyanDBDAO implements IH
     @Override
     public List<InstanceHierarchyRelationTraffic> readInstanceHierarchyRelations(final String instanceId,
                                                                                  final String layer) throws Exception {
-        MeasureQueryResponse resp = query(InstanceHierarchyRelationTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ServiceHierarchyRelationTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                                               INSTANCE_HIERARCHY_RELATION_TAGS,
-                                          Collections.emptySet(), buildInstanceRelationsQuery(instanceId, layer)
+                                          Collections.emptySet(), null, buildInstanceRelationsQuery(instanceId, layer)
         );
 
         List<InstanceHierarchyRelationTraffic> relations = new ArrayList<>();
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(
-            InstanceHierarchyRelationTraffic.INDEX_NAME, DownSampling.Minute);
         for (final DataPoint dataPoint : resp.getDataPoints()) {
             relations.add(new InstanceHierarchyRelationTraffic.Builder().storage2Entity(
                 new BanyanDBConverter.StorageToMeasure(schema, dataPoint)));

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetadataQueryDAO.java
@@ -86,17 +86,17 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
 
     @Override
     public List<Service> listServices() throws IOException {
-        MeasureQueryResponse resp = query(ServiceTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ServiceTraffic.INDEX_NAME, DownSampling.Minute);
+
+        MeasureQueryResponse resp = query(schema,
                 SERVICE_TRAFFIC_TAGS,
-                Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
+                Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
                     }
                 });
 
         final List<Service> services = new ArrayList<>();
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ServiceTraffic.INDEX_NAME, DownSampling.Minute);
-
         for (final DataPoint dataPoint : resp.getDataPoints()) {
             services.add(buildService(dataPoint, schema));
         }
@@ -110,7 +110,8 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         if (duration != null) {
             timestampRange = new TimestampRange(0, duration.getEndTimestamp());
         }
-        MeasureQueryResponse resp = query(InstanceTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(InstanceTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 INSTANCE_TRAFFIC_TAGS,
                 Collections.emptySet(),
                 timestampRange,
@@ -126,7 +127,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                 });
 
         final List<ServiceInstance> instances = new ArrayList<>();
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(InstanceTraffic.INDEX_NAME, DownSampling.Minute);
         for (final DataPoint dataPoint : resp.getDataPoints()) {
             instances.add(buildInstance(dataPoint, schema));
         }
@@ -137,9 +137,11 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
     @Override
     public ServiceInstance getInstance(String instanceId) throws IOException {
         IDManager.ServiceInstanceID.InstanceIDDefinition id = IDManager.ServiceInstanceID.analysisId(instanceId);
-        MeasureQueryResponse resp = query(InstanceTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(InstanceTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 INSTANCE_TRAFFIC_TAGS,
                 Collections.emptySet(),
+                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -147,15 +149,16 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                                 .and(eq(InstanceTraffic.NAME, id.getName()));
                     }
                 });
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(InstanceTraffic.INDEX_NAME, DownSampling.Minute);
         return resp.size() > 0 ? buildInstance(resp.getDataPoints().get(0), schema) : null;
     }
 
     @Override
     public List<ServiceInstance> getInstances(List<String> instanceIds) throws IOException {
-        MeasureQueryResponse resp = query(InstanceTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(InstanceTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 INSTANCE_TRAFFIC_TAGS,
                 Collections.emptySet(),
+                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -169,15 +172,16 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                         query.criteria(or(instanceRelationsQueryConditions));
                     }
                 });
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(InstanceTraffic.INDEX_NAME, DownSampling.Minute);
         return resp.getDataPoints().stream().map(e -> buildInstance(e, schema)).collect(Collectors.toList());
     }
 
     @Override
     public List<Endpoint> findEndpoint(String keyword, String serviceId, int limit) throws IOException {
-        MeasureQueryResponse resp = query(EndpointTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(EndpointTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 ENDPOINT_TRAFFIC_TAGS,
                 Collections.emptySet(),
+                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -188,7 +192,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                 });
 
         final List<Endpoint> endpoints = new ArrayList<>();
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(EndpointTraffic.INDEX_NAME, DownSampling.Minute);
         for (final DataPoint dataPoint : resp.getDataPoints()) {
             endpoints.add(buildEndpoint(dataPoint, schema));
         }
@@ -201,9 +204,11 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
 
     @Override
     public List<Process> listProcesses(String serviceId, ProfilingSupportStatus supportStatus, long lastPingStartTimeBucket, long lastPingEndTimeBucket) throws IOException {
-        MeasureQueryResponse resp = query(ProcessTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
+                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -222,7 +227,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                 });
 
         final List<Process> processes = new ArrayList<>();
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
         for (final DataPoint dataPoint : resp.getDataPoints()) {
             processes.add(buildProcess(dataPoint, schema));
         }
@@ -232,10 +236,12 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
 
     @Override
     public List<Process> listProcesses(String serviceInstanceId, Duration duration, boolean includeVirtual) throws IOException {
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
         long lastPingStartTimeBucket = duration.getStartTimeBucket();
-        MeasureQueryResponse resp = query(ProcessTraffic.INDEX_NAME,
+        MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
+                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -248,7 +254,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                 });
 
         final List<Process> processes = new ArrayList<>();
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
         for (final DataPoint dataPoint : resp.getDataPoints()) {
             processes.add(buildProcess(dataPoint, schema));
         }
@@ -258,9 +263,11 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
 
     @Override
     public List<Process> listProcesses(String agentId) throws IOException {
-        MeasureQueryResponse resp = query(ProcessTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
+                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -270,7 +277,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                 });
 
         final List<Process> processes = new ArrayList<>();
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
         for (final DataPoint dataPoint : resp.getDataPoints()) {
             processes.add(buildProcess(dataPoint, schema));
         }
@@ -280,9 +286,11 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
 
     @Override
     public long getProcessCount(String serviceId, ProfilingSupportStatus profilingSupportStatus, long lastPingStartTimeBucket, long lastPingEndTimeBucket) throws IOException {
-        MeasureQueryResponse resp = query(ProcessTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
+                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -301,9 +309,11 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
 
     @Override
     public long getProcessCount(String instanceId) throws IOException {
-        MeasureQueryResponse resp = query(ProcessTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
+                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -320,9 +330,11 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
 
     @Override
     public Process getProcess(String processId) throws IOException {
-        MeasureQueryResponse resp = query(ProcessTraffic.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
+                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -331,7 +343,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
                         }
                     }
                 });
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ProcessTraffic.INDEX_NAME, DownSampling.Minute);
 
         return resp.size() > 0 ? buildProcess(resp.getDataPoints().get(0), schema) : null;
     }

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetadataQueryDAO.java
@@ -90,7 +90,7 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
 
         MeasureQueryResponse resp = query(schema,
                 SERVICE_TRAFFIC_TAGS,
-                Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
+                Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
                     }
@@ -141,7 +141,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         MeasureQueryResponse resp = query(schema,
                 INSTANCE_TRAFFIC_TAGS,
                 Collections.emptySet(),
-                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -158,7 +157,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         MeasureQueryResponse resp = query(schema,
                 INSTANCE_TRAFFIC_TAGS,
                 Collections.emptySet(),
-                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -181,7 +179,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         MeasureQueryResponse resp = query(schema,
                 ENDPOINT_TRAFFIC_TAGS,
                 Collections.emptySet(),
-                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -208,7 +205,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
-                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -241,7 +237,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
-                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -267,7 +262,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
-                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -290,7 +284,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
-                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -313,7 +306,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
-                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {
@@ -334,7 +326,6 @@ public class BanyanDBMetadataQueryDAO extends AbstractBanyanDBDAO implements IMe
         MeasureQueryResponse resp = query(schema,
                 PROCESS_TRAFFIC_TAGS,
                 Collections.emptySet(),
-                null,
                 new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(MeasureQuery query) {

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetricsDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetricsDAO.java
@@ -125,7 +125,7 @@ public class BanyanDBMetricsDAO extends AbstractBanyanDBDAO implements IMetricsD
         }
 
         List<Metrics> metricsInStorage = new ArrayList<>(metrics.size());
-        MeasureQueryResponse resp = query(model.getName(), schema.getTags(), schema.getFields(), timestampRange, new QueryBuilder<MeasureQuery>() {
+        MeasureQueryResponse resp = query(schema, schema.getTags(), schema.getFields(), timestampRange, new QueryBuilder<MeasureQuery>() {
                 @Override
             protected void apply(MeasureQuery query) {
                 seriesIDColumns.entrySet().forEach(entry -> {

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBNetworkAddressAliasDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBNetworkAddressAliasDAO.java
@@ -65,7 +65,6 @@ public class BanyanDBNetworkAddressAliasDAO extends AbstractBanyanDBDAO implemen
                     getSchema(),
                     TAGS,
                     Collections.emptySet(),
-                    null,
                     new QueryBuilder<MeasureQuery>() {
                         @Override
                         protected void apply(final MeasureQuery query) {

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBNetworkAddressAliasDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBNetworkAddressAliasDAO.java
@@ -62,9 +62,10 @@ public class BanyanDBNetworkAddressAliasDAO extends AbstractBanyanDBDAO implemen
     public List<NetworkAddressAlias> loadLastUpdate(long timeBucket) {
         try {
             MeasureQueryResponse resp = query(
-                    NetworkAddressAlias.INDEX_NAME,
+                    getSchema(),
                     TAGS,
                     Collections.emptySet(),
+                    null,
                     new QueryBuilder<MeasureQuery>() {
                         @Override
                         protected void apply(final MeasureQuery query) {

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBServiceLabelDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBServiceLabelDAO.java
@@ -27,9 +27,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.skywalking.banyandb.v1.client.MeasureQuery;
+import org.apache.skywalking.oap.server.core.analysis.DownSampling;
+import org.apache.skywalking.oap.server.core.analysis.manual.instance.InstanceTraffic;
 import org.apache.skywalking.oap.server.core.analysis.manual.process.ServiceLabelRecord;
 import org.apache.skywalking.oap.server.core.storage.profiling.ebpf.IServiceLabelDAO;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageClient;
+import org.apache.skywalking.oap.server.storage.plugin.banyandb.MetadataRegistry;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.stream.AbstractBanyanDBDAO;
 
 public class BanyanDBServiceLabelDAO extends AbstractBanyanDBDAO implements IServiceLabelDAO {
@@ -41,8 +44,9 @@ public class BanyanDBServiceLabelDAO extends AbstractBanyanDBDAO implements ISer
 
     @Override
     public List<String> queryAllLabels(String serviceId) throws IOException {
-        return query(ServiceLabelRecord.INDEX_NAME, TAGS,
-                Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(InstanceTraffic.INDEX_NAME, DownSampling.Minute);
+        return query(schema, TAGS,
+                Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(final MeasureQuery query) {
                         query.and(eq(ServiceLabelRecord.SERVICE_ID, serviceId));

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBServiceLabelDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBServiceLabelDAO.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 
 import org.apache.skywalking.banyandb.v1.client.MeasureQuery;
 import org.apache.skywalking.oap.server.core.analysis.DownSampling;
-import org.apache.skywalking.oap.server.core.analysis.manual.instance.InstanceTraffic;
 import org.apache.skywalking.oap.server.core.analysis.manual.process.ServiceLabelRecord;
 import org.apache.skywalking.oap.server.core.storage.profiling.ebpf.IServiceLabelDAO;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageClient;
@@ -44,9 +43,9 @@ public class BanyanDBServiceLabelDAO extends AbstractBanyanDBDAO implements ISer
 
     @Override
     public List<String> queryAllLabels(String serviceId) throws IOException {
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(InstanceTraffic.INDEX_NAME, DownSampling.Minute);
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ServiceLabelRecord.INDEX_NAME, DownSampling.Minute);
         return query(schema, TAGS,
-                Collections.emptySet(), null, new QueryBuilder<MeasureQuery>() {
+                Collections.emptySet(), new QueryBuilder<MeasureQuery>() {
                     @Override
                     protected void apply(final MeasureQuery query) {
                         query.and(eq(ServiceLabelRecord.SERVICE_ID, serviceId));

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBTagAutocompleteQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBTagAutocompleteQueryDAO.java
@@ -23,12 +23,14 @@ import org.apache.skywalking.banyandb.v1.client.DataPoint;
 import org.apache.skywalking.banyandb.v1.client.MeasureQuery;
 import org.apache.skywalking.banyandb.v1.client.MeasureQueryResponse;
 import org.apache.skywalking.banyandb.v1.client.TimestampRange;
+import org.apache.skywalking.oap.server.core.analysis.DownSampling;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.analysis.manual.searchtag.TagAutocompleteData;
 import org.apache.skywalking.oap.server.core.analysis.manual.searchtag.TagType;
 import org.apache.skywalking.oap.server.core.query.input.Duration;
 import org.apache.skywalking.oap.server.core.storage.query.ITagAutoCompleteQueryDAO;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageClient;
+import org.apache.skywalking.oap.server.storage.plugin.banyandb.MetadataRegistry;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.stream.AbstractBanyanDBDAO;
 
 import java.io.IOException;
@@ -51,6 +53,7 @@ public class BanyanDBTagAutocompleteQueryDAO extends AbstractBanyanDBDAO impleme
 
     @Override
     public Set<String> queryTagAutocompleteKeys(TagType tagType, int limit, Duration duration) throws IOException {
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(TagAutocompleteData.INDEX_NAME, DownSampling.Minute);
         long startTB = 0;
         long endTB = 0;
         if (nonNull(duration)) {
@@ -61,7 +64,7 @@ public class BanyanDBTagAutocompleteQueryDAO extends AbstractBanyanDBDAO impleme
         if (startTB > 0 && endTB > 0) {
             range = new TimestampRange(TimeBucket.getTimestamp(startTB), TimeBucket.getTimestamp(endTB));
         }
-        MeasureQueryResponse resp = query(TagAutocompleteData.INDEX_NAME,
+        MeasureQueryResponse resp = query(schema,
                 TAGS_KEY, Collections.emptySet(),
                 range,
                 new QueryBuilder<MeasureQuery>() {
@@ -87,6 +90,7 @@ public class BanyanDBTagAutocompleteQueryDAO extends AbstractBanyanDBDAO impleme
 
     @Override
     public Set<String> queryTagAutocompleteValues(TagType tagType, String tagKey, int limit, Duration duration) throws IOException {
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(TagAutocompleteData.INDEX_NAME, DownSampling.Minute);
         long startSecondTB = 0;
         long endSecondTB = 0;
         if (nonNull(duration)) {
@@ -101,7 +105,7 @@ public class BanyanDBTagAutocompleteQueryDAO extends AbstractBanyanDBDAO impleme
         if (startTB > 0 && endTB > 0) {
             range = new TimestampRange(TimeBucket.getTimestamp(startTB), TimeBucket.getTimestamp(endTB));
         }
-        MeasureQueryResponse resp = query(TagAutocompleteData.INDEX_NAME,
+        MeasureQueryResponse resp = query(schema,
                 TAGS_KV, Collections.emptySet(),
                 range,
                 new QueryBuilder<MeasureQuery>() {

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBTopologyQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBTopologyQueryDAO.java
@@ -34,7 +34,6 @@ import org.apache.skywalking.banyandb.v1.client.MeasureQuery;
 import org.apache.skywalking.banyandb.v1.client.MeasureQueryResponse;
 import org.apache.skywalking.banyandb.v1.client.TimestampRange;
 import org.apache.skywalking.oap.server.core.UnexpectedException;
-import org.apache.skywalking.oap.server.core.analysis.DownSampling;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.analysis.manual.relation.endpoint.EndpointRelationServerSideMetrics;
 import org.apache.skywalking.oap.server.core.analysis.manual.relation.instance.ServiceInstanceRelationClientSideMetrics;
@@ -205,7 +204,7 @@ public class BanyanDBTopologyQueryDAO extends AbstractBanyanDBDAO implements ITo
         }
         final String modelName = detectPoint == DetectPoint.SERVER ? ServiceInstanceRelationServerSideMetrics.INDEX_NAME :
                 ServiceInstanceRelationClientSideMetrics.INDEX_NAME;
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(modelName, DownSampling.Minute);
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(modelName, duration.getStep());
         MeasureQueryResponse resp = query(schema,
                 ImmutableSet.of(
                         Metrics.ENTITY_ID
@@ -269,7 +268,7 @@ public class BanyanDBTopologyQueryDAO extends AbstractBanyanDBDAO implements ITo
         if (startTB > 0 && endTB > 0) {
             timestampRange = new TimestampRange(TimeBucket.getTimestamp(startTB), TimeBucket.getTimestamp(endTB));
         }
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(EndpointRelationServerSideMetrics.INDEX_NAME, DownSampling.Minute);
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(EndpointRelationServerSideMetrics.INDEX_NAME, duration.getStep());
         MeasureQueryResponse resp = query(schema,
                 ImmutableSet.of(
                         Metrics.ENTITY_ID
@@ -304,7 +303,7 @@ public class BanyanDBTopologyQueryDAO extends AbstractBanyanDBDAO implements ITo
         }
         final String modelName = detectPoint == DetectPoint.SERVER ? ProcessRelationServerSideMetrics.INDEX_NAME :
                 ProcessRelationClientSideMetrics.INDEX_NAME;
-        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(modelName, DownSampling.Minute);
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(modelName, duration.getStep());
         MeasureQueryResponse resp = query(schema,
                 ImmutableSet.of(Metrics.ENTITY_ID, ProcessRelationClientSideMetrics.COMPONENT_ID),
                 Collections.emptySet(), timestampRange, new QueryBuilder<MeasureQuery>() {

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBTopologyQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBTopologyQueryDAO.java
@@ -34,6 +34,7 @@ import org.apache.skywalking.banyandb.v1.client.MeasureQuery;
 import org.apache.skywalking.banyandb.v1.client.MeasureQueryResponse;
 import org.apache.skywalking.banyandb.v1.client.TimestampRange;
 import org.apache.skywalking.oap.server.core.UnexpectedException;
+import org.apache.skywalking.oap.server.core.analysis.DownSampling;
 import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
 import org.apache.skywalking.oap.server.core.analysis.manual.relation.endpoint.EndpointRelationServerSideMetrics;
 import org.apache.skywalking.oap.server.core.analysis.manual.relation.instance.ServiceInstanceRelationClientSideMetrics;
@@ -50,6 +51,7 @@ import org.apache.skywalking.oap.server.core.source.DetectPoint;
 import org.apache.skywalking.oap.server.core.storage.query.ITopologyQueryDAO;
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageClient;
+import org.apache.skywalking.oap.server.storage.plugin.banyandb.MetadataRegistry;
 import org.apache.skywalking.oap.server.storage.plugin.banyandb.stream.AbstractBanyanDBDAO;
 
 import static java.util.Objects.nonNull;
@@ -120,8 +122,8 @@ public class BanyanDBTopologyQueryDAO extends AbstractBanyanDBDAO implements ITo
         }
         final String modelName = detectPoint == DetectPoint.SERVER ? ServiceRelationServerSideMetrics.INDEX_NAME :
                 ServiceRelationClientSideMetrics.INDEX_NAME;
-
-        MeasureQueryResponse resp = query(modelName,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(modelName, duration.getStep());
+        MeasureQueryResponse resp = queryDebuggable(schema,
                 ImmutableSet.of(
                         ServiceRelationClientSideMetrics.COMPONENT_IDS,
                         Metrics.ENTITY_ID
@@ -203,8 +205,8 @@ public class BanyanDBTopologyQueryDAO extends AbstractBanyanDBDAO implements ITo
         }
         final String modelName = detectPoint == DetectPoint.SERVER ? ServiceInstanceRelationServerSideMetrics.INDEX_NAME :
                 ServiceInstanceRelationClientSideMetrics.INDEX_NAME;
-
-        MeasureQueryResponse resp = query(modelName,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(modelName, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 ImmutableSet.of(
                         Metrics.ENTITY_ID
                 ),
@@ -267,8 +269,8 @@ public class BanyanDBTopologyQueryDAO extends AbstractBanyanDBDAO implements ITo
         if (startTB > 0 && endTB > 0) {
             timestampRange = new TimestampRange(TimeBucket.getTimestamp(startTB), TimeBucket.getTimestamp(endTB));
         }
-
-        MeasureQueryResponse resp = query(EndpointRelationServerSideMetrics.INDEX_NAME,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(EndpointRelationServerSideMetrics.INDEX_NAME, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 ImmutableSet.of(
                         Metrics.ENTITY_ID
                 ),
@@ -302,8 +304,8 @@ public class BanyanDBTopologyQueryDAO extends AbstractBanyanDBDAO implements ITo
         }
         final String modelName = detectPoint == DetectPoint.SERVER ? ProcessRelationServerSideMetrics.INDEX_NAME :
                 ProcessRelationClientSideMetrics.INDEX_NAME;
-
-        MeasureQueryResponse resp = query(modelName,
+        MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(modelName, DownSampling.Minute);
+        MeasureQueryResponse resp = query(schema,
                 ImmutableSet.of(Metrics.ENTITY_ID, ProcessRelationClientSideMetrics.COMPONENT_ID),
                 Collections.emptySet(), timestampRange, new QueryBuilder<MeasureQuery>() {
                     @Override

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/stream/AbstractBanyanDBDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/stream/AbstractBanyanDBDAO.java
@@ -204,6 +204,13 @@ public abstract class AbstractBanyanDBDAO extends AbstractDAO<BanyanDBStorageCli
         }
     }
 
+    protected MeasureQueryResponse query(MetadataRegistry.Schema schema,
+                                         Set<String> tags,
+                                         Set<String> fields,
+                                         QueryBuilder<MeasureQuery> builder) throws IOException {
+        return query(schema, tags, fields, null, builder);
+    }
+
     protected MeasureQueryResponse query(MetadataRegistry.Schema schema, Set<String> tags, Set<String> fields,
                                          TimestampRange timestampRange, QueryBuilder<MeasureQuery> builder) throws IOException {
         if (schema == null) {


### PR DESCRIPTION
This bug will make OAP always query Minutes dimension metrics from BanyanDB no matter the Duration is. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
