### PR TITLE
Fix checking OTEL DataPointFlags

### DIFF
--- a/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricRequestProcessor.java
+++ b/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricRequestProcessor.java
@@ -238,8 +238,8 @@ public class OpenTelemetryMetricRequestProcessor implements Service {
         final Map<String, String> nodeLabels,
         final io.opentelemetry.proto.metrics.v1.Metric metric) {
         if (metric.hasGauge()) {
-            return metric.getGauge().getDataPointsList().stream().filter(point -> point.getFlags()
-                             != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
+            return metric.getGauge().getDataPointsList().stream().filter(point -> 
+                (point.getFlags() & DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE) != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
                          .map(point -> new Gauge(
                              metric.getName(),
                              mergeLabels(
@@ -259,8 +259,8 @@ public class OpenTelemetryMetricRequestProcessor implements Service {
             }
             if (sum
                 .getAggregationTemporality() == AGGREGATION_TEMPORALITY_DELTA) {
-                return sum.getDataPointsList().stream().filter(point -> point.getFlags()
-                              != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
+                return sum.getDataPointsList().stream().filter(point -> 
+                    (point.getFlags() & DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE) != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
                           .map(point -> new Gauge(
                               metric.getName(),
                               mergeLabels(
@@ -273,8 +273,8 @@ public class OpenTelemetryMetricRequestProcessor implements Service {
                           ));
             }
             if (sum.getIsMonotonic()) {
-                return sum.getDataPointsList().stream().filter(point -> point.getFlags()
-                              != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
+                return sum.getDataPointsList().stream().filter(point ->
+                    (point.getFlags() & DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE) != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
                           .map(point -> new Counter(
                               metric.getName(),
                               mergeLabels(
@@ -286,8 +286,8 @@ public class OpenTelemetryMetricRequestProcessor implements Service {
                               point.getTimeUnixNano() / 1000000
                           ));
             } else {
-                return sum.getDataPointsList().stream().filter(point -> point.getFlags()
-                              != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
+                return sum.getDataPointsList().stream().filter(point ->
+                    (point.getFlags() & DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE) != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
                           .map(point -> new Gauge(
                               metric.getName(),
                               mergeLabels(
@@ -301,8 +301,8 @@ public class OpenTelemetryMetricRequestProcessor implements Service {
             }
         }
         if (metric.hasHistogram()) {
-            return metric.getHistogram().getDataPointsList().stream().filter(point -> point.getFlags()
-                             != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
+            return metric.getHistogram().getDataPointsList().stream().filter(point ->
+                    (point.getFlags() & DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE) != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
                          .map(point -> new Histogram(
                              metric.getName(),
                              mergeLabels(
@@ -319,8 +319,8 @@ public class OpenTelemetryMetricRequestProcessor implements Service {
                          ));
         }
         if (metric.hasExponentialHistogram()) {
-            return metric.getExponentialHistogram().getDataPointsList().stream().filter(point -> point.getFlags()
-                             != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
+            return metric.getExponentialHistogram().getDataPointsList().stream().filter(point ->
+                    (point.getFlags() & DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE) != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
                          .map(point -> new Histogram(
                              metric.getName(),
                              mergeLabels(
@@ -340,8 +340,8 @@ public class OpenTelemetryMetricRequestProcessor implements Service {
                          ));
         }
         if (metric.hasSummary()) {
-            return metric.getSummary().getDataPointsList().stream().filter(point -> point.getFlags()
-                             != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
+            return metric.getSummary().getDataPointsList().stream().filter(point ->
+                    (point.getFlags() & DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE) != DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE)
                          .map(point -> new Summary(
                              metric.getName(),
                              mergeLabels(


### PR DESCRIPTION
https://github.com/apache/skywalking/pull/12680 used a wrong way to test if the `FLAG_NO_RECORDED_VALUE_VALUE` is present, as per the doc:

```
 * <pre>
 * DataPointFlags is defined as a protobuf 'uint32' type and is to be used as a
 * bit-field representing 32 distinct boolean flags.  Each flag defined in this
 * enum is a bit-mask.  To test the presence of a single flag in the flags of
 * a data point, for example, use an expression like:
 *   (point.flags &amp; FLAG_NO_RECORDED_VALUE) == FLAG_NO_RECORDED_VALUE
 * </pre>
```