### PR TITLE
Fix the previous analysis result missing in the ALS `k8s-mesh` analyzer

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -62,6 +62,7 @@
 * Add self-observability metrics for OpenTelemetry receiver.
 * Support service level metrics aggregate when missing pod context in eBPF Access Log Receiver.
 * Fix query `getGlobalTopology` throw exception when didn't find any services by the given Layer.
+* Fix the previous analysis result missing in the ALS `k8s-mesh` analyzer.
 
 #### UI
 

--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/als/k8s/K8sALSServiceMeshHTTPAnalysis.java
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/als/k8s/K8sALSServiceMeshHTTPAnalysis.java
@@ -79,6 +79,10 @@ public class K8sALSServiceMeshHTTPAnalysis extends AbstractALSAnalyzer {
                     return result;
                 }
                 return analyzeSideCar(result, entry);
+            case NONE:
+                // For the Ambient Istio with waypoint mode, the role is NONE.
+                // The analysis should keep the result from other roles.
+                return result;
         }
 
         return Result.builder().build();


### PR DESCRIPTION
When I try to use Amient Istio with waypoint mode, the waypoint(envoy) will send ALS data with role=`NONE`. If the OAP configures the analysis with `mx-mesh,k8s-mesh`, The `mx-mesh` analyzer would parse ALS data successfully, but the `k8s-mesh` would ignore the previous analyzed data when role=`NONE`. 

So in this PR, I have changed the original result when role=`NONE` in the `k8s-mesh` analyzer. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
