### PR TITLE
Fix the unit of the "Network Bandwidth Usage" widget in Windows-Service Dashboard

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -44,6 +44,8 @@
 * Add Error URL in the browser log.
 * Add a SolonMVC icon.
 * Adding cilium icon and i18n for menu.
+* Fix the mismatch between the unit and calculation of the "Network Bandwidth Usage" widget in Windows-Service Dashboard.
+
 
 #### Documentation
 

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/os_windows/windows-service.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/os_windows/windows-service.json
@@ -20,8 +20,16 @@
             "showYAxis": true
           },
           "expressions": [
-            "meter_win_network_receive",
-            "meter_win_network_transmit"
+            "meter_win_network_receive/1024",
+            "meter_win_network_transmit/1024"
+          ],
+          "metricConfig": [
+            {
+              "label": "receive"
+            },
+            {
+              "label": "transmit"
+            }
           ]
         },
         {
@@ -49,7 +57,7 @@
               "label": "read"
             },
             {
-              "calculation": "written"
+              "label": "written"
             }
           ]
         },


### PR DESCRIPTION
### Fix the unit of the "Network Bandwidth Usage" widget in Windows-Service Dashboard
- [x] Explain briefly why the bug exists and how to fix it.

Windows service before:
<img width="1393" alt="image" src="https://github.com/user-attachments/assets/d46ff09d-7743-4ecd-95ac-c65b361131a6">

1. mismatch result of  `Network Bandwidth Usage`
windows_net_bytes_received_total: Total bytes received by interface
windows_net_bytes_sent_total: Total bytes transmitted by interface
details [here](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.net.md)

2. add label of `meter_win_network_receive`,`meter_win_network_transmit`,`meter_win_disk_written`

Windows service later:
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/c6b5356d-b8e8-44dc-af89-6b7728d3f95b">


- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
