### PR TITLE
Reduce Kubernetes metrics calculate in the MQE and Add global widget in Kubernetes Dashboard

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -19,8 +19,9 @@
 * Add content decorations to Table and Card widgets.
 * Support the endpoint list widget query with duration parameter.
 * Support ranges for Value Mappings.
-* Add service global topN widget on `General-Root` and `Mesh-Root` dashboard.
+* Add service global topN widget on `General-Root`, `Mesh-Root`, `K8S-Root` dashboard.
 * Fix initialization dashboards.
+* Update the Kubernetes metrics for reduce multiple metrics calculate in MQE.
 
 #### Documentation
 * Update release document to adopt newly added revision-based process.

--- a/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/OALListener.java
+++ b/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/OALListener.java
@@ -125,7 +125,7 @@ public class OALListener extends OALParserBaseListener {
         current.setSourceDecorator(decoratorNameTrim);
         Map<String, ISourceDecorator<ISource>> map = SourceDecoratorManager.DECORATOR_MAP;
         int currentScopeId = current.getFrom().getSourceScopeId();
-        if (currentScopeId != DefaultScopeDefine.SERVICE) {
+        if (currentScopeId != DefaultScopeDefine.SERVICE && currentScopeId != DefaultScopeDefine.K8S_SERVICE) {
             throw new IllegalArgumentException("OAL metric: " + current.getMetricsName() + ", decorate source only support service scope.");
         }
         ISourceDecorator<ISource> decorator = map.get(decoratorNameTrim);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/K8SService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/K8SService.java
@@ -19,8 +19,12 @@
 package org.apache.skywalking.oap.server.core.source;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.skywalking.oap.server.core.analysis.IDManager;
+import org.apache.skywalking.oap.server.core.analysis.ISourceDecorator;
 import org.apache.skywalking.oap.server.core.analysis.Layer;
+import org.apache.skywalking.oap.server.core.analysis.SourceDecoratorManager;
 
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.K8S_SERVICE;
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_CATALOG_NAME;
@@ -38,6 +42,27 @@ public class K8SService extends K8SMetrics {
 
     private DetectPoint detectPoint;
 
+    @Getter
+    @Setter
+    @ScopeDefaultColumn.DefinedByField(columnName = "attr0", isAttribute = true)
+    private String attr0;
+    @Getter
+    @Setter
+    @ScopeDefaultColumn.DefinedByField(columnName = "attr1", isAttribute = true)
+    private String attr1;
+    @Getter
+    @Setter
+    @ScopeDefaultColumn.DefinedByField(columnName = "attr2", isAttribute = true)
+    private String attr2;
+    @Getter
+    @Setter
+    @ScopeDefaultColumn.DefinedByField(columnName = "attr3", isAttribute = true)
+    private String attr3;
+    @Getter
+    @Setter
+    @ScopeDefaultColumn.DefinedByField(columnName = "attr4", isAttribute = true)
+    private String attr4;
+
     @Override
     public int scope() {
         return K8S_SERVICE;
@@ -46,5 +71,14 @@ public class K8SService extends K8SMetrics {
     @Override
     public void prepare() {
         entityId = IDManager.ServiceID.buildId(name, layer.isNormal());
+    }
+
+    /**
+     * Get the decorator through given name and invoke.
+     * @param decorator The decorator class simpleName.
+     */
+    public void decorate(String decorator) {
+        ISourceDecorator<ISource> sourceDecorator = SourceDecoratorManager.DECORATOR_MAP.get(decorator);
+        sourceDecorator.decorate(this);
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/K8SServiceDecorator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/K8SServiceDecorator.java
@@ -16,20 +16,22 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.manual.endpoint;
+package org.apache.skywalking.oap.server.core.source;
 
-import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
-import org.apache.skywalking.oap.server.core.analysis.worker.MetricsStreamProcessor;
-import org.apache.skywalking.oap.server.core.source.K8SEndpoint;
+import org.apache.skywalking.oap.server.core.analysis.ISourceDecorator;
 
-public class K8SEndpointTrafficDispatcher implements SourceDispatcher<K8SEndpoint> {
+public class K8SServiceDecorator implements ISourceDecorator<K8SService> {
     @Override
-    public void dispatch(K8SEndpoint source) {
-        final EndpointTraffic traffic = new EndpointTraffic();
-        traffic.setTimeBucket(source.getTimeBucket());
-        traffic.setName(source.getEndpointName());
-        traffic.setServiceId(source.getServiceId());
-        traffic.setLastPingTimestamp(source.getTimeBucket());
-        MetricsStreamProcessor.getInstance().in(traffic);
+    public int getSourceScope() {
+        return DefaultScopeDefine.K8S_SERVICE;
+    }
+
+    /**
+     * Set the Layer name to attr0
+     * @param source The source instance to be decorated
+     */
+    @Override
+    public void decorate(final K8SService source) {
+        source.setAttr0(source.getLayer().name());
     }
 }

--- a/oap-server/server-starter/src/main/resources/oal/ebpf.oal
+++ b/oap-server/server-starter/src/main/resources/oal/ebpf.oal
@@ -18,37 +18,37 @@
 
 // Kubernetes Service
 kubernetes_service_connect_cpm = from(K8SService.*).filter(type == "connect").cpm();
-kubernetes_service_connect_duration = from(K8SService.connect.duration).filter(type == "connect").sum();
+kubernetes_service_connect_time = from(K8SService.connect.duration).filter(type == "connect").longAvg();
 kubernetes_service_connect_success_cpm = from(K8SService.*).filter(type == "connect").filter(connect.success == true).cpm();
 kubernetes_service_accept_cpm = from(K8SService.*).filter(type == "accept").cpm();
-kubernetes_service_accept_duration = from(K8SService.accept.duration).filter(type == "accept").sum();
+kubernetes_service_accept_time = from(K8SService.accept.duration).filter(type == "accept").longAvg();
 kubernetes_service_close_cpm = from(K8SService.*).filter(type == "close").cpm();
-kubernetes_service_close_duration = from(K8SService.close.duration).filter(type == "close").sum();
+kubernetes_service_close_time = from(K8SService.close.duration).filter(type == "close").longAvg();
 
 kubernetes_service_write_cpm = from(K8SService.*).filter(type == "write").cpm();
-kubernetes_service_write_duration = from(K8SService.write.duration).filter(type == "write").sum();
-kubernetes_service_write_l4_duration = from(K8SService.write.l4.duration).filter(type == "write").sum();
+kubernetes_service_write_time = from(K8SService.write.duration).filter(type == "write").longAvg();
+kubernetes_service_write_l4_time = from(K8SService.write.l4.duration).filter(type == "write").longAvg();
 kubernetes_service_write_package_cpm = from(K8SService.write.l4.transmitPackageCount).filter(type == "write").sum();
 kubernetes_service_write_retrains_package_cpm = from(K8SService.write.l4.retransmitPackageCount).filter(type == "write").sum();
 kubernetes_service_write_package_size = from(K8SService.write.l4.totalPackageSize).filter(type == "write").sum();
-kubernetes_service_write_l3_duration = from(K8SService.write.l3.duration).filter(type == "write").sum();
-kubernetes_service_write_l3_local_duration = from(K8SService.write.l3.localDuration).filter(type == "write").sum();
-kubernetes_service_write_l3_output_duration = from(K8SService.write.l3.outputDuration).filter(type == "write").sum();
-kubernetes_service_write_l2_duration = from(K8SService.write.l2.duration).filter(type == "write").sum();
-kubernetes_service_write_l2_enter_queue_count = from(K8SService.write.l2.enterQueueBufferCount).filter(type == "write").sum();
-kubernetes_service_write_l2_ready_send_duration = from(K8SService.write.l2.readySendDuration).filter(type == "write").sum();
-kubernetes_service_write_l2_net_device_send_duration = from(K8SService.write.l2.networkDeviceSendDuration).filter(type == "write").sum();
+kubernetes_service_write_l3_time = from(K8SService.write.l3.duration).filter(type == "write").longAvg();
+kubernetes_service_write_l3_local_time = from(K8SService.write.l3.localDuration).filter(type == "write").longAvg();
+kubernetes_service_write_l3_output_time = from(K8SService.write.l3.outputDuration).filter(type == "write").longAvg();
+kubernetes_service_write_l2_time = from(K8SService.write.l2.duration).filter(type == "write").longAvg();
+kubernetes_service_write_l2_enter_avg_queue_count = from(K8SService.write.l2.enterQueueBufferCount).filter(type == "write").longAvg();
+kubernetes_service_write_l2_ready_avg_send_duration = from(K8SService.write.l2.readySendDuration).filter(type == "write").longAvg();
+kubernetes_service_write_l2_net_device_avg_send_duration = from(K8SService.write.l2.networkDeviceSendDuration).filter(type == "write").longAvg();
 
 kubernetes_service_read_cpm = from(K8SService.*).filter(type == "read").cpm();
-kubernetes_service_read_duration = from(K8SService.read.duration).filter(type == "read").sum();
-kubernetes_service_read_l4_duration = from(K8SService.read.l4.duration).filter(type == "read").sum();
-kubernetes_service_read_l3_duration = from(K8SService.read.l3.duration).filter(type == "read").sum();
-kubernetes_service_read_l3_rcv_duration = from(K8SService.read.l3.rcvDuration).filter(type == "read").sum();
-kubernetes_service_read_l3_local_duration = from(K8SService.read.l3.localDuration).filter(type == "read").sum();
+kubernetes_service_read_time = from(K8SService.read.duration).filter(type == "read").longAvg();
+kubernetes_service_read_l4_time = from(K8SService.read.l4.duration).filter(type == "read").longAvg();
+kubernetes_service_read_l3_time = from(K8SService.read.l3.duration).filter(type == "read").longAvg();
+kubernetes_service_read_l3_rcv_time = from(K8SService.read.l3.rcvDuration).filter(type == "read").longAvg();
+kubernetes_service_read_l3_local_time = from(K8SService.read.l3.localDuration).filter(type == "read").longAvg();
 kubernetes_service_read_package_cpm = from(K8SService.read.l2.packageCount).filter(type == "read").sum();
 kubernetes_service_read_package_size = from(K8SService.read.l2.totalPackageSize).filter(type == "read").sum();
-kubernetes_service_read_package_to_queue_duration = from(K8SService.read.l2.packageToQueueDuration).filter(type == "read").sum();
-kubernetes_service_read_rcv_package_from_queue_duration = from(K8SService.read.l2.packageToQueueDuration).filter(type == "read").sum();
+kubernetes_service_read_package_to_queue_time = from(K8SService.read.l2.packageToQueueDuration).filter(type == "read").longAvg();
+kubernetes_service_read_rcv_package_from_queue_time = from(K8SService.read.l2.packageToQueueDuration).filter(type == "read").longAvg();
 
 kubernetes_service_resolve_mac_cpm = from(K8SService.write.l3.resolveMACCount).filter(type == "write").sum();
 kubernetes_service_resolve_mac_duration = from(K8SService.write.l3.resolveMACDuration).filter(type == "write").sum();
@@ -57,13 +57,15 @@ kubernetes_service_write_netfilter_duration = from(K8SService.write.l3.netFilter
 kubernetes_service_read_netfilter_cpm = from(K8SService.read.l3.netFilterCount).filter(type == "read").sum();
 kubernetes_service_read_netfilter_duration = from(K8SService.read.l3.netFilterDuration).filter(type == "read").sum();
 
-kubernetes_service_http_call_cpm = from(K8SService.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").cpm();
-kubernetes_service_http_call_duration = from(K8SService.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_http_call_success_count = from(K8SService.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.success == true).cpm();
-kubernetes_service_http_req_header_size = from(K8SService.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_http_req_body_size = from(K8SService.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_http_resp_header_size = from(K8SService.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_http_resp_body_size = from(K8SService.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_http_call_cpm = from(K8SService.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").cpm().decorator("K8SServiceDecorator");
+kubernetes_service_http_call_time = from(K8SService.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg().decorator("K8SServiceDecorator");
+kubernetes_service_http_call_successful_rate = from(K8SService.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").percent(protocol.success == true).decorator("K8SServiceDecorator");
+kubernetes_service_http_avg_req_header_size = from(K8SService.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_http_avg_req_body_size = from(K8SService.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_http_avg_resp_header_size = from(K8SService.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_http_avg_resp_body_size = from(K8SService.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_apdex = from(K8SService.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").apdex(name, protocol.success).decorator("K8SServiceDecorator");
+kubernetes_service_percentile = from(K8SService.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").percentile2(10);
 
 kubernetes_service_http_status_1xx_cpm = from(K8SService.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.http.statusCode >= 100).filter(protocol.http.statusCode < 200).cpm();
 kubernetes_service_http_status_2xx_cpm = from(K8SService.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.http.statusCode >= 200).filter(protocol.http.statusCode < 300).cpm();
@@ -74,37 +76,37 @@ kubernetes_service_http_status_5xx_cpm = from(K8SService.*).filter(detectPoint =
 
 // Kubernetes Service Instance
 kubernetes_service_instance_connect_cpm = from(K8SServiceInstance.*).filter(type == "connect").cpm();
-kubernetes_service_instance_connect_duration = from(K8SServiceInstance.connect.duration).filter(type == "connect").sum();
+kubernetes_service_instance_connect_time = from(K8SServiceInstance.connect.duration).filter(type == "connect").longAvg();
 kubernetes_service_instance_connect_success_cpm = from(K8SServiceInstance.*).filter(type == "connect").filter(connect.success == true).cpm();
 kubernetes_service_instance_accept_cpm = from(K8SServiceInstance.*).filter(type == "accept").cpm();
-kubernetes_service_instance_accept_duration = from(K8SServiceInstance.accept.duration).filter(type == "accept").sum();
+kubernetes_service_instance_accept_time = from(K8SServiceInstance.accept.duration).filter(type == "accept").longAvg();
 kubernetes_service_instance_close_cpm = from(K8SServiceInstance.*).filter(type == "close").cpm();
-kubernetes_service_instance_close_duration = from(K8SServiceInstance.close.duration).filter(type == "close").sum();
+kubernetes_service_instance_close_time = from(K8SServiceInstance.close.duration).filter(type == "close").longAvg();
 
 kubernetes_service_instance_write_cpm = from(K8SServiceInstance.*).filter(type == "write").cpm();
-kubernetes_service_instance_write_duration = from(K8SServiceInstance.write.duration).filter(type == "write").sum();
-kubernetes_service_instance_write_l4_duration = from(K8SServiceInstance.write.l4.duration).filter(type == "write").sum();
+kubernetes_service_instance_write_time = from(K8SServiceInstance.write.duration).filter(type == "write").longAvg();
+kubernetes_service_instance_write_l4_time = from(K8SServiceInstance.write.l4.duration).filter(type == "write").longAvg();
 kubernetes_service_instance_write_package_cpm = from(K8SServiceInstance.write.l4.transmitPackageCount).filter(type == "write").sum();
 kubernetes_service_instance_write_retrains_package_cpm = from(K8SServiceInstance.write.l4.retransmitPackageCount).filter(type == "write").sum();
 kubernetes_service_instance_write_package_size = from(K8SServiceInstance.write.l4.totalPackageSize).filter(type == "write").sum();
-kubernetes_service_instance_write_l3_duration = from(K8SServiceInstance.write.l3.duration).filter(type == "write").sum();
-kubernetes_service_instance_write_l3_local_duration = from(K8SServiceInstance.write.l3.localDuration).filter(type == "write").sum();
-kubernetes_service_instance_write_l3_output_duration = from(K8SServiceInstance.write.l3.outputDuration).filter(type == "write").sum();
-kubernetes_service_instance_write_l2_duration = from(K8SServiceInstance.write.l2.duration).filter(type == "write").sum();
-kubernetes_service_instance_write_l2_enter_queue_count = from(K8SServiceInstance.write.l2.enterQueueBufferCount).filter(type == "write").sum();
-kubernetes_service_instance_write_l2_ready_send_duration = from(K8SServiceInstance.write.l2.readySendDuration).filter(type == "write").sum();
-kubernetes_service_instance_write_l2_net_device_send_duration = from(K8SServiceInstance.write.l2.networkDeviceSendDuration).filter(type == "write").sum();
+kubernetes_service_instance_write_l3_time = from(K8SServiceInstance.write.l3.duration).filter(type == "write").longAvg();
+kubernetes_service_instance_write_l3_local_time = from(K8SServiceInstance.write.l3.localDuration).filter(type == "write").longAvg();
+kubernetes_service_instance_write_l3_output_time = from(K8SServiceInstance.write.l3.outputDuration).filter(type == "write").longAvg();
+kubernetes_service_instance_write_l2_time = from(K8SServiceInstance.write.l2.duration).filter(type == "write").longAvg();
+kubernetes_service_instance_write_l2_avg_enter_queue_count = from(K8SServiceInstance.write.l2.enterQueueBufferCount).filter(type == "write").longAvg();
+kubernetes_service_instance_write_l2_ready_send_time = from(K8SServiceInstance.write.l2.readySendDuration).filter(type == "write").longAvg();
+kubernetes_service_instance_write_l2_net_device_send_time = from(K8SServiceInstance.write.l2.networkDeviceSendDuration).filter(type == "write").longAvg();
 
 kubernetes_service_instance_read_cpm = from(K8SServiceInstance.*).filter(type == "read").cpm();
-kubernetes_service_instance_read_duration = from(K8SServiceInstance.read.duration).filter(type == "read").sum();
-kubernetes_service_instance_read_l4_duration = from(K8SServiceInstance.read.l4.duration).filter(type == "read").sum();
-kubernetes_service_instance_read_l3_duration = from(K8SServiceInstance.read.l3.duration).filter(type == "read").sum();
-kubernetes_service_instance_read_l3_rcv_duration = from(K8SServiceInstance.read.l3.rcvDuration).filter(type == "read").sum();
-kubernetes_service_instance_read_l3_local_duration = from(K8SServiceInstance.read.l3.localDuration).filter(type == "read").sum();
+kubernetes_service_instance_read_time = from(K8SServiceInstance.read.duration).filter(type == "read").longAvg();
+kubernetes_service_instance_read_l4_time = from(K8SServiceInstance.read.l4.duration).filter(type == "read").longAvg();
+kubernetes_service_instance_read_l3_time = from(K8SServiceInstance.read.l3.duration).filter(type == "read").longAvg();
+kubernetes_service_instance_read_l3_rcv_time = from(K8SServiceInstance.read.l3.rcvDuration).filter(type == "read").longAvg();
+kubernetes_service_instance_read_l3_local_time = from(K8SServiceInstance.read.l3.localDuration).filter(type == "read").longAvg();
 kubernetes_service_instance_read_package_cpm = from(K8SServiceInstance.read.l2.packageCount).filter(type == "read").sum();
 kubernetes_service_instance_read_package_size = from(K8SServiceInstance.read.l2.totalPackageSize).filter(type == "read").sum();
-kubernetes_service_instance_read_package_to_queue_duration = from(K8SServiceInstance.read.l2.packageToQueueDuration).filter(type == "read").sum();
-kubernetes_service_instance_read_rcv_package_from_queue_duration = from(K8SServiceInstance.read.l2.packageToQueueDuration).filter(type == "read").sum();
+kubernetes_service_instance_read_package_to_queue_time = from(K8SServiceInstance.read.l2.packageToQueueDuration).filter(type == "read").longAvg();
+kubernetes_service_instance_read_rcv_package_from_queue_time = from(K8SServiceInstance.read.l2.packageToQueueDuration).filter(type == "read").longAvg();
 
 kubernetes_service_instance_resolve_mac_cpm = from(K8SServiceInstance.write.l3.resolveMACCount).filter(type == "write").sum();
 kubernetes_service_instance_resolve_mac_duration = from(K8SServiceInstance.write.l3.resolveMACDuration).filter(type == "write").sum();
@@ -114,12 +116,14 @@ kubernetes_service_instance_read_netfilter_cpm = from(K8SServiceInstance.read.l3
 kubernetes_service_instance_read_netfilter_duration = from(K8SServiceInstance.read.l3.netFilterDuration).filter(type == "read").sum();
 
 kubernetes_service_instance_http_call_cpm = from(K8SServiceInstance.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").cpm();
-kubernetes_service_instance_http_call_duration = from(K8SServiceInstance.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_http_call_success_count = from(K8SServiceInstance.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.success == true).cpm();
-kubernetes_service_instance_http_req_header_size = from(K8SServiceInstance.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_http_req_body_size = from(K8SServiceInstance.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_http_resp_header_size = from(K8SServiceInstance.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_http_resp_body_size = from(K8SServiceInstance.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_instance_http_call_time = from(K8SServiceInstance.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_http_call_successful_rate = from(K8SServiceInstance.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").percent(protocol.success == true);
+kubernetes_service_instance_http_avg_req_header_size = from(K8SServiceInstance.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_http_avg_req_body_size = from(K8SServiceInstance.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_http_avg_resp_header_size = from(K8SServiceInstance.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_http_avg_resp_body_size = from(K8SServiceInstance.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_apdex = from(K8SServiceInstance.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").apdex(serviceName, protocol.success);
+kubernetes_service_instance_percentile = from(K8SServiceInstance.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").percentile2(10);
 
 kubernetes_service_instance_http_status_1xx_cpm = from(K8SServiceInstance.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.http.statusCode >= 100).filter(protocol.http.statusCode < 200).cpm();
 kubernetes_service_instance_http_status_2xx_cpm = from(K8SServiceInstance.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.http.statusCode >= 200).filter(protocol.http.statusCode < 300).cpm();
@@ -129,16 +133,16 @@ kubernetes_service_instance_http_status_5xx_cpm = from(K8SServiceInstance.*).fil
 
 // Kubernetes Service Endpoint
 kubernetes_service_endpoint_call_cpm = from(K8SEndpoint.*).cpm();
-kubernetes_service_endpoint_call_success_cpm = from(K8SEndpoint.*).filter(success == true).cpm();
-kubernetes_service_endpoint_call_duration = from(K8SEndpoint.duration).filter(success == true).sum();
+kubernetes_service_endpoint_call_successful_rate = from(K8SEndpoint.*).percent(success == true);
+kubernetes_service_endpoint_call_time = from(K8SEndpoint.duration).longAvg();
 
 kubernetes_service_endpoint_http_call_cpm = from(K8SEndpoint.*).filter(type == "http").cpm();
-kubernetes_service_endpoint_http_call_success_cpm = from(K8SEndpoint.*).filter(type == "http").filter(success == true).cpm();
-kubernetes_service_endpoint_http_call_duration = from(K8SEndpoint.http.latency).filter(type == "http").sum();
-kubernetes_service_endpoint_http_req_header_size = from(K8SEndpoint.http.sizeOfRequestHeader).filter(type == "http").sum();
-kubernetes_service_endpoint_http_req_body_size = from(K8SEndpoint.http.sizeOfRequestBody).filter(type == "http").sum();
-kubernetes_service_endpoint_http_resp_header_size = from(K8SEndpoint.http.sizeOfResponseHeader).filter(type == "http").sum();
-kubernetes_service_endpoint_http_resp_body_size = from(K8SEndpoint.http.sizeOfResponseBody).filter(type == "http").sum();
+kubernetes_service_endpoint_http_call_successful_rate = from(K8SEndpoint.*).filter(type == "http").percent(success == true);
+kubernetes_service_endpoint_http_call_time = from(K8SEndpoint.http.latency).filter(type == "http").longAvg();
+kubernetes_service_endpoint_http_avg_req_header_size = from(K8SEndpoint.http.sizeOfRequestHeader).filter(type == "http").longAvg();
+kubernetes_service_endpoint_http_avg_req_body_size = from(K8SEndpoint.http.sizeOfRequestBody).filter(type == "http").longAvg();
+kubernetes_service_endpoint_http_avg_resp_header_size = from(K8SEndpoint.http.sizeOfResponseHeader).filter(type == "http").longAvg();
+kubernetes_service_endpoint_http_avg_resp_body_size = from(K8SEndpoint.http.sizeOfResponseBody).filter(type == "http").longAvg();
 
 kubernetes_service_endpoint_http_status_1xx_cpm = from(K8SEndpoint.*).filter(type == "http").filter(http.statusCode >= 100).filter(http.statusCode < 200).cpm();
 kubernetes_service_endpoint_http_status_2xx_cpm = from(K8SEndpoint.*).filter(type == "http").filter(http.statusCode >= 200).filter(http.statusCode < 300).cpm();
@@ -175,33 +179,33 @@ kubernetes_service_relation_client_read_package_cpm = from(K8SServiceRelation.re
 kubernetes_service_relation_client_read_package_size = from(K8SServiceRelation.read.l2.totalPackageSize).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
 kubernetes_service_relation_client_read_package_duration = from(K8SServiceRelation.read.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
 
-kubernetes_service_relation_server_write_l4_duration = from(K8SServiceRelation.write.l4.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_relation_server_write_l3_duration = from(K8SServiceRelation.write.l3.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_relation_server_write_l3_local_duration = from(K8SServiceRelation.write.l3.localDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_relation_server_write_l3_output_duration = from(K8SServiceRelation.write.l3.outputDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_relation_server_write_l2_duration = from(K8SServiceRelation.write.l2.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_relation_server_write_l2_ready_send_duration = from(K8SServiceRelation.write.l2.readySendDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_relation_server_write_l2_net_dev_send_duration = from(K8SServiceRelation.write.l2.networkDeviceSendDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_relation_server_read_l4_duration = from(K8SServiceRelation.read.l4.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_relation_server_read_l3_duration = from(K8SServiceRelation.read.l3.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_relation_server_read_l3_rcv_duration = from(K8SServiceRelation.read.l3.rcvDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_relation_server_read_l3_local_duration = from(K8SServiceRelation.read.l3.localDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_relation_server_read_l2_package_to_queue_duration = from(K8SServiceRelation.read.l2.packageToQueueDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_relation_server_read_l2_rcv_package_from_queue_duration = from(K8SServiceRelation.read.l2.rcvPackageFromQueueDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
+kubernetes_service_relation_server_write_l4_time = from(K8SServiceRelation.write.l4.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_relation_server_write_l3_time = from(K8SServiceRelation.write.l3.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_relation_server_write_l3_local_time = from(K8SServiceRelation.write.l3.localDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_relation_server_write_l3_output_time = from(K8SServiceRelation.write.l3.outputDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_relation_server_write_l2_time = from(K8SServiceRelation.write.l2.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_relation_server_write_l2_ready_send_time = from(K8SServiceRelation.write.l2.readySendDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_relation_server_write_l2_net_dev_send_time = from(K8SServiceRelation.write.l2.networkDeviceSendDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_relation_server_read_l4_time = from(K8SServiceRelation.read.l4.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_relation_server_read_l3_time = from(K8SServiceRelation.read.l3.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_relation_server_read_l3_rcv_time = from(K8SServiceRelation.read.l3.rcvDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_relation_server_read_l3_local_time = from(K8SServiceRelation.read.l3.localDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_relation_server_read_l2_package_to_queue_time = from(K8SServiceRelation.read.l2.packageToQueueDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_relation_server_read_l2_rcv_package_from_queue_time = from(K8SServiceRelation.read.l2.rcvPackageFromQueueDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
 
-kubernetes_service_relation_client_write_l4_duration = from(K8SServiceRelation.write.l4.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_relation_client_write_l3_duration = from(K8SServiceRelation.write.l3.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_relation_client_write_l3_local_duration = from(K8SServiceRelation.write.l3.localDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_relation_client_write_l3_output_duration = from(K8SServiceRelation.write.l3.outputDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_relation_client_write_l2_duration = from(K8SServiceRelation.write.l2.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_relation_client_write_l2_ready_send_duration = from(K8SServiceRelation.write.l2.readySendDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_relation_client_write_l2_net_dev_send_duration = from(K8SServiceRelation.write.l2.networkDeviceSendDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_relation_client_read_l4_duration = from(K8SServiceRelation.read.l4.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_relation_client_read_l3_duration = from(K8SServiceRelation.read.l3.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_relation_client_read_l3_rcv_duration = from(K8SServiceRelation.read.l3.rcvDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_relation_client_read_l3_local_duration = from(K8SServiceRelation.read.l3.localDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_relation_client_read_l2_package_to_queue_duration = from(K8SServiceRelation.read.l2.packageToQueueDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_relation_client_read_l2_rcv_package_from_queue_duration = from(K8SServiceRelation.read.l2.rcvPackageFromQueueDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
+kubernetes_service_relation_client_write_l4_time = from(K8SServiceRelation.write.l4.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_relation_client_write_l3_time = from(K8SServiceRelation.write.l3.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_relation_client_write_l3_local_time = from(K8SServiceRelation.write.l3.localDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_relation_client_write_l3_output_time = from(K8SServiceRelation.write.l3.outputDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_relation_client_write_l2_time = from(K8SServiceRelation.write.l2.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_relation_client_write_l2_ready_send_time = from(K8SServiceRelation.write.l2.readySendDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_relation_client_write_l2_net_dev_send_time = from(K8SServiceRelation.write.l2.networkDeviceSendDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_relation_client_read_l4_time = from(K8SServiceRelation.read.l4.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_relation_client_read_l3_time = from(K8SServiceRelation.read.l3.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_relation_client_read_l3_rcv_time = from(K8SServiceRelation.read.l3.rcvDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_relation_client_read_l3_local_time = from(K8SServiceRelation.read.l3.localDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_relation_client_read_l2_package_to_queue_time = from(K8SServiceRelation.read.l2.packageToQueueDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_relation_client_read_l2_rcv_package_from_queue_time = from(K8SServiceRelation.read.l2.rcvPackageFromQueueDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
 
 kubernetes_service_relation_server_write_resolve_mac_cpm = from(K8SServiceRelation.write.l3.resolveMACCount).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
 kubernetes_service_relation_server_write_resolve_mac_duration = from(K8SServiceRelation.write.l3.resolveMACDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
@@ -219,19 +223,24 @@ kubernetes_service_relation_client_read_netfilter_duration = from(K8SServiceRela
 
 kubernetes_service_relation_server_http_call_cpm = from(K8SServiceRelation.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").cpm();
 kubernetes_service_relation_server_http_success_cpm = from(K8SServiceRelation.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.success == true).cpm();
-kubernetes_service_relation_server_http_call_duration = from(K8SServiceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_relation_server_http_req_header_size = from(K8SServiceRelation.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_relation_server_http_req_body_size = from(K8SServiceRelation.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_relation_server_http_resp_header_size = from(K8SServiceRelation.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_relation_server_http_resp_body_size = from(K8SServiceRelation.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_relation_server_http_call_time = from(K8SServiceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_server_http_avg_req_header_size = from(K8SServiceRelation.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_server_http_avg_req_body_size = from(K8SServiceRelation.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_server_http_avg_resp_header_size = from(K8SServiceRelation.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_server_http_avg_resp_body_size = from(K8SServiceRelation.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_server_apdex = from(K8SServiceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").apdex(destServiceName, protocol.success);
+kubernetes_service_relation_server_percentile = from(K8SServiceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").percentile2(10);
 
 kubernetes_service_relation_client_http_call_cpm = from(K8SServiceRelation.*).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").cpm();
 kubernetes_service_relation_client_http_success_cpm = from(K8SServiceRelation.*).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.success == true).cpm();
 kubernetes_service_relation_client_http_call_duration = from(K8SServiceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_relation_client_http_req_header_size = from(K8SServiceRelation.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_relation_client_http_req_body_size = from(K8SServiceRelation.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_relation_client_http_resp_header_size = from(K8SServiceRelation.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_relation_client_http_resp_body_size = from(K8SServiceRelation.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_relation_client_http_call_time = from(K8SServiceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_client_http_avg_req_header_size = from(K8SServiceRelation.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_client_http_avg_req_body_size = from(K8SServiceRelation.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_client_http_avg_resp_header_size = from(K8SServiceRelation.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_client_http_avg_resp_body_size = from(K8SServiceRelation.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_relation_client_apdex = from(K8SServiceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").apdex(sourceServiceName, protocol.success);
+kubernetes_service_relation_client_percentile = from(K8SServiceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").percentile2(10);
 
 kubernetes_service_relation_server_http_status_1xx_cpm = from(K8SServiceRelation.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.http.statusCode >= 100).filter(protocol.http.statusCode < 200).cpm();
 kubernetes_service_relation_server_http_status_2xx_cpm = from(K8SServiceRelation.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.http.statusCode >= 200).filter(protocol.http.statusCode < 300).cpm();
@@ -274,33 +283,33 @@ kubernetes_service_instance_relation_client_read_package_cpm = from(K8SServiceIn
 kubernetes_service_instance_relation_client_read_package_size = from(K8SServiceInstanceRelation.read.l2.totalPackageSize).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
 kubernetes_service_instance_relation_client_read_package_duration = from(K8SServiceInstanceRelation.read.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
 
-kubernetes_service_instance_relation_server_write_l4_duration = from(K8SServiceInstanceRelation.write.l4.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_instance_relation_server_write_l3_duration = from(K8SServiceInstanceRelation.write.l3.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_instance_relation_server_write_l3_local_duration = from(K8SServiceInstanceRelation.write.l3.localDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_instance_relation_server_write_l3_output_duration = from(K8SServiceInstanceRelation.write.l3.outputDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_instance_relation_server_write_l2_duration = from(K8SServiceInstanceRelation.write.l2.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_instance_relation_server_write_l2_ready_send_duration = from(K8SServiceInstanceRelation.write.l2.readySendDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_instance_relation_server_write_l2_net_dev_send_duration = from(K8SServiceInstanceRelation.write.l2.networkDeviceSendDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
-kubernetes_service_instance_relation_server_read_l4_duration = from(K8SServiceInstanceRelation.read.l4.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_instance_relation_server_read_l3_duration = from(K8SServiceInstanceRelation.read.l3.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_instance_relation_server_read_l3_rcv_duration = from(K8SServiceInstanceRelation.read.l3.rcvDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_instance_relation_server_read_l3_local_duration = from(K8SServiceInstanceRelation.read.l3.localDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_instance_relation_server_read_l2_package_to_queue_duration = from(K8SServiceInstanceRelation.read.l2.packageToQueueDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
-kubernetes_service_instance_relation_server_read_l2_rcv_package_from_queue_duration = from(K8SServiceInstanceRelation.read.l2.rcvPackageFromQueueDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").sum();
+kubernetes_service_instance_relation_server_write_l4_time = from(K8SServiceInstanceRelation.write.l4.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_server_write_l3_time = from(K8SServiceInstanceRelation.write.l3.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_server_write_l3_local_time = from(K8SServiceInstanceRelation.write.l3.localDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_server_write_l3_output_time = from(K8SServiceInstanceRelation.write.l3.outputDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_server_write_l2_time = from(K8SServiceInstanceRelation.write.l2.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_server_write_l2_ready_send_time = from(K8SServiceInstanceRelation.write.l2.readySendDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_server_write_l2_net_dev_send_time = from(K8SServiceInstanceRelation.write.l2.networkDeviceSendDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_server_read_l4_time = from(K8SServiceInstanceRelation.read.l4.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_server_read_l3_time = from(K8SServiceInstanceRelation.read.l3.duration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_server_read_l3_rcv_time = from(K8SServiceInstanceRelation.read.l3.rcvDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_server_read_l3_local_time = from(K8SServiceInstanceRelation.read.l3.localDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_server_read_l2_package_to_queue_time = from(K8SServiceInstanceRelation.read.l2.packageToQueueDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_server_read_l2_rcv_package_from_queue_time = from(K8SServiceInstanceRelation.read.l2.rcvPackageFromQueueDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "read").longAvg();
 
-kubernetes_service_instance_relation_client_write_l4_duration = from(K8SServiceInstanceRelation.write.l4.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_instance_relation_client_write_l3_duration = from(K8SServiceInstanceRelation.write.l3.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_instance_relation_client_write_l3_local_duration = from(K8SServiceInstanceRelation.write.l3.localDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_instance_relation_client_write_l3_output_duration = from(K8SServiceInstanceRelation.write.l3.outputDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_instance_relation_client_write_l2_duration = from(K8SServiceInstanceRelation.write.l2.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_instance_relation_client_write_l2_ready_send_duration = from(K8SServiceInstanceRelation.write.l2.readySendDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_instance_relation_client_write_l2_net_dev_send_duration = from(K8SServiceInstanceRelation.write.l2.networkDeviceSendDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").sum();
-kubernetes_service_instance_relation_client_read_l4_duration = from(K8SServiceInstanceRelation.read.l4.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_instance_relation_client_read_l3_duration = from(K8SServiceInstanceRelation.read.l3.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_instance_relation_client_read_l3_rcv_duration = from(K8SServiceInstanceRelation.read.l3.rcvDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_instance_relation_client_read_l3_local_duration = from(K8SServiceInstanceRelation.read.l3.localDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_instance_relation_client_read_l2_package_to_queue_duration = from(K8SServiceInstanceRelation.read.l2.packageToQueueDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
-kubernetes_service_instance_relation_client_read_l2_rcv_package_from_queue_duration = from(K8SServiceInstanceRelation.read.l2.rcvPackageFromQueueDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
+kubernetes_service_instance_relation_client_write_l4_time = from(K8SServiceInstanceRelation.write.l4.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_client_write_l3_time = from(K8SServiceInstanceRelation.write.l3.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_client_write_l3_local_time = from(K8SServiceInstanceRelation.write.l3.localDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_client_write_l3_output_time = from(K8SServiceInstanceRelation.write.l3.outputDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_client_write_l2_time = from(K8SServiceInstanceRelation.write.l2.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_client_write_l2_ready_send_time = from(K8SServiceInstanceRelation.write.l2.readySendDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_client_write_l2_net_dev_send_time = from(K8SServiceInstanceRelation.write.l2.networkDeviceSendDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "write").longAvg();
+kubernetes_service_instance_relation_client_read_l4_time = from(K8SServiceInstanceRelation.read.l4.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_client_read_l3_time = from(K8SServiceInstanceRelation.read.l3.duration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_client_read_l3_rcv_time = from(K8SServiceInstanceRelation.read.l3.rcvDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_client_read_l3_local_time = from(K8SServiceInstanceRelation.read.l3.localDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_client_read_l2_package_to_queue_time = from(K8SServiceInstanceRelation.read.l2.packageToQueueDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
+kubernetes_service_instance_relation_client_read_l2_rcv_package_from_queue_time = from(K8SServiceInstanceRelation.read.l2.rcvPackageFromQueueDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").longAvg();
 
 kubernetes_service_instance_relation_server_write_resolve_mac_cpm = from(K8SServiceInstanceRelation.write.l3.resolveMACCount).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
 kubernetes_service_instance_relation_server_write_resolve_mac_duration = from(K8SServiceInstanceRelation.write.l3.resolveMACDuration).filter(detectPoint == DetectPoint.SERVER).filter(type == "write").sum();
@@ -317,18 +326,22 @@ kubernetes_service_instance_relation_client_read_netfilter_cpm = from(K8SService
 kubernetes_service_instance_relation_client_read_netfilter_duration = from(K8SServiceInstanceRelation.read.l3.netFilterDuration).filter(detectPoint == DetectPoint.CLIENT).filter(type == "read").sum();
 
 kubernetes_service_instance_relation_server_http_call_cpm = from(K8SServiceInstanceRelation.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").cpm();
-kubernetes_service_instance_relation_server_http_call_duration = from(K8SServiceInstanceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_relation_server_http_req_header_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_relation_server_http_req_body_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_relation_server_http_resp_header_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_relation_server_http_resp_body_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_instance_relation_server_http_call_time = from(K8SServiceInstanceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_relation_server_http_avg_req_header_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_relation_server_http_avg_req_body_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_relation_server_http_avg_resp_header_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_relation_server_http_avg_resp_body_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_relation_server_apdex = from(K8SServiceInstanceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").apdex(destServiceName, protocol.success);
+kubernetes_service_instance_relation_server_percentile = from(K8SServiceInstanceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").percentile2(10);
 
 kubernetes_service_instance_relation_client_http_call_cpm = from(K8SServiceInstanceRelation.*).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").cpm();
-kubernetes_service_instance_relation_client_http_call_duration = from(K8SServiceInstanceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_relation_client_http_req_header_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_relation_client_http_req_body_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_relation_client_http_resp_header_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
-kubernetes_service_instance_relation_client_http_resp_body_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_instance_relation_client_http_call_time = from(K8SServiceInstanceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").longAvg();
+kubernetes_service_instance_relation_client_http_avg_req_header_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfRequestHeader).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_instance_relation_client_http_avg_req_body_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfRequestBody).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_instance_relation_client_http_avg_resp_header_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfResponseHeader).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_instance_relation_client_http_avg_resp_body_size = from(K8SServiceInstanceRelation.protocol.http.sizeOfResponseBody).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").sum();
+kubernetes_service_instance_relation_client_apdex = from(K8SServiceInstanceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").apdex(sourceServiceName, protocol.success);
+kubernetes_service_instance_relation_client_percentile = from(K8SServiceInstanceRelation.protocol.http.latency).filter(detectPoint == DetectPoint.CLIENT).filter(type == "protocol").filter(protocol.type == "http").percentile2(10);
 
 kubernetes_service_instance_relation_server_http_status_1xx_cpm = from(K8SServiceInstanceRelation.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.http.statusCode >= 100).filter(protocol.http.statusCode < 200).cpm();
 kubernetes_service_instance_relation_server_http_status_2xx_cpm = from(K8SServiceInstanceRelation.*).filter(detectPoint == DetectPoint.SERVER).filter(type == "protocol").filter(protocol.type == "http").filter(protocol.http.statusCode >= 200).filter(protocol.http.statusCode < 300).cpm();

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Endpoint.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Endpoint.json
@@ -64,7 +64,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_endpoint_http_call_duration/kubernetes_service_endpoint_http_call_cpm"
+                    "kubernetes_service_endpoint_http_call_time"
                   ],
                   "metricConfig": [
                     {
@@ -106,8 +106,8 @@
                   "i": "2",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_endpoint_http_req_header_size/kubernetes_service_endpoint_http_call_cpm/1024",
-                    "kubernetes_service_endpoint_http_req_body_size/kubernetes_service_endpoint_http_call_cpm/1024"
+                    "kubernetes_service_endpoint_http_avg_req_header_size/1024",
+                    "kubernetes_service_endpoint_http_avg_req_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -152,8 +152,8 @@
                   "i": "3",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_endpoint_http_resp_header_size/kubernetes_service_endpoint_http_call_cpm/1024",
-                    "kubernetes_service_endpoint_http_resp_body_size/kubernetes_service_endpoint_http_call_cpm/1024"
+                    "kubernetes_service_endpoint_http_avg_resp_header_size/1024",
+                    "kubernetes_service_endpoint_http_avg_resp_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Service-Instance-Relation.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Service-Instance-Relation.json
@@ -1816,13 +1816,13 @@
                   "i": "16",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_client_write_l4_duration/kubernetes_service_instance_relation_client_write_cpm",
-                    "kubernetes_service_instance_relation_client_write_l3_duration/kubernetes_service_instance_relation_client_write_cpm",
-                    "kubernetes_service_instance_relation_client_write_l3_local_duration/kubernetes_service_instance_relation_client_write_cpm",
-                    "kubernetes_service_instance_relation_client_write_l3_output_duration/kubernetes_service_instance_relation_client_write_cpm",
-                    "kubernetes_service_instance_relation_client_write_l2_duration/kubernetes_service_instance_relation_client_write_cpm",
-                    "kubernetes_service_instance_relation_client_write_l2_ready_send_duration/kubernetes_service_instance_relation_client_write_cpm",
-                    "kubernetes_service_instance_relation_client_write_l2_net_dev_send_duration/kubernetes_service_instance_relation_client_write_cpm"
+                    "kubernetes_service_instance_relation_client_write_l4_time",
+                    "kubernetes_service_instance_relation_client_write_l3_time",
+                    "kubernetes_service_instance_relation_client_write_l3_local_time",
+                    "kubernetes_service_instance_relation_client_write_l3_output_time",
+                    "kubernetes_service_instance_relation_client_write_l2_time",
+                    "kubernetes_service_instance_relation_client_write_l2_ready_send_time",
+                    "kubernetes_service_instance_relation_client_write_l2_net_dev_send_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1951,11 +1951,11 @@
                   "i": "17",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_client_read_l4_duration/kubernetes_service_instance_relation_client_read_cpm",
-                    "kubernetes_service_instance_relation_client_read_l3_duration/kubernetes_service_instance_relation_client_read_cpm",
-                    "kubernetes_service_instance_relation_client_read_l3_rcv_duration/kubernetes_service_instance_relation_client_read_cpm",
-                    "kubernetes_service_instance_relation_client_read_l3_local_duration/kubernetes_service_instance_relation_client_read_cpm",
-                    "kubernetes_service_instance_relation_client_read_l2_package_to_queue_duration/kubernetes_service_instance_relation_client_read_cpm"
+                    "kubernetes_service_instance_relation_client_read_l4_time",
+                    "kubernetes_service_instance_relation_client_read_l3_time",
+                    "kubernetes_service_instance_relation_client_read_l3_rcv_time",
+                    "kubernetes_service_instance_relation_client_read_l3_local_time",
+                    "kubernetes_service_instance_relation_client_read_l2_package_to_queue_time"
                   ],
                   "metricConfig": [
                     {
@@ -2078,13 +2078,13 @@
                   "i": "18",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_server_write_l4_duration/kubernetes_service_instance_relation_server_write_cpm",
-                    "kubernetes_service_instance_relation_server_write_l3_duration/kubernetes_service_instance_relation_server_write_cpm",
-                    "kubernetes_service_instance_relation_server_write_l3_local_duration/kubernetes_service_instance_relation_server_write_cpm",
-                    "kubernetes_service_instance_relation_server_write_l3_output_duration/kubernetes_service_instance_relation_server_write_cpm",
-                    "kubernetes_service_instance_relation_server_write_l2_duration/kubernetes_service_instance_relation_server_write_cpm",
-                    "kubernetes_service_instance_relation_server_write_l2_ready_send_duration/kubernetes_service_instance_relation_server_write_cpm",
-                    "kubernetes_service_instance_relation_server_write_l2_net_dev_send_duration/kubernetes_service_instance_relation_server_write_cpm"
+                    "kubernetes_service_instance_relation_server_write_l4_time",
+                    "kubernetes_service_instance_relation_server_write_l3_time",
+                    "kubernetes_service_instance_relation_server_write_l3_local_time",
+                    "kubernetes_service_instance_relation_server_write_l3_output_time",
+                    "kubernetes_service_instance_relation_server_write_l2_time",
+                    "kubernetes_service_instance_relation_server_write_l2_ready_send_time",
+                    "kubernetes_service_instance_relation_server_write_l2_net_dev_send_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -2213,11 +2213,11 @@
                   "i": "19",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_server_read_l4_duration/kubernetes_service_instance_relation_server_read_cpm",
-                    "kubernetes_service_instance_relation_server_read_l3_duration/kubernetes_service_instance_relation_server_read_cpm",
-                    "kubernetes_service_instance_relation_server_read_l3_rcv_duration/kubernetes_service_instance_relation_server_read_cpm",
-                    "kubernetes_service_instance_relation_server_read_l3_local_duration/kubernetes_service_instance_relation_server_read_cpm",
-                    "kubernetes_service_instance_relation_server_read_l2_package_to_queue_duration/kubernetes_service_instance_relation_server_read_cpm"
+                    "kubernetes_service_instance_relation_server_read_l4_time",
+                    "kubernetes_service_instance_relation_server_read_l3_time",
+                    "kubernetes_service_instance_relation_server_read_l3_rcv_time",
+                    "kubernetes_service_instance_relation_server_read_l3_local_time",
+                    "kubernetes_service_instance_relation_server_read_l2_package_to_queue_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3286,7 +3286,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_client_http_call_duration/kubernetes_service_instance_relation_client_http_call_cpm"
+                    "kubernetes_service_instance_relation_client_http_call_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3400,7 +3400,7 @@
                   "i": "3",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_server_http_call_duration/kubernetes_service_instance_relation_server_http_call_cpm"
+                    "kubernetes_service_instance_relation_server_http_call_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3457,8 +3457,8 @@
                   "i": "4",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_server_http_req_header_size/kubernetes_service_instance_relation_server_http_call_cpm/1024",
-                    "kubernetes_service_instance_relation_server_http_req_body_size/kubernetes_service_instance_relation_server_http_call_cpm/1024"
+                    "kubernetes_service_instance_relation_server_http_avg_req_header_size/1024",
+                    "kubernetes_service_instance_relation_server_http_avg_req_header_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3518,8 +3518,8 @@
                   "i": "5",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_server_http_resp_header_size/kubernetes_service_instance_relation_server_http_call_cpm/1024",
-                    "kubernetes_service_instance_relation_server_http_resp_body_size/kubernetes_service_instance_relation_server_http_call_cpm/1024"
+                    "kubernetes_service_instance_relation_server_http_avg_resp_header_size/1024",
+                    "kubernetes_service_instance_relation_server_http_avg_resp_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3579,8 +3579,8 @@
                   "i": "6",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_client_http_req_header_size/kubernetes_service_instance_relation_client_http_call_cpm/1024",
-                    "kubernetes_service_instance_relation_client_http_req_body_size/kubernetes_service_instance_relation_client_http_call_cpm/1024"
+                    "kubernetes_service_instance_relation_client_http_avg_req_header_size/1024",
+                    "kubernetes_service_instance_relation_client_http_avg_req_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3640,8 +3640,8 @@
                   "i": "7",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_relation_server_http_resp_header_size/kubernetes_service_instance_relation_server_http_call_cpm/1024",
-                    "kubernetes_service_instance_relation_server_http_resp_body_size/kubernetes_service_instance_relation_server_http_call_cpm/1024"
+                    "kubernetes_service_instance_relation_client_http_avg_resp_header_size/1024",
+                    "kubernetes_service_instance_relation_client_http_avg_resp_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Service-Relation.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/K8S-Service-Relation.json
@@ -1816,13 +1816,13 @@
                   "i": "16",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_client_write_l4_duration/kubernetes_service_relation_client_write_cpm",
-                    "kubernetes_service_relation_client_write_l3_duration/kubernetes_service_relation_client_write_cpm",
-                    "kubernetes_service_relation_client_write_l3_local_duration/kubernetes_service_relation_client_write_cpm",
-                    "kubernetes_service_relation_client_write_l3_output_duration/kubernetes_service_relation_client_write_cpm",
-                    "kubernetes_service_relation_client_write_l2_duration/kubernetes_service_relation_client_write_cpm",
-                    "kubernetes_service_relation_client_write_l2_ready_send_duration/kubernetes_service_relation_client_write_cpm",
-                    "kubernetes_service_relation_client_write_l2_net_dev_send_duration/kubernetes_service_relation_client_write_cpm"
+                    "kubernetes_service_relation_client_write_l4_time",
+                    "kubernetes_service_relation_client_write_l3_time",
+                    "kubernetes_service_relation_client_write_l3_local_time",
+                    "kubernetes_service_relation_client_write_l3_output_time",
+                    "kubernetes_service_relation_client_write_l2_time",
+                    "kubernetes_service_relation_client_write_l2_ready_send_time",
+                    "kubernetes_service_relation_client_write_l2_net_dev_send_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1951,11 +1951,11 @@
                   "i": "17",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_client_read_l4_duration/kubernetes_service_relation_client_read_cpm",
-                    "kubernetes_service_relation_client_read_l3_duration/kubernetes_service_relation_client_read_cpm",
-                    "kubernetes_service_relation_client_read_l3_rcv_duration/kubernetes_service_relation_client_read_cpm",
-                    "kubernetes_service_relation_client_read_l3_local_duration/kubernetes_service_relation_client_read_cpm",
-                    "kubernetes_service_relation_client_read_l2_package_to_queue_duration/kubernetes_service_relation_client_read_cpm"
+                    "kubernetes_service_relation_client_read_l4_time",
+                    "kubernetes_service_relation_client_read_l3_time",
+                    "kubernetes_service_relation_client_read_l3_rcv_time",
+                    "kubernetes_service_relation_client_read_l3_local_time",
+                    "kubernetes_service_relation_client_read_l2_package_to_queue_time"
                   ],
                   "metricConfig": [
                     {
@@ -2078,13 +2078,13 @@
                   "i": "18",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_server_write_l4_duration/kubernetes_service_relation_server_write_cpm",
-                    "kubernetes_service_relation_server_write_l3_duration/kubernetes_service_relation_server_write_cpm",
-                    "kubernetes_service_relation_server_write_l3_local_duration/kubernetes_service_relation_server_write_cpm",
-                    "kubernetes_service_relation_server_write_l3_output_duration/kubernetes_service_relation_server_write_cpm",
-                    "kubernetes_service_relation_server_write_l2_duration/kubernetes_service_relation_server_write_cpm",
-                    "kubernetes_service_relation_server_write_l2_ready_send_duration/kubernetes_service_relation_server_write_cpm",
-                    "kubernetes_service_relation_server_write_l2_net_dev_send_duration/kubernetes_service_relation_server_write_cpm"
+                    "kubernetes_service_relation_server_write_l4_time",
+                    "kubernetes_service_relation_server_write_l3_time",
+                    "kubernetes_service_relation_server_write_l3_local_time",
+                    "kubernetes_service_relation_server_write_l3_output_time",
+                    "kubernetes_service_relation_server_write_l2_time",
+                    "kubernetes_service_relation_server_write_l2_ready_send_time",
+                    "kubernetes_service_relation_server_write_l2_net_dev_send_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -2213,11 +2213,11 @@
                   "i": "19",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_server_read_l4_duration/kubernetes_service_relation_server_read_cpm",
-                    "kubernetes_service_relation_server_read_l3_duration/kubernetes_service_relation_server_read_cpm",
-                    "kubernetes_service_relation_server_read_l3_rcv_duration/kubernetes_service_relation_server_read_cpm",
-                    "kubernetes_service_relation_server_read_l3_local_duration/kubernetes_service_relation_server_read_cpm",
-                    "kubernetes_service_relation_server_read_l2_package_to_queue_duration/kubernetes_service_relation_server_read_cpm"
+                    "kubernetes_service_relation_server_read_l4_time",
+                    "kubernetes_service_relation_server_read_l3_time",
+                    "kubernetes_service_relation_server_read_l3_rcv_time",
+                    "kubernetes_service_relation_server_read_l3_local_time",
+                    "kubernetes_service_relation_server_read_l2_package_to_queue_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3286,7 +3286,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_client_http_call_cpm"
+                    "kubernetes_service_relation_client_http_call_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3400,7 +3400,7 @@
                   "i": "3",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_server_http_call_cpm"
+                    "kubernetes_service_relation_server_http_call_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3457,8 +3457,8 @@
                   "i": "4",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_server_http_req_header_size/kubernetes_service_relation_server_http_call_cpm/1024",
-                    "kubernetes_service_relation_server_http_req_body_size/kubernetes_service_relation_server_http_call_cpm/1024"
+                    "kubernetes_service_relation_server_http_avg_req_header_size/1024",
+                    "kubernetes_service_relation_server_http_avg_req_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3518,8 +3518,8 @@
                   "i": "5",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_server_http_resp_header_size/kubernetes_service_relation_server_http_call_cpm/1024",
-                    "kubernetes_service_relation_server_http_resp_body_size/kubernetes_service_relation_server_http_call_cpm/1024"
+                    "kubernetes_service_relation_server_http_avg_resp_header_size/1024",
+                    "kubernetes_service_relation_server_http_avg_resp_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3579,8 +3579,8 @@
                   "i": "6",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_client_http_req_header_size/kubernetes_service_relation_client_http_call_cpm/1024",
-                    "kubernetes_service_relation_client_http_req_body_size/kubernetes_service_relation_client_http_call_cpm/1024"
+                    "kubernetes_service_relation_client_http_avg_req_header_size/1024",
+                    "kubernetes_service_relation_client_http_avg_req_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -3640,8 +3640,8 @@
                   "i": "7",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_relation_server_http_resp_header_size/kubernetes_service_relation_server_http_call_cpm/1024",
-                    "kubernetes_service_relation_server_http_resp_body_size/kubernetes_service_relation_server_http_call_cpm/1024"
+                    "kubernetes_service_relation_client_http_avg_resp_header_size/1024",
+                    "kubernetes_service_relation_client_http_avg_resp_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-pod.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-pod.json
@@ -128,7 +128,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_connect_duration/kubernetes_service_instance_connect_cpm"
+                    "kubernetes_service_instance_connect_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -273,7 +273,7 @@
                   "i": "3",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_accept_duration/kubernetes_service_instance_accept_cpm"
+                    "kubernetes_service_instance_accept_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -652,7 +652,7 @@
                   "i": "8",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_write_duration/kubernetes_service_instance_write_cpm"
+                    "kubernetes_service_instance_write_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -722,7 +722,7 @@
                   "i": "9",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_read_duration/kubernetes_service_instance_read_cpm"
+                    "kubernetes_service_instance_read_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -792,11 +792,11 @@
                   "i": "10",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_read_l4_duration/kubernetes_service_instance_read_cpm",
-                    "kubernetes_service_instance_read_l3_duration/kubernetes_service_instance_read_cpm",
-                    "kubernetes_service_instance_read_l3_rcv_duration/kubernetes_service_instance_read_cpm",
-                    "kubernetes_service_instance_read_l3_local_duration/kubernetes_service_instance_read_cpm",
-                    "kubernetes_service_instance_read_package_to_queue_duration/kubernetes_service_instance_read_package_cpm"
+                    "kubernetes_service_instance_read_l4_time",
+                    "kubernetes_service_instance_read_l3_time",
+                    "kubernetes_service_instance_read_l3_rcv_time",
+                    "kubernetes_service_instance_read_l3_local_time",
+                    "kubernetes_service_instance_read_package_to_queue_time"
                   ],
                   "metricConfig": [
                     {
@@ -883,14 +883,14 @@
                   "i": "11",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_write_l4_duration/kubernetes_service_instance_write_cpm",
-                    "kubernetes_service_instance_write_l3_duration/kubernetes_service_instance_write_cpm",
-                    "kubernetes_service_instance_write_l3_local_duration/kubernetes_service_instance_write_cpm",
-                    "kubernetes_service_instance_write_l3_output_duration/kubernetes_service_instance_write_cpm",
-                    "kubernetes_service_instance_write_l2_duration/kubernetes_service_instance_write_cpm",
-                    "kubernetes_service_instance_write_l2_enter_queue_count/kubernetes_service_instance_write_cpm",
-                    "kubernetes_service_instance_write_l2_ready_send_duration/kubernetes_service_instance_write_cpm",
-                    "kubernetes_service_instance_write_l2_net_device_send_duration/kubernetes_service_instance_write_cpm"
+                    "kubernetes_service_instance_write_l4_time",
+                    "kubernetes_service_instance_write_l3_time",
+                    "kubernetes_service_instance_write_l3_local_time",
+                    "kubernetes_service_instance_write_l3_output_time",
+                    "kubernetes_service_instance_write_l2_time",
+                    "kubernetes_service_instance_write_l2_avg_enter_queue_count",
+                    "kubernetes_service_instance_write_l2_ready_send_time",
+                    "kubernetes_service_instance_write_l2_net_device_send_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1336,7 +1336,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm"
+                    "kubernetes_service_instance_http_call_time"
                   ],
                   "metricConfig": [
                     {
@@ -1378,8 +1378,8 @@
                   "i": "2",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_http_req_header_size/kubernetes_service_instance_http_call_cpm/1024",
-                    "kubernetes_service_instance_http_req_body_size/kubernetes_service_instance_http_call_cpm/1024"
+                    "kubernetes_service_instance_http_avg_req_header_size/1024",
+                    "kubernetes_service_instance_http_avg_req_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1424,8 +1424,8 @@
                   "i": "3",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_instance_http_resp_header_size/kubernetes_service_instance_http_call_cpm/1024",
-                    "kubernetes_service_instance_http_resp_body_size/kubernetes_service_instance_http_call_cpm/1024"
+                    "kubernetes_service_instance_http_avg_resp_header_size/1024",
+                    "kubernetes_service_instance_http_avg_resp_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1533,8 +1533,8 @@
         "avg(kubernetes_service_instance_write_package_size)/60",
         "avg(kubernetes_service_instance_read_package_size)/60",
         "avg(kubernetes_service_instance_http_call_cpm)",
-        "avg(kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm)",
-        "avg(kubernetes_service_instance_http_call_success_count / kubernetes_service_instance_http_call_cpm*100)"
+        "avg(kubernetes_service_instance_http_call_time)",
+        "avg(kubernetes_service_instance_http_call_successful_rate/100)"
       ],
       "expressionsConfig": [
         {

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-root.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-root.json
@@ -24,7 +24,7 @@
         },
         {
           "x": 0,
-          "y": 2,
+          "y": 13,
           "w": 24,
           "h": 50,
           "i": "101",
@@ -45,7 +45,7 @@
                     "latest(k8s_service_cpu_cores_requests)",
                     "latest(k8s_service_cpu_cores_limits)",
                     "latest(kubernetes_service_http_call_cpm)",
-                    "latest(kubernetes_service_http_call_success_count/kubernetes_service_http_call_cpm*100)"
+                    "latest(kubernetes_service_http_call_successful_rate/100)"
                   ],
                   "graph": {
                     "type": "ServiceList",
@@ -112,23 +112,23 @@
                     "avg(kubernetes_service_relation_server_write_package_size)/60",
                     "avg(kubernetes_service_relation_server_read_package_size)/60",
                     "avg(kubernetes_service_relation_client_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_client_http_call_cpm)"
+                    "avg(kubernetes_service_relation_client_http_call_time)"
                   ],
                   "linkClientExpressions": [
                     "avg(kubernetes_service_relation_client_write_package_size)/60",
                     "avg(kubernetes_service_relation_client_read_package_size)/60",
                     "avg(kubernetes_service_relation_server_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_server_http_call_cpm)"
+                    "avg(kubernetes_service_relation_server_http_call_time)"
                   ],
                   "nodeExpressions": [
                     "avg(kubernetes_service_write_package_size)/60",
                     "avg(kubernetes_service_read_package_size)/60",
                     "avg(kubernetes_service_http_call_cpm)",
-                    "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)",
-                    "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
+                    "avg(kubernetes_service_http_call_time)",
+                    "avg(kubernetes_service_http_call_successful_rate/100)"
                   ],
                   "legendMQE": {
-                    "expression": "(avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100) < 95) * (avg(kubernetes_service_http_call_cpm) > 1) == 1"
+                    "expression": "(avg(kubernetes_service_http_call_successful_rate) < 9500) * (avg(kubernetes_service_http_call_cpm) > 1) == 1"
                   },
                   "description": {
                     "healthy": "Healthy",
@@ -196,6 +196,78 @@
               ]
             }
           ]
+        },
+        {
+          "x": 0,
+          "y": 2,
+          "w": 6,
+          "h": 11,
+          "i": "102",
+          "type": "Widget",
+          "expressions": [
+            "top_n(kubernetes_service_apdex,10,asc,attr0='K8S_SERVICE')/10000"
+          ],
+          "graph": {
+            "type": "TopList",
+            "color": "purple"
+          },
+          "widget": {
+            "title": "Service HTTP Apdex"
+          }
+        },
+        {
+          "x": 6,
+          "y": 2,
+          "w": 6,
+          "h": 11,
+          "i": "103",
+          "type": "Widget",
+          "expressions": [
+            "top_n(kubernetes_service_http_call_successful_rate,10,asc,attr0='K8S_SERVICE')/100"
+          ],
+          "graph": {
+            "type": "TopList",
+            "color": "purple"
+          },
+          "widget": {
+            "title": "HTTP Success Rate"
+          }
+        },
+        {
+          "x": 12,
+          "y": 2,
+          "w": 6,
+          "h": 11,
+          "i": "104",
+          "type": "Widget",
+          "expressions": [
+            "top_n(kubernetes_service_http_call_time,10,des,attr0='K8S_SERVICE')"
+          ],
+          "graph": {
+            "type": "TopList",
+            "color": "purple"
+          },
+          "widget": {
+            "title": "Service Avg HTTP Response Time (ms)"
+          }
+        },
+        {
+          "x": 18,
+          "y": 2,
+          "w": 6,
+          "h": 11,
+          "i": "105",
+          "type": "Widget",
+          "expressions": [
+            "top_n(kubernetes_service_http_call_cpm,10,des,attr0='K8S_SERVICE')"
+          ],
+          "graph": {
+            "type": "TopList",
+            "color": "purple"
+          },
+          "widget": {
+            "title": "Service HTTP Load (calls / min)"
+          }
         }
       ],
       "id": "K8S-Service-Root",

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/k8s_service/k8s-service-service.json
@@ -233,23 +233,23 @@
                     "avg(kubernetes_service_relation_server_write_package_size)/60",
                     "avg(kubernetes_service_relation_server_read_package_size)/60",
                     "avg(kubernetes_service_relation_server_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_server_http_call_duration/kubernetes_service_relation_client_http_call_cpm)"
+                    "avg(kubernetes_service_relation_server_http_call_time)"
                   ],
                   "linkClientExpressions": [
                     "avg(kubernetes_service_relation_client_write_package_size)/60",
                     "avg(kubernetes_service_relation_client_read_package_size)/60",
                     "avg(kubernetes_service_relation_client_http_call_cpm)/60",
-                    "avg(kubernetes_service_relation_client_http_call_duration/kubernetes_service_relation_server_http_call_cpm)"
+                    "avg(kubernetes_service_relation_client_http_call_time)"
                   ],
                   "nodeExpressions": [
                     "avg(kubernetes_service_write_package_size)/60",
                     "avg(kubernetes_service_read_package_size)/60",
                     "avg(kubernetes_service_http_call_cpm)",
-                    "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)",
-                    "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
+                    "avg(kubernetes_service_http_call_time)",
+                    "avg(kubernetes_service_http_call_successful_rate/100)"
                   ],
                   "legendMQE": {
-                    "expression": "(avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100) < 95) * (avg(kubernetes_service_http_call_cpm) > 1) == 1"
+                    "expression": "(avg(kubernetes_service_http_call_successful_rate) < 9500) * (avg(kubernetes_service_http_call_cpm) > 1) == 1"
                   },
                   "description": {
                     "healthy": "Healthy",
@@ -406,7 +406,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_connect_duration/kubernetes_service_connect_cpm"
+                    "kubernetes_service_connect_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -551,7 +551,7 @@
                   "i": "3",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_accept_duration/kubernetes_service_accept_cpm"
+                    "kubernetes_service_accept_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -930,7 +930,7 @@
                   "i": "8",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_write_duration/kubernetes_service_write_cpm"
+                    "kubernetes_service_write_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1000,7 +1000,7 @@
                   "i": "9",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_read_duration/kubernetes_service_read_cpm"
+                    "kubernetes_service_read_time"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1070,11 +1070,11 @@
                   "i": "10",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_read_l4_duration/kubernetes_service_read_cpm",
-                    "kubernetes_service_read_l3_duration/kubernetes_service_read_cpm",
-                    "kubernetes_service_read_l3_rcv_duration/kubernetes_service_read_cpm",
-                    "kubernetes_service_read_l3_local_duration/kubernetes_service_read_cpm",
-                    "kubernetes_service_read_package_to_queue_duration/kubernetes_service_read_package_cpm"
+                    "kubernetes_service_read_l4_time",
+                    "kubernetes_service_read_l3_time",
+                    "kubernetes_service_read_l3_rcv_time",
+                    "kubernetes_service_read_l3_local_time",
+                    "kubernetes_service_read_package_to_queue_time"
                   ],
                   "metricConfig": [
                     {
@@ -1161,14 +1161,14 @@
                   "i": "11",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_write_l4_duration/kubernetes_service_write_cpm",
-                    "kubernetes_service_write_l3_duration/kubernetes_service_write_cpm",
-                    "kubernetes_service_write_l3_local_duration/kubernetes_service_write_cpm",
-                    "kubernetes_service_write_l3_output_duration/kubernetes_service_write_cpm",
-                    "kubernetes_service_write_l2_duration/kubernetes_service_write_cpm",
-                    "kubernetes_service_write_l2_enter_queue_count/kubernetes_service_write_cpm",
-                    "kubernetes_service_write_l2_ready_send_duration/kubernetes_service_write_cpm",
-                    "kubernetes_service_write_l2_net_device_send_duration/kubernetes_service_write_cpm"
+                    "kubernetes_service_write_l4_time",
+                    "kubernetes_service_write_l3_time",
+                    "kubernetes_service_write_l3_local_time",
+                    "kubernetes_service_write_l3_output_time",
+                    "kubernetes_service_write_l2_time",
+                    "kubernetes_service_write_l2_enter_avg_queue_count",
+                    "kubernetes_service_write_l2_ready_avg_send_duration",
+                    "kubernetes_service_write_l2_net_device_avg_send_duration"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1614,7 +1614,7 @@
                   "i": "1",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm"
+                    "kubernetes_service_http_call_time"
                   ],
                   "metricConfig": [
                     {
@@ -1656,8 +1656,8 @@
                   "i": "2",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_http_req_header_size/kubernetes_service_http_call_cpm/1024",
-                    "kubernetes_service_http_req_body_size/kubernetes_service_http_call_cpm/1024"
+                    "kubernetes_service_http_avg_req_header_size/1024",
+                    "kubernetes_service_http_avg_req_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1702,8 +1702,8 @@
                   "i": "3",
                   "type": "Widget",
                   "expressions": [
-                    "kubernetes_service_http_resp_header_size/kubernetes_service_http_call_cpm/1024",
-                    "kubernetes_service_http_resp_body_size/kubernetes_service_http_call_cpm/1024"
+                    "kubernetes_service_http_avg_resp_header_size/1024",
+                    "kubernetes_service_http_avg_resp_body_size/1024"
                   ],
                   "graph": {
                     "type": "Line",
@@ -1831,8 +1831,8 @@
                   ],
                   "expressions": [
                     "latest(kubernetes_service_instance_http_call_cpm)",
-                    "latest(kubernetes_service_instance_http_call_duration/kubernetes_service_instance_http_call_cpm)",
-                    "latest(kubernetes_service_instance_http_call_success_count/kubernetes_service_instance_http_call_cpm*100)"
+                    "latest(kubernetes_service_instance_http_call_time)",
+                    "latest(kubernetes_service_instance_http_call_successful_rate/100)"
                   ]
                 }
               ]
@@ -1873,13 +1873,13 @@
                   ],
                   "expressions": [
                     "avg(kubernetes_service_endpoint_call_cpm)",
-                    "avg(kubernetes_service_endpoint_call_success_cpm/kubernetes_service_endpoint_call_cpm*100)",
-                    "avg(kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm)"
+                    "avg(kubernetes_service_endpoint_call_successful_rate/100)",
+                    "avg(kubernetes_service_endpoint_call_time)"
                   ],
                   "subExpressions": [
                     "kubernetes_service_endpoint_call_cpm",
-                    "kubernetes_service_endpoint_call_success_cpm/kubernetes_service_endpoint_call_cpm*100",
-                    "kubernetes_service_endpoint_call_duration/kubernetes_service_endpoint_call_cpm"
+                    "kubernetes_service_endpoint_call_successful_rate/100",
+                    "kubernetes_service_endpoint_call_time"
                   ]
                 }
               ]
@@ -1928,8 +1928,8 @@
         "avg(kubernetes_service_write_package_size)/60",
         "avg(kubernetes_service_read_package_size)/60",
         "avg(kubernetes_service_http_call_cpm)",
-        "avg(kubernetes_service_http_call_duration/kubernetes_service_http_call_cpm)",
-        "avg(kubernetes_service_http_call_success_count / kubernetes_service_http_call_cpm*100)"
+        "avg(kubernetes_service_http_call_time)",
+        "avg(kubernetes_service_http_call_successful_rate/100)"
       ],
       "expressionsConfig": [
         {

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/accesslog-cases.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/accesslog-cases.yaml
@@ -42,7 +42,7 @@ cases:
     expected: expected/metrics-has-value.yml
   - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_read_cpm --service-name=productpage.default
     expected: expected/metrics-has-value.yml
-  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_write_l4_duration --service-name=productpage.default
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_write_l4_time --service-name=productpage.default
     expected: expected/metrics-has-value.yml
   - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_read_l4_duration --service-name=productpage.default
     expected: expected/metrics-has-value.yml

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/accesslog-cases.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/accesslog-cases.yaml
@@ -44,7 +44,7 @@ cases:
     expected: expected/metrics-has-value.yml
   - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_write_l4_time --service-name=productpage.default
     expected: expected/metrics-has-value.yml
-  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_read_l4_duration --service-name=productpage.default
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_read_l4_time --service-name=productpage.default
     expected: expected/metrics-has-value.yml
   - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_write_package_cpm --service-name=productpage.default
     expected: expected/metrics-has-value.yml
@@ -52,7 +52,7 @@ cases:
     expected: expected/metrics-has-value.yml
   - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_http_call_cpm --service-name=reviews.default
     expected: expected/metrics-has-value.yml
-  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_http_call_duration --service-name=reviews.default
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_http_call_time --service-name=reviews.default
     expected: expected/metrics-has-value.yml
 
   # service instance level metrics
@@ -66,7 +66,7 @@ cases:
     expected: expected/metrics-has-value.yml
   - query: |
       instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
-      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_write_l4_duration --service-name=productpage.default --instance-name=$instance_name
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_write_l4_time --service-name=productpage.default --instance-name=$instance_name
     expected: expected/metrics-has-value.yml
   - query: |
       instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
@@ -78,7 +78,7 @@ cases:
     expected: expected/metrics-has-value.yml
   - query: |
       instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
-      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_read_l4_duration --service-name=productpage.default --instance-name=$instance_name
+      swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_read_l4_time --service-name=productpage.default --instance-name=$instance_name
     expected: expected/metrics-has-value.yml
   - query: |
       instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name productpage.default | yq '.[0].name' -)
@@ -88,7 +88,7 @@ cases:
       instance_name=$(swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql instance ls --service-name reviews.default | yq '.[0].name' -)
       swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_instance_http_call_cpm --service-name=reviews.default --instance-name=$instance_name
     expected: expected/metrics-has-value.yml
-  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression="top_n(kubernetes_service_instance_write_l4_duration,10,des)" --service-name=details.default
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression="top_n(kubernetes_service_instance_write_l4_time,10,des)" --service-name=details.default
     expected: expected/metrics-sorted-has-value.yml
 
   # service endpoint level metrics
@@ -96,7 +96,7 @@ cases:
     expected: expected/metrics-has-value.yml
   - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression=kubernetes_service_endpoint_http_call_cpm --service-name=details.default --endpoint-name=GET:/details/0
     expected: expected/metrics-has-value.yml
-  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression="top_n(kubernetes_service_endpoint_call_duration,10,des)" --service-name=details.default
+  - query: swctl --display yaml --base-url=http://${service_skywalking_ui_host}:${service_skywalking_ui_80}/graphql metrics exec --expression="top_n(kubernetes_service_endpoint_call_time,10,des)" --service-name=details.default
     expected: expected/metrics-sorted-has-value.yml
 
   # service relation metrics


### PR DESCRIPTION
In this PR, I simplified the method of using multiple metrics for joint calculation in MQE within the Kubernetes Dashboard.
And I have generated the service list based on TopN in the Kubernetes Root Dashboard.

![image](https://github.com/user-attachments/assets/70a1bdc3-8bc4-4b8b-a64d-1447d516f884)

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
