### PR TITLE
bug fix: concurrent increase by CounterWindow may cause PriorityQueue breaken

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -46,6 +46,7 @@
 * BanyanDB: stream sort-by `time` query, use internal time-series rather than `index` to improve the query performance.
 * Bump up graphql-java to 21.5.
 * Add Unknown Node when receive Kubernetes peer address is not aware in current cluster.
+* Fix CounterWindow concurrent increase cause NPE by PriorityQueue
 
 #### UI
 


### PR DESCRIPTION
### Fix <[#12503](https://github.com/apache/skywalking/issues/12503)>
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

as org.apache.skywalking.oap.meter.analyzer.dsl.counter.CounterWindow are single instance, the windows which type ConcurrentHashMap will return the same PriorityQueue object for the same meter, when the same meter increase with concurrent call, some unexcpected exception will occur in PriorityQueue object, source code:

```java
public class CounterWindow {

    public static final CounterWindow INSTANCE = new CounterWindow();

    private final Map<ID, Tuple2<Long, Double>> lastElementMap = new ConcurrentHashMap<>();
    private final Map<ID, Queue<Tuple2<Long, Double>>> windows = new ConcurrentHashMap<>();

    public Tuple2<Long, Double> increase(String name, ImmutableMap<String, String> labels, Double value, long windowSize, long now) {
        ID id = new ID(name, labels);
        // there will return the same PriorityQueue object for concurrent operation
        Queue<Tuple2<Long, Double>> window = windows.computeIfAbsent(id, unused -> new PriorityQueue<>());
        window.offer(Tuple.of(now, value));  // some unexpected error will occur in this line when concurrent operation
        long waterLevel = now - windowSize;
        Tuple2<Long, Double> peek = window.peek();
        if (peek._1 > waterLevel) {
            return peek;
        }

        Tuple2<Long, Double> result = peek;
        while (peek._1 < waterLevel) {
            result = window.poll();  // some unexpected error will occur in this line when concurrent operation
            peek = window.element();  // some unexpected error will occur in this line when concurrent operation
        }

        // Choose the closed slot to the expected timestamp
        if (waterLevel - result._1 <= peek._1 - waterLevel) {
            return result;
        }

        return peek;
    }
    //....
}
```

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes [#12503](https://github.com/apache/skywalking/issues/12503).
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
