### PR TITLE
Improve the performance of OTEL metrics handler.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -73,6 +73,7 @@
 * BanyanDB: support using native term searching for `keyword` in query `findEndpoint` and `getAlarm`.
 * BanyanDB: support TLS connection and configuration.
 * PromQL service: query API support RFC3399 time format.
+* Improve the performance of OTEL metrics handler.
 
 #### UI
 

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/prometheus/PrometheusMetricConverter.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/prometheus/PrometheusMetricConverter.java
@@ -52,15 +52,15 @@ import static org.apache.skywalking.oap.meter.analyzer.Analyzer.NIL;
  */
 @Slf4j
 public class PrometheusMetricConverter {
-    private static final Pattern metricsNameEscapePattern = Pattern.compile("[/.]");
+    private static final Pattern METRICS_NAME_ESCAPE_PATTERN = Pattern.compile("[/.]");
 
-    private static final LoadingCache<String, String> escapedMetricsNameCache =
+    private static final LoadingCache<String, String> ESCAPED_METRICS_NAME_CACHE =
         CacheBuilder.newBuilder()
                     .maximumSize(1000)
                     .build(new CacheLoader<String, String>() {
                         @Override
                         public String load(final String name) {
-                            return metricsNameEscapePattern.matcher(name).replaceAll("_");
+                            return METRICS_NAME_ESCAPE_PATTERN.matcher(name).replaceAll("_");
                         }
                     });
 
@@ -143,10 +143,10 @@ public class PrometheusMetricConverter {
     // Returns the escaped name of the given one, with "." and "/" replaced by "_"
     protected static String escapedName(final String name) {
         try {
-            return escapedMetricsNameCache.get(name);
+            return ESCAPED_METRICS_NAME_CACHE.get(name);
         } catch (ExecutionException e) {
             log.error("Failed to get escaped metrics name from cache", e);
-            return metricsNameEscapePattern.matcher(name).replaceAll("_");
+            return METRICS_NAME_ESCAPE_PATTERN.matcher(name).replaceAll("_");
         }
     }
 }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

### Improve the performance of OTEL metrics handler
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [x] The benchmark result.
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

Prometheus metrics just need convert once, it doesen't need convert for every meter converter.
The preformance of otel metrics won't become worse by the increment of supported monitorings.

This perf changes is friendly to CPU and GC, the latency of otel metrics  decrease significantly.

# before
![截图_选择区域_20240925144124](https://github.com/user-attachments/assets/6c4c342d-2d63-4452-af86-b8f68b4326be)
![截图_选择区域_20240925144112](https://github.com/user-attachments/assets/190c83aa-34c0-478e-a1e3-a38b3827963b)


# after
![截图_选择区域_20240925151209](https://github.com/user-attachments/assets/797e148f-5f2c-41ba-b7c3-c6e2043f4b5a)
![截图_选择区域_20240925151235](https://github.com/user-attachments/assets/aee50fb3-c5c1-4e05-8635-0f034183df05)


