### PR TITLE
Convert Kubernetes HTTP latency related metrics unit from ns to ms

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -31,6 +31,7 @@
 * Fix expression of graph `Current QPS` in MySQL dashboard.
 * Support tracing logs query for debugging.
 * BanyanDB: fix Tag autocomplete data storage and query.
+* Update the kubernetes HTTP latency related metrics source unit from `ns` to `ms`.
 
 #### UI
 * Highlight search log keywords.

--- a/docs/en/setup/backend/backend-k8s-monitoring-rover.md
+++ b/docs/en/setup/backend/backend-k8s-monitoring-rover.md
@@ -86,15 +86,15 @@ Based on each transfer data analysis, extract the information of the 7-layer net
 
 #### HTTP/1.x or HTTP/2.x
 
-| Name                 | Init        | Description                                      |
-|----------------------|-------------|--------------------------------------------------|
-| Call CPM             | Count       | HTTP Request calls per minutes.                  |
-| Duration             | Nanoseconds | Total HTTP Response use duration.                |
-| Success CPM          | Count       | Total HTTP Response success(status < 500) count. |
-| Request Header Size  | Bytes       | Total Request Header size.                       |
-| Request Body Size    | Bytes       | Total Request Body size.                         |
-| Response Header Size | Bytes       | Total Response Header size.                      |
-| Response Body Size   | Bytes       | Total Response Body size.                        |
+| Name                 | Init         | Description                                      |
+|----------------------|--------------|--------------------------------------------------|
+| Call CPM             | Count        | HTTP Request calls per minutes.                  |
+| Duration             | Milliseconds | Total HTTP Response use duration.                |
+| Success CPM          | Count        | Total HTTP Response success(status < 500) count. |
+| Request Header Size  | Bytes        | Total Request Header size.                       |
+| Request Body Size    | Bytes        | Total Request Body size.                         |
+| Response Header Size | Bytes        | Total Response Header size.                      |
+| Response Body Size   | Bytes        | Total Response Body size.                        |
 
 ## Customizations
 You can customize your own metrics/dashboard panel.

--- a/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/AccessLogServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/AccessLogServiceHandler.java
@@ -300,7 +300,8 @@ public class AccessLogServiceHandler extends EBPFAccessLogServiceGrpc.EBPFAccess
                 protocol.setHttp(new K8SMetrics.ProtocolHTTP());
                 protocol.setSuccess(success);
 
-                protocol.getHttp().setLatency(getDurationFromTimestamp(node, http.getStartTime(), http.getEndTime()));
+                duration = convertNsToMs(getDurationFromTimestamp(node, http.getStartTime(), http.getEndTime()));
+                protocol.getHttp().setLatency(duration);
                 protocol.getHttp().setUrl(http.getRequest().getPath());
                 protocol.getHttp().setMethod(http.getRequest().getMethod().name());
                 protocol.getHttp().setStatusCode(http.getResponse().getStatusCode());
@@ -308,7 +309,6 @@ public class AccessLogServiceHandler extends EBPFAccessLogServiceGrpc.EBPFAccess
                 protocol.getHttp().setSizeOfRequestBody(http.getRequest().getSizeOfBodyBytes());
                 protocol.getHttp().setSizeOfResponseHeader(http.getResponse().getSizeOfHeadersBytes());
                 protocol.getHttp().setSizeOfResponseBody(http.getResponse().getSizeOfBodyBytes());
-                duration = protocol.getHttp().getLatency();
                 break;
         }
 
@@ -715,5 +715,9 @@ public class AccessLogServiceHandler extends EBPFAccessLogServiceGrpc.EBPFAccess
         public void increaseCount() {
             count.incrementAndGet();
         }
