### PR TITLE
Fix wrong phase of delombok plugin to reduce build warnings

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -8,6 +8,7 @@
 * Push snapshot data-generator docker image to ghcr.io.
 * Bump up skywalking-infra-e2e to work around GHA removing `docker-compose` v1.
 * Bump up CodeQL GitHub Actions.
+* Fix wrong phase of delombok plugin to reduce build warnings.
 
 #### OAP Server
 

--- a/pom.xml
+++ b/pom.xml
@@ -534,7 +534,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <phase>generate-sources</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>delombok</goal>
                         </goals>


### PR DESCRIPTION
delombok plugin was configured to `generate-sources` phase because we wanted to make the `maven-javadoc-plugin` build successfully, back to https://github.com/apache/skywalking/pull/10534, but the lombok plugin was configured to `compile` phase, this causes the build produce a bunch of warnings:

<details><summary>Details</summary>
<p>

```
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/ContinuousProfilingPolicyCommand.java:39: error: package Command does not exist
    public Command.Builder serialize() {
                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/CommandDeserializer.java:20: error: package org.apache.skywalking.apm.network.common.v3 does not exist
import org.apache.skywalking.apm.network.common.v3.Command;
                                                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/CommandDeserializer.java:24: error: cannot find symbol
    public static BaseCommand deserialize(final Command command) {
                                                ^
  symbol:   class Command
  location: class org.apache.skywalking.oap.server.network.trace.component.command.CommandDeserializer
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/ProfileTaskCommand.java:21: error: package org.apache.skywalking.apm.network.common.v3 does not exist
import org.apache.skywalking.apm.network.common.v3.Command;
                                                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/ProfileTaskCommand.java:22: error: package org.apache.skywalking.apm.network.common.v3 does not exist
import org.apache.skywalking.apm.network.common.v3.KeyStringValuePair;
                                                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/ProfileTaskCommand.java:54: error: cannot find symbol
    public ProfileTaskCommand deserialize(Command command) {
                                          ^
  symbol:   class Command
  location: class org.apache.skywalking.oap.server.network.trace.component.command.ProfileTaskCommand
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/ProfileTaskCommand.java:92: error: package Command does not exist
    public Command.Builder serialize() {
                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/ContinuousProfilingReportCommand.java:21: error: package org.apache.skywalking.apm.network.common.v3 does not exist
import org.apache.skywalking.apm.network.common.v3.Command;
                                                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/ContinuousProfilingReportCommand.java:22: error: package org.apache.skywalking.apm.network.common.v3 does not exist
import org.apache.skywalking.apm.network.common.v3.KeyStringValuePair;
                                                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/ContinuousProfilingReportCommand.java:35: error: package Command does not exist
    public Command.Builder serialize() {
                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/TraceIgnoreCommand.java:21: error: package org.apache.skywalking.apm.network.common.v3 does not exist
import org.apache.skywalking.apm.network.common.v3.Command;
                                                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/TraceIgnoreCommand.java:22: error: package org.apache.skywalking.apm.network.common.v3 does not exist
import org.apache.skywalking.apm.network.common.v3.KeyStringValuePair;
                                                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/TraceIgnoreCommand.java:34: error: package Command does not exist
    public Command.Builder serialize() {
                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/EBPFProfilingTaskCommand.java:25: error: package org.apache.skywalking.apm.network.common.v3 does not exist
import org.apache.skywalking.apm.network.common.v3.Command;
                                                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/EBPFProfilingTaskCommand.java:26: error: package org.apache.skywalking.apm.network.common.v3 does not exist
import org.apache.skywalking.apm.network.common.v3.KeyStringValuePair;
                                                  ^
/Users/kezhenxu94/workspace/skywalking/apm-protocol/apm-network/src/main/java/org/apache/skywalking/oap/server/network/trace/component/command/EBPFProfilingTaskCommand.java:61: error: package Command does not exist
    public Command.Builder serialize() {
```

</p>
</details> 

instead, we should also move the delombok to compile phase so it can find the lombok’ed classes to delombok.