### PR TITLE
Add naming control for `EndpointDependencyBuilder`.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -14,6 +14,7 @@
 * Support adding additional attr[0-4] for service level metrics.
 * Support async-profiler feature for performance analysis.
 * Add metrics value owner for metrics topN query result.
+* Add naming control for `EndpointDependencyBuilder`.
 
 #### UI
 

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/EndpointDepFromCrossThreadAnalysisListener.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/EndpointDepFromCrossThreadAnalysisListener.java
@@ -123,6 +123,7 @@ public class EndpointDepFromCrossThreadAnalysisListener extends CommonAnalysisLi
     @Override
     public void build() {
         depBuilders.forEach(endpointDep -> {
+            endpointDep.prepare();
             // Source endpoint meta could be generated duplicated if it belongs to an entry span of downstream.
             // But if it belongs a local or exit span, then miss it in metadata.
             // Consider OAP has the capability to remove duplicate, generate it anyway.

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/EndpointDependencyBuilder.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/EndpointDependencyBuilder.java
@@ -33,6 +33,10 @@ import org.apache.skywalking.oap.server.core.source.EndpointRelation;
 public class EndpointDependencyBuilder {
     private final RPCTrafficSourceBuilder rpcTrafficSourceBuilder;
 
+    void prepare() {
+        rpcTrafficSourceBuilder.prepare();
+    }
+
     EndpointRelation toEndpointRelation() {
         return rpcTrafficSourceBuilder.toEndpointRelation();
     }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix naming control of `EndpointDependencyBuilder`.
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

Endpoint dependency analyse generate endpoint traffic without grouping them, it produced massive endpoint traffic for restful api.
