### PR TITLE
Fix query `getGlobalTopology` throw exception when didn't find any services by the given Layer.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -61,6 +61,7 @@
 * Update the endpoint name format to `<Method>:<Path>` in eBPF Access Log Receiver.
 * Add self-observability metrics for OpenTelemetry receiver.
 * Support service level metrics aggregate when missing pod context in eBPF Access Log Receiver.
+* Fix query `getGlobalTopology` throw exception when didn't find any services by the given Layer.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TopologyQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TopologyQueryService.java
@@ -130,6 +130,9 @@ public class TopologyQueryService implements Service {
                 span = traceContext.createSpan("Query Service: getServiceTopology");
                 span.setMsg("Duration: " + duration + ", ServiceIds: " + serviceIds);
             }
+            if (CollectionUtils.isEmpty(serviceIds)) {
+                return new Topology();
+            }
             return invokeGetServiceTopology(duration, serviceIds);
         } finally {
             if (traceContext != null && span != null) {


### PR DESCRIPTION
@ButterBright 
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