+    }
+
+    protected long convertNsToMs(long latency) {
+        return TimeUnit.NANOSECONDS.toMillis(latency);
     }
 }

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Endpoint.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Endpoint.json
@@ -64,7 +64,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_endpoint_http_call_duration/kubernetes_service_endpoint_http_call_cpm/1000000"
+                    "kubernetes_service_endpoint_http_call_duration/kubernetes_service_endpoint_http_call_cpm"
                   ],
                   "metricConfig": [
                     {

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Service-Instance-Relation.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Service-Instance-Relation.json
@@ -3286,7 +3286,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_client_http_call_duration/kubernetes_service_instance_relation_client_http_call_cpm/1000000"
+                    "kubernetes_service_instance_relation_client_http_call_duration/kubernetes_service_instance_relation_client_http_call_cpm"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3400,7 +3400,7 @@
                   "i": "3",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_server_http_call_duration/kubernetes_service_instance_relation_server_http_call_cpm/1000000"
+                    "kubernetes_service_instance_relation_server_http_call_duration/kubernetes_service_instance_relation_server_http_call_cpm"
                   ],
                   "graph": {
                     "type": "Line",

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Service-Relation.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Service-Relation.json
@@ -3286,7 +3286,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_client_http_call_cpm/1000000"
+                    "kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_client_http_call_cpm"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3400,7 +3400,7 @@
                   "i": "3",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_server_http_call_cpm/1000000"
+                    "kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_server_http_call_cpm"
                   ],
                   "graph": {
                     "type": "Line",

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-pod.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-pod.json
@@ -1336,7 +1336,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm/1000000"
+                    "kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm"
                   ],
                   "metricConfig": [
                     {
@@ -1533,7 +1533,7 @@
         "avg(kubernetes_service_instance_write_package_size)/60",
         "avg(kubernetes_service_instance_read_package_size)/60",
         "avg(kubernetes_service_instance_http_call_cpm)",
-        "avg(kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm/1000000)",
+        "avg(kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm)",
         "avg(kubernetes_service_instance_http_call_success_count / kubernetes_service_instance_http_call_cpm*100)"
       ],
       "expressionsConfig": [

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-root.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-root.json
@@ -104,19 +104,19 @@
                     "avg(kubernetes_service_relation_server_write_package_size)/60",
                     "avg(kubernetes_service_relation_server_read_package_size)/60",
                     "avg(kubernetes_service_relation_client_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_client_http_call_cpm)/1000000"
+                    "avg(kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_client_http_call_cpm)"
                   ],
                   "linkClientExpressions": [
                     "avg(kubernetes_service_relation_client_write_package_size)/60",
                     "avg(kubernetes_service_relation_client_read_package_size)/60",
                     "avg(kubernetes_service_relation_server_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_server_http_call_cpm)/1000000"
+                    "avg(kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_server_http_call_cpm)"
                   ],
                   "nodeExpressions": [
                     "avg(kubernetes_service_write_package_size)/60",
                     "avg(kubernetes_service_read_package_size)/60",
                     "avg(kubernetes_service_http_call_cpm)",
-                    "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)/1000000",
+                    "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)",
                     "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
                   ],
                   "legendMQE": {

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
@@ -220,19 +220,19 @@
                     "avg(kubernetes_service_relation_server_write_package_size)/60",
                     "avg(kubernetes_service_relation_server_read_package_size)/60",
                     "avg(kubernetes_service_relation_server_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_client_http_call_cpm)/1000000"
+                    "avg(kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_client_http_call_cpm)"
                   ],
                   "linkClientExpressions": [
                     "avg(kubernetes_service_relation_client_write_package_size)/60",
                     "avg(kubernetes_service_relation_client_read_package_size)/60",
                     "avg(kubernetes_service_relation_client_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_server_http_call_cpm)/1000000"
+                    "avg(kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_server_http_call_cpm)"
                   ],
                   "nodeExpressions": [
                     "avg(kubernetes_service_write_package_size)/60",
                     "avg(kubernetes_service_read_package_size)/60",
                     "avg(kubernetes_service_http_call_cpm)",
-                    "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)/1000000",
+                    "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)",
                     "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
                   ],
                   "legendMQE": {
@@ -1601,7 +1601,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm/1000000"
+                    "kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm"
                   ],
                   "metricConfig": [
                     {
@@ -1818,7 +1818,7 @@
                   ],
                   "expressions": [
                     "latest(kubernetes_service_instance_http_call_cpm)",
-                    "latest(kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm)/1000000",
+                    "latest(kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm)",
                     "latest(kubernetes_service_instance_http_call_success_count/kubernetes_service_instance_http_call_cpm*100)"
                   ]
                 }
@@ -1861,12 +1861,12 @@
                   "expressions": [
                     "avg(kubernetes_service_endpoint_call_cpm)",
                     "avg(kubernetes_service_endpoint_call_success_cpm/kubernetes_service_endpoint_call_cpm*100)",
-                    "avg(kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm/1000000)"
+                    "avg(kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm)"
                   ],
                   "subExpressions": [
                     "kubernetes_service_endpoint_call_cpm",
                     "kubernetes_service_endpoint_call_success_cpm/kubernetes_service_endpoint_call_cpm*100",
-                    "kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm/1000000"
+                    "kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm"
                   ]
                 }
               ]
@@ -1915,7 +1915,7 @@
         "avg(kubernetes_service_write_package_size)/60",
         "avg(kubernetes_service_read_package_size)/60",
         "avg(kubernetes_service_http_call_cpm)",
-        "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm/1000000)",
+        "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)",
         "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
       ],
       "expressionsConfig": [


### PR DESCRIPTION
Change the latency metric of HTTP Source in Kubernetes from nanoseconds to milliseconds, to reduce overflow due to large values.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
