### PR TITLE
Add protection for dynamic config change propagate chain.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -37,6 +37,7 @@
 * BanyanDB: Support `@EnableSort` on the column to enable sorting for `IndexRule` and set the default to false.
 * Support `Get Effective TTL Configurations` API.
 * Fix `ServerStatusService.statusWatchers` concurrent modification.
+* Add protection for dynamic config change propagate chain.
 
 #### UI
 

--- a/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigWatcherRegister.java
+++ b/oap-server/server-configuration/configuration-api/src/main/java/org/apache/skywalking/oap/server/configuration/api/ConfigWatcherRegister.java
@@ -37,17 +37,25 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
         if (newItemValue == null) {
             if (watcher.value() != null) {
                 // Notify watcher, the new value is null with delete event type.
-                watcher.notify(
-                    new ConfigChangeWatcher.ConfigChangeEvent(null, ConfigChangeWatcher.EventType.DELETE));
+                try {
+                    watcher.notify(
+                        new ConfigChangeWatcher.ConfigChangeEvent(null, ConfigChangeWatcher.EventType.DELETE));
+                } catch (Exception e) {
+                    log.error("notify config change watcher {} failed", watcher, e);
+                }
             } else {
                 // Don't need to notify, stay in null.
             }
         } else {
             if (!newItemValue.equals(watcher.value())) {
-                watcher.notify(new ConfigChangeWatcher.ConfigChangeEvent(
-                    newItemValue,
-                    ConfigChangeWatcher.EventType.MODIFY
-                ));
+                try {
+                    watcher.notify(new ConfigChangeWatcher.ConfigChangeEvent(
+                        newItemValue,
+                        ConfigChangeWatcher.EventType.MODIFY
+                    ));
+                } catch (Exception e) {
+                    log.error("notify config change watcher {} failed", watcher, e);
+                }
             } else {
                 // Don't need to notify, stay in the same config value.
             }
@@ -99,7 +107,11 @@ public abstract class ConfigWatcherRegister implements DynamicConfigurationServi
         });
 
         if (changedGroupItems.size() > 0) {
-            watcher.notifyGroup(changedGroupItems);
+            try {
+                watcher.notifyGroup(changedGroupItems);
+            } catch (Exception e) {
+                log.error("notify config change watcher {} failed", watcher, e);
+            }
         }
     }
 


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Add protection for dynamic config change propagate chain.
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

If user misconfig wrong rules(eg: wrong metrics name for alarm rule), config notify will skip the next watchers like apdex, agent-configuration, endpoint grouping. 

Add protection for every watcher notify method can improve the robustness of dynamic config notification.