### PR TITLE
Fix expression of graph `Current QPS` in MySQL dashboard.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -28,6 +28,7 @@
 * BanyanDB client config: rise the default `maxBulkSize` to 10000, add `flushTimeout` and set default to 10s.
 * Polish BanyanDB group and schema creation logic to fix the schema creation failure issue in distributed race conditions.
 * Support tracing topology query for debugging.
+* Fix expression of graph `Current QPS` in MySQL dashboard.
 
 #### UI
 * Highlight search log keywords.

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/mysql/mysql-instance.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/mysql/mysql-instance.json
@@ -52,7 +52,7 @@
             }
           ],
           "expressions": [
-            "avg(meter_mysql_instance_qps)"
+            "meter_mysql_instance_qps"
           ]
         },
         {


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix expression of graph `Current QPS` in MySQL dashboard.
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

`Current QPS` is a line graph, so I removed avg function in expression.
![image](https://github.com/apache/skywalking/assets/16346644/586079b4-3a47-45d8-9570-c4e989336c5d)

