### PR TITLE
Enhance cilium fetcher with rules

### DIFF
--- a/apm-dist/src/main/assembly/binary.xml
+++ b/apm-dist/src/main/assembly/binary.xml
@@ -72,6 +72,7 @@
                 <include>lal/*</include>
                 <include>log-mal-rules/**</include>
                 <include>telegraf-rules/*</include>
+                <include>cilium-rules/*</include>
             </includes>
             <outputDirectory>config</outputDirectory>
         </fileSet>

--- a/docs/en/concepts-and-designs/service-hierarchy-configuration.md
+++ b/docs/en/concepts-and-designs/service-hierarchy-configuration.md
@@ -53,6 +53,7 @@ layer-levels:
   MYSQL: 2
   POSTGRESQL: 2
   MESH_DP: 1
+  CILIUM_SERVICE: 1
   K8S_SERVICE: 0
 ```
 

--- a/docs/en/setup/backend/backend-k8s-monitoring-cilium.md
+++ b/docs/en/setup/backend/backend-k8s-monitoring-cilium.md
@@ -48,7 +48,10 @@ namespaces:   # define with traffic from which namespace should be excluded
 
 labels:       # define with traffic from which endpoint labels should be excluded, if matches any labels, the traffic would be excluded.
    - k8s:io.cilium.k8s.namespace.labels.istio-injection: "enabled" # Each labels is a key-value pair, the key is the label key, the value is the label value.
+     k8s:security.istio.io/tlsMode: istio
 ```
+
+By default, all the traffic from `kube-system` and traffic management by istio mesh would be excluded.
 
 NOTE: Only the endpoint in both source and destination matches the exclude rules would be excluded. Otherwise, the traffic would be still included.
 

--- a/docs/en/setup/backend/backend-k8s-monitoring-cilium.md
+++ b/docs/en/setup/backend/backend-k8s-monitoring-cilium.md
@@ -34,6 +34,23 @@ cilium-fetcher:
    3. `sslPrivateKeyFile`: the path of the private key file.
    4. `sslCertChainFile`: the path of the certificate chain file.
    5. `sslCaFile`: the path of the CA file.
+3. Configure the cilium rules please configure the following configuration:
+   1. `cilium-rules/exclude.yaml`: Configure the which endpoint should be excluded from the monitoring, Please read [exclude rules selection](#exclude-rules) for more detail.
+   2. `cilium-rules/metadata-service-mapping.yaml`: Configure the service name and endpoint mapping.
+
+### Exclude Rules
+
+The exclude configuration in Cilium rules is used to specify which Cilium Endpoints would be excluded from being added to the topology map or from the generation of metrics and other data.
+
+```yaml
+namespaces:   # define with traffic from which namespace should be excluded
+   - kube-system
+
+labels:       # define with traffic from which endpoint labels should be excluded, if matches any labels, the traffic would be excluded.
+   - k8s:io.cilium.k8s.namespace.labels.istio-injection: "enabled" # Each labels is a key-value pair, the key is the label key, the value is the label value.
+```
+
+NOTE: Only the endpoint in both source and destination matches the exclude rules would be excluded. Otherwise, the traffic would be still included.
 
 ## Generated Entities
 

--- a/oap-server/server-fetcher-plugin/cilium-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/fetcher/cilium/ExcludeRules.java
+++ b/oap-server/server-fetcher-plugin/cilium-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/fetcher/cilium/ExcludeRules.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.fetcher.cilium;
+
+import io.cilium.api.flow.Endpoint;
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.skywalking.oap.server.library.util.ResourceUtils;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ExcludeRules {
+
+    private final Set<String> namespaces;
+    private final List<Labels> labels;
+
+    public static ExcludeRules loadRules(final String path) throws IOException {
+        try (FileReader r = new FileReader(ResourceUtils.getPath(path).toFile())) {
+            final RuleYaml yaml = new Yaml().loadAs(r, RuleYaml.class);
+            return new ExcludeRules(yaml);
+        }
+    }
+
+    /**
+     * check if the endpoint should be excluded
+     */
+    public boolean shouldExclude(Endpoint endpoint) {
+        // if the namespace is in the exclude list, return true
+        if (namespaces.contains(endpoint.getNamespace())) {
+            return true;
+        }
+        // if the endpoint has no labels, return false
+        if (endpoint.getLabelsCount() == 0) {
+            return false;
+        }
+        return labels.stream().anyMatch(label -> label.isMatch(endpoint));
+    }
+
+    private ExcludeRules(RuleYaml yaml) {
+        this.namespaces = Set.copyOf(yaml.getNamespaces());
+        this.labels = yaml.getLabels().stream().map(Labels::new).collect(Collectors.toList());
+    }
+
+    private static class Labels {
+        private Map<String, String> labelMap;
+
+        public Labels(Map<String, String> labelMap) {
+            this.labelMap = labelMap;
+        }
+
+        /**
+         * validate if the endpoint matches all the labels
+         */
+        public boolean isMatch(Endpoint endpoint) {
+            int matchCount = 0;
+            for (Map.Entry<String, String> entry : labelMap.entrySet()) {
+                for (String endpointLabel : endpoint.getLabelsList()) {
+                    // ignore when the key is not match
+                    if (endpointLabel.indexOf(entry.getKey()) != 0) {
+                        continue;
+                    }
+                    // ignore when the value is not match
+                    if (!StringUtils.substring(endpointLabel, entry.getKey().length() + 1).equals(entry.getValue())) {
+                        return false;
+                    }
+                    matchCount++;
+
+                    // check the match count(full matched) to avoid unnecessary iteration
+                    if (matchCount == labelMap.size()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+    @Data
+    public static class RuleYaml {
+        private List<String> namespaces;
+        private List<Map<String, String>> labels;
+    }
+}

--- a/oap-server/server-starter/pom.xml
+++ b/oap-server/server-starter/pom.xml
@@ -320,6 +320,7 @@
                         <exclude>lal/</exclude>
                         <exclude>log-mal-rules/</exclude>
                         <exclude>telegraf-rules/</exclude>
+                        <exclude>cilium-rules/</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/oap-server/server-starter/src/main/resources/cilium-rules/exclude.yaml
+++ b/oap-server/server-starter/src/main/resources/cilium-rules/exclude.yaml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+namespaces:
+    - kube-system
+
+labels:
+    - k8s:io.cilium.k8s.namespace.labels.istio-injection: enabled
+      k8s:security.istio.io/tlsMode: istio

--- a/oap-server/server-starter/src/main/resources/cilium-rules/metadata-service-mapping.yaml
+++ b/oap-server/server-starter/src/main/resources/cilium-rules/metadata-service-mapping.yaml
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+serviceName: ${LABELS."service.istio.io/canonical-name",LABELS."app.kubernetes.io/name",LABELS.component,LABELS.app,LABELS.k8s-app}.${NAMESPACE}
+serviceInstanceName: ${NAME}

--- a/oap-server/server-starter/src/main/resources/hierarchy-definition.yml
+++ b/oap-server/server-starter/src/main/resources/hierarchy-definition.yml
@@ -112,8 +112,7 @@ layer-levels:
   ACTIVEMQ: 2
 
   MESH_DP: 1
+  CILIUM_SERVICE: 1
 
   K8S_SERVICE: 0
-
-  CILIUM_SERVICE: 1
 

--- a/oap-server/server-starter/src/main/resources/hierarchy-definition.yml
+++ b/oap-server/server-starter/src/main/resources/hierarchy-definition.yml
@@ -74,6 +74,9 @@ hierarchy:
     KAFKA: lower-short-name-with-fqdn
     PULSAR: lower-short-name-with-fqdn
 
+  CILIUM_SERVICE:
+    K8S_SERVICE: short-name
+
 # Use Groovy script to define the matching rules, the input parameters are the upper service(u) and the lower service(l) and the return value is a boolean,
 # which are used to match the relation between the upper service(u) and the lower service(l) on the different layers.
 auto-matching-rules:
@@ -111,4 +114,6 @@ layer-levels:
   MESH_DP: 1
 
   K8S_SERVICE: 0
+
+  CILIUM_SERVICE: 1
 

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/cilium_service/cilium-service.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/cilium_service/cilium-service.json
@@ -554,7 +554,37 @@
             "layer": "CILIUM_SERVICE",
             "entity": "Service",
             "name": "Cilium-Service",
-            "isRoot": false
+            "isRoot": false,
+            "isDefault": true,
+            "expressions": [
+                "avg(cilium_service_l4_read_pkg_cpm)",
+                "avg(cilium_service_l4_write_pkg_cpm)",
+                "avg(cilium_service_protocol_cpm)",
+                "avg(cilium_service_protocol_call_duration/cilium_service_protocol_cpm)/1000000",
+                "avg(cilium_service_protocol_call_success_count/cilium_service_protocol_cpm*100)"
+            ],
+            "expressionsConfig": [
+                {
+                    "unit": "package / min",
+                    "label": "Read"
+                },
+                {
+                    "label": "Write",
+                    "unit": "package / min"
+                },
+                {
+                    "label": "Load",
+                    "unit": "calls / min"
+                },
+                {
+                    "label": "Latency",
+                    "unit": "ms"
+                },
+                {
+                    "label": "Success Rate",
+                    "unit": "%"
+                }
+            ]
         }
     }
 ]


### PR DESCRIPTION
Due to Cilium monitoring all services in the same cluster, and it will result in a large amount of unnecessary data. Therefore, the following parts have been introduced:
1. Exclusion policy: When meeting the exclusion policy criteria, some traffic will be ignored to reduce data generation.
2. Customize metadata: In previous designs, automatic use of ALS metadata mapping files was used; here we reuse a new metadata mapping file instead with unchanged rules.
3. Support for Hierarchy function provisioning: Allowing it to point towards Kubernetes monitoring in hierarchies

Since Cilium Fetcher is a new feature in this milestone and has already been added to the changelog, there's no need for re-addition.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
