### PR TITLE
Support `labelAvg` function in the OAL engine

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -13,7 +13,7 @@
     source tar from the website and publish them to your private maven repository.
 * [Breaking Change] Remove H2 as storage option permanently. BanyanDB 0.8(OAP 10.2 required) is easy, stable and 
   production-ready. Don't need H2 as default storage anymore.
-* Support `labelCount` function in the OAL engine.
+* Support `labelAvg` function in the OAL engine.
 * Added `maxLabelCount` parameter in the `labelCount` function of OAL to limit the number of labels can be counted.
 
 #### OAP Server

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -13,6 +13,8 @@
     source tar from the website and publish them to your private maven repository.
 * [Breaking Change] Remove H2 as storage option permanently. BanyanDB 0.8(OAP 10.2 required) is easy, stable and 
   production-ready. Don't need H2 as default storage anymore.
+* Support `labelCount` function in the OAL engine.
+* Added `maxLabelCount` parameter in the `labelCount` function of OAL to limit the number of labels can be counted.
 
 #### OAP Server
 

--- a/docs/en/concepts-and-designs/oal.md
+++ b/docs/en/concepts-and-designs/oal.md
@@ -103,9 +103,14 @@ In this case, see `p99`, `p95`, `p90`, `p75`, and `p50` of all incoming requests
 In this case, the p99 value of all incoming requests. The parameter is precise to a latency at p99, such as in the above case, and 120ms and 124ms are considered to produce the same response time.
 
 - `labelCount`. The count of the label value.
-> drop_reason_count = from(CiliumService.*).filter(verdict == "dropped").labelCount(dropReason);
+> drop_reason_count = from(CiliumService.*).filter(verdict == "dropped").labelCount(dropReason, 100);
 
-In this case, the count of the drop reason of each Cilium service. 
+In this case, the count of the drop reason of each Cilium service, max support calculate `100` reasons(optional configuration). 
+
+- `labelAvg`. The avg of the label value.
+> drop_reason_avg = from(BrowserResourcePerf.*).labelAvg(name, duration, 100);
+
+In this case, the avg of the duration of each browser resource file, max support calculate `100` resource file(optional configuration).
 
 ## Metrics name
 The metrics name for storage implementor, alarm and query modules. The type inference is supported by core.

--- a/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/AggregationFuncStmt.java
+++ b/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/AggregationFuncStmt.java
@@ -67,4 +67,8 @@ public class AggregationFuncStmt {
     public Argument getNextFuncArg() {
         return funcArgs.get(argGetIdx++);
     }
+
+    public boolean hasNextArg() {
+        return argGetIdx < funcArgs.size();
+    }
 }

--- a/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/DeepAnalysis.java
+++ b/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/rt/parser/DeepAnalysis.java
@@ -23,6 +23,7 @@ import org.apache.skywalking.oal.rt.util.TypeCastUtil;
 import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
 import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.Arg;
 import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.ConstOne;
+import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.DefaultValue;
 import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.Entrance;
 import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.SourceFrom;
 import org.apache.skywalking.oap.server.core.storage.annotation.Column;
@@ -123,6 +124,12 @@ public class DeepAnalysis {
                 }
             } else if (annotation instanceof Arg) {
                 entryMethod.addArg(parameterType, result.getAggregationFuncStmt().getNextFuncArg());
+            } else if (annotation instanceof DefaultValue) {
+                if (result.getAggregationFuncStmt().hasNextArg()) {
+                    entryMethod.addArg(parameterType, result.getAggregationFuncStmt().getNextFuncArg());
+                } else {
+                    entryMethod.addArg(parameterType, ((DefaultValue) annotation).value());
+                }
             } else {
                 throw new IllegalArgumentException(
                     "Entrance method:" + entranceMethod + " doesn't the expected annotation.");

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/DataTable.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/DataTable.java
@@ -70,8 +70,18 @@ public class DataTable implements StorageDataComplexObject<DataTable> {
      * Accumulate the value with existing value in the same given key.
      */
     public void valueAccumulation(String key, Long value) {
+        this.valueAccumulation(key, value, 0);
+    }
+
+    /**
+     * Accumulate the value with existing value in the same given key, and limit the data size.
+     */
+    public void valueAccumulation(String key, Long value, int maxDataSize) {
         Long element = data.get(key);
         if (element == null) {
+            if (maxDataSize > 0 && data.size() >= maxDataSize) {
+                return;
+            }
             element = value;
         } else {
             element += value;
@@ -155,9 +165,16 @@ public class DataTable implements StorageDataComplexObject<DataTable> {
     }
 
     public DataTable append(DataTable dataTable) {
+        return this.append(dataTable, 0);
+    }
+
+    public DataTable append(DataTable dataTable, int maxDataSize) {
         dataTable.data.forEach((key, value) -> {
             Long current = this.data.get(key);
             if (current == null) {
+                if (maxDataSize > 0 && data.size() >= maxDataSize) {
+                    return;
+                }
                 current = value;
             } else {
                 current += value;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/LabelAvgMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/LabelAvgMetrics.java
@@ -26,7 +26,6 @@ import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.Entranc
 import org.apache.skywalking.oap.server.core.analysis.metrics.annotation.MetricsFunction;
 import org.apache.skywalking.oap.server.core.storage.annotation.BanyanDB;
 import org.apache.skywalking.oap.server.core.storage.annotation.Column;
-import org.apache.skywalking.oap.server.core.storage.annotation.ElasticSearch;
 
 import java.util.Objects;
 import java.util.Set;
@@ -42,19 +41,16 @@ public abstract class LabelAvgMetrics extends Metrics implements LabeledValueHol
     @Getter
     @Setter
     @Column(name = SUMMATION, storageOnly = true)
-    @ElasticSearch.Column(legacyName = "summation")
     @BanyanDB.MeasureField
     protected DataTable summation;
     @Getter
     @Setter
     @Column(name = COUNT, storageOnly = true)
-    @ElasticSearch.Column(legacyName = "count")
     @BanyanDB.MeasureField
     protected DataTable count;
     @Getter
     @Setter
     @Column(name = VALUE, dataType = Column.ValueDataType.LABELED_VALUE, storageOnly = true)
-    @ElasticSearch.Column(legacyName = "value")
     @BanyanDB.MeasureField
     private DataTable value;
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/LabelAvgMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/LabelAvgMetrics.java
@@ -68,7 +68,7 @@ public abstract class LabelAvgMetrics extends Metrics implements LabeledValueHol
     }
 
     @Entrance
-    public final void combine(@Arg String label, @Arg long count, @DefaultValue("1024") int maxLabelCount) {
+    public final void combine(@Arg String label, @Arg long count, @DefaultValue("50") int maxLabelCount) {
         this.isCalculated = false;
         this.maxLabelCount = maxLabelCount;
         this.summation.valueAccumulation(label, count, maxLabelCount);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/LabelCountMetrics.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/LabelCountMetrics.java
@@ -58,7 +58,7 @@ public abstract class LabelCountMetrics extends Metrics implements LabeledValueH
     }
 
     @Entrance
-    public final void combine(@Arg String label, @ConstOne long count, @DefaultValue("1024") int maxLabelCount) {
+    public final void combine(@Arg String label, @ConstOne long count, @DefaultValue("50") int maxLabelCount) {
         this.isCalculated = false;
         this.maxLabelCount = maxLabelCount;
         this.dataset.valueAccumulation(label, count, maxLabelCount);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/annotation/DefaultValue.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/metrics/annotation/DefaultValue.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.analysis.metrics.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DefaultValue {
+    String value();
+}


### PR DESCRIPTION
For implementation the OAP side of https://github.com/apache/skywalking/blob/master/docs/en/api/browser-http-api-protocol.md#post-httplocalhost12800browserperfdataresources, the OAP need to support `labelAvg` function in the OAL engine. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
