### PR TITLE
Fix `ServerStatusService.statusWatchers` concurrent modification.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -36,6 +36,7 @@
 * BanyanDB: Speed up OAP booting while initializing BanyanDB.
 * BanyanDB: Support `@EnableSort` on the column to enable sorting for `IndexRule` and set the default to false.
 * Support `Get Effective TTL Configurations` API.
+* Fix `ServerStatusService.statusWatchers` concurrent modification.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/BootingStatus.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/BootingStatus.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.status;
 
+import java.util.concurrent.CountDownLatch;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,6 +29,7 @@ import lombok.Setter;
 @Getter
 @Setter(AccessLevel.PACKAGE)
 public class BootingStatus {
+    private final CountDownLatch bootingLatch = new CountDownLatch(1);
     /**
      * The status of OAP is fully booted successfully.
      */
@@ -36,4 +38,13 @@ public class BootingStatus {
      * The uptime in milliseconds if {@link #isBooted} is true;
      */
     private long uptime = 0;
+
+    public void setBooted(final boolean booted) {
+        isBooted = booted;
+        bootingLatch.countDown();
+    }
+
+    public void waitUntilBooted() throws InterruptedException {
+        bootingLatch.await();
+    }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/BootingStatus.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/BootingStatus.java
@@ -31,7 +31,7 @@ public class BootingStatus {
     /**
      * The status of OAP is fully booted successfully.
      */
-    private boolean isBooted = false;
+    private volatile boolean isBooted = false;
     /**
      * The uptime in milliseconds if {@link #isBooted} is true;
      */

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/BootingStatus.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/BootingStatus.java
@@ -18,7 +18,6 @@
 
 package org.apache.skywalking.oap.server.core.status;
 
-import java.util.concurrent.CountDownLatch;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -29,22 +28,12 @@ import lombok.Setter;
 @Getter
 @Setter(AccessLevel.PACKAGE)
 public class BootingStatus {
-    private final CountDownLatch bootingLatch = new CountDownLatch(1);
     /**
      * The status of OAP is fully booted successfully.
      */
-    private volatile boolean isBooted = false;
+    private boolean isBooted = false;
     /**
      * The uptime in milliseconds if {@link #isBooted} is true;
      */
     private long uptime = 0;
-
-    public void setBooted(final boolean booted) {
-        isBooted = booted;
-        bootingLatch.countDown();
-    }
-
-    public void waitUntilBooted() throws InterruptedException {
-        bootingLatch.await();
-    }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/ServerStatusService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/ServerStatusService.java
@@ -18,8 +18,8 @@
 
 package org.apache.skywalking.oap.server.core.status;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.skywalking.oap.server.core.CoreModuleConfig;
@@ -46,7 +46,7 @@ public class ServerStatusService implements Service {
     @Getter
     private ClusterStatus clusterStatus = new ClusterStatus();
 
-    private List<ServerStatusWatcher> statusWatchers = new ArrayList<>();
+    private List<ServerStatusWatcher> statusWatchers = new CopyOnWriteArrayList<>();
 
     private List<ApplicationConfiguration.ModuleConfiguration> configurations;
 
@@ -64,14 +64,6 @@ public class ServerStatusService implements Service {
     }
 
     public void rebalancedCluster(long rebalancedTime) {
-        if (!bootingStatus.isBooted()) {
-            try {
-                bootingStatus.waitUntilBooted();
-            } catch (InterruptedException e) {
-                // ignore
-            }
-        }
-
         clusterStatus.setRebalancedTime(rebalancedTime);
         manager.find(TelemetryModule.NAME)
                .provider()

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/ServerStatusService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/ServerStatusService.java
@@ -64,6 +64,10 @@ public class ServerStatusService implements Service {
     }
 
     public void rebalancedCluster(long rebalancedTime) {
+        if (!bootingStatus.isBooted()) {
+            return;
+        }
+
         clusterStatus.setRebalancedTime(rebalancedTime);
         manager.find(TelemetryModule.NAME)
                .provider()

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/ServerStatusService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/status/ServerStatusService.java
@@ -65,7 +65,11 @@ public class ServerStatusService implements Service {
 
     public void rebalancedCluster(long rebalancedTime) {
         if (!bootingStatus.isBooted()) {
-            return;
+            try {
+                bootingStatus.waitUntilBooted();
+            } catch (InterruptedException e) {
+                // ignore
+            }
         }
 
         clusterStatus.setRebalancedTime(rebalancedTime);


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix `ServerStatusService.statusWatchers` concurrent modification.
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

`ServerStatusService#registerWatcher` called in main thread and `ServerStatusService#rebalancedCluster` called in 
cluster coordinator thread, this may cause concurrent modification of statusWatchers ArrayList when oap server bootstrap.

![ccdee70023589eacb6b37e5648848ace](https://github.com/user-attachments/assets/97c4d216-05b7-45b6-8be7-a0bbc4ed39a5)