### PR TITLE
Update browser protocol

### DIFF
--- a/docs/en/api/browser-http-api-protocol.md
+++ b/docs/en/api/browser-http-api-protocol.md
@@ -59,25 +59,6 @@ OutPut:
 
 Http Status: 204
 
-### POST http://localhost:12800/browser/perfData/webInteraction
-
-Send a performance data object in JSON format. Since client-js 1.0.0, the following attached metrics are reported.
-
-Input:
-
-```json
-{
-  "service": "web",
-  "serviceVersion": "v0.0.1",
-  "pagePath": "/index.html",
-  "fidTime": 10,
-}
-```
-
-OutPut:
-
-Http Status: 204
-
 ### POST http://localhost:12800/browser/perfData/resources
 
 Send a static resources data object in JSON format. Since client-js 1.0.0, the following attached metrics are reported.


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

Since the [FID](https://developer.mozilla.org/en-US/docs/Glossary/First_input_delay) metric has removed from `[Core Web Vitals](https://developers.google.com/search/docs/appearance/core-web-vitals)`, I also remove it here and will remove it from browser agent. And will implement the INP metric to replace the FID metric in browser agent.

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
