### PR TITLE
Fix format the endpoint name with empty string

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -48,6 +48,7 @@
 * Bump up graphql-java to 21.5.
 * Add Unknown Node when receive Kubernetes peer address is not aware in current cluster.
 * Fix CounterWindow concurrent increase cause NPE by PriorityQueue
+* Fix format the endpoint name with empty string.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/NamingControl.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/config/NamingControl.java
@@ -96,7 +96,7 @@ public class NamingControl implements Service {
      * @return the string, which length less than or equals {@link #endpointNameMaxLength};
      */
     public String formatEndpointName(String serviceName, String endpointName) {
-        if (StringUtil.isEmpty(serviceName) || endpointName == null) {
+        if (StringUtil.isEmpty(serviceName) || StringUtil.isEmpty(endpointName)) {
             return endpointName;
         }
 


### PR DESCRIPTION
When I try to use the [R3](https://github.com/skyapm/R3/) in the showcase, I find there is an empty endpoint name cached to the unformatted endpoint cache. After investing, I found when analyzing an event with the source, the endpoint name could be empty(because the gRPC will use an empty string as the default value instant `null`), so I changed the format endpoint strategy. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
