### PR TITLE
Fix wrong health check endpoint to OAP backend

### DIFF
--- a/apm-webapp/src/main/java/org/apache/skywalking/oap/server/webapp/OapProxyService.java
+++ b/apm-webapp/src/main/java/org/apache/skywalking/oap/server/webapp/OapProxyService.java
@@ -58,7 +58,7 @@ public final class OapProxyService extends AbstractHttpService {
     private static WebClient newLoadBalancingClient(EndpointGroup oapGroup) {
         final HealthCheckedEndpointGroup healthCheckedGroup =
             HealthCheckedEndpointGroup
-                .builder(oapGroup, "/internal/l7check")
+                .builder(oapGroup, "/healthcheck")
                 .protocol(SessionProtocol.HTTP)
                 .retryInterval(Duration.ofSeconds(10))
                 .build();

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -74,6 +74,7 @@
 * Bump up dependencies to fix CVEs.
 * Add a loading view for initialization page.
 * Fix a bug for selectors when clicking the refresh icon.
+* Fix health check to OAP backend.
 
 #### Documentation
 


### PR DESCRIPTION
https://github.com/apache/skywalking/pull/12485 changes the health check endpoint from `internal/l7check` to `/healthcheck` and the web ui needs to change accordingly