### PR TITLE
MQE: Support `&&(and)`, `||(or)` bool operators.

### DIFF
--- a/docs/en/api/metrics-query-expression.md
+++ b/docs/en/api/metrics-query-expression.md
@@ -163,6 +163,28 @@ and get result:
 ### Compare Operation Rules and Result Type
 Same as the [Binary Operation Rules](#binary-operation-rules).
 
+## Bool Operation
+Bool Operation takes two `compare` expressions and performs a logical operation on their results.
+The following table lists the bool operations supported by MQE.
+
+Expression:
+```text
+Compare Expression1 <Bool-Operator> Expression2
+```
+**Notice**: The `Bool-Operator` only supports the `compare` expressions, which means the result of the left and right expressions should be `Compare Operation Result`.
+
+| Operator | Definition  |
+|----------|-------------|
+| &&       | logical AND |
+| \|\|     | logical OR  |
+
+For example:
+If we want to query the `service_resp_time` metric value greater than 3000 and `service_cpm` less than 1000, we can use the following expression:
+
+```text
+service_resp_time > 3000 && service_cpm < 1000
+```
+
 ## Aggregation Operation
 Aggregation Operation takes an expression and performs aggregate calculations on its results.
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -61,6 +61,7 @@
 * Adapt the new Browser API(`/browser/perfData/webVitals`, `/browser/perfData/resources`) protocol.
 * Add Circuit Breaking mechanism.
 * BanyanDB: Add support for compatibility checks based on the BanyanDB server's API version.
+* MQE: Support `&&(and)`, `||(or)` bool operators.
 
 #### UI
 

--- a/docs/en/setup/backend/backend-alarm.md
+++ b/docs/en/setup/backend/backend-alarm.md
@@ -20,7 +20,8 @@ Defines the relation between scope and entity name.
 An alerting rule is made up of the following elements:
 - **Rule name**. A unique name shown in the alarm message. It must end with `_rule`.
 - **Expression**. A [MQE](../../api/metrics-query-expression.md) expression that defines the conditions of the rule.
-The result type must be `SINGLE_VALUE` and the root operation of the expression must be a [Compare Operation](../../api/metrics-query-expression.md#compare-operation) which provides `1`(true) or `0`(false) result.
+The result type must be `SINGLE_VALUE` and the root operation of the expression must be a 
+[Compare Operation](../../api/metrics-query-expression.md#compare-operation) or [Bool Operation](../../api/metrics-query-expression.md#bool-operation) which provides `1`(true) or `0`(false) result.
 When the result is `1`(true), the alarm will be triggered.
 For example, `avg(service_resp_time / 1000) > 1` is a valid expression to indicate the request latency is slower than 1s. The typical illegal expressions are
     - `avg(service_resp_time > 1000) + 1` expression root doesn't use `Compare Operation`
@@ -95,7 +96,7 @@ rules:
       - "slack.custom1"
       - "pagerduty.custom1"
   comp_rule:
-    expression: (avg(service_sla / 100) > 80) * (avg(service_percentile{p='0'}) > 1000) == 1
+    expression: (avg(service_sla / 100) > 80) && (avg(service_percentile{p='0'}) > 1000)
     period: 10
     message: Service {name} avg successful rate is less than 80% and P50 of avg response time is over 1000ms in last 10 minutes.
     tags:

--- a/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQELexer.g4
+++ b/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQELexer.g4
@@ -46,6 +46,10 @@ LT:          '<';
 GTE:         '>=';
 GT:          '>';
 
+// Bool operators
+AND:         '&&';
+OR:          '||';
+
 // Aggregation operators
 AVG:         'avg';
 COUNT:       'count';

--- a/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQEParser.g4
+++ b/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQEParser.g4
@@ -28,6 +28,7 @@ expression
     | expression mulDivMod expression  # mulDivModOp
     | expression addSub expression     # addSubOp
     | expression compare expression    # compareOp
+    | expression bool_operator expression #boolOP
     | aggregation L_PAREN expression R_PAREN # aggregationOp
     | mathematical_operator0 L_PAREN expression R_PAREN #mathematicalOperator0OP
     | mathematical_operator1 L_PAREN expression COMMA parameter R_PAREN #mathematicalOperator1OP
@@ -81,6 +82,9 @@ topNOf: TOP_N_OF;
 
 logical_operator:
     VIEW_AS_SEQ | IS_PRESENT;
+
+bool_operator:
+    AND | OR;
 
 relabels: RELABELS;
 

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/MQEVisitorBase.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/MQEVisitorBase.java
@@ -452,7 +452,7 @@ public abstract class MQEVisitorBase extends MQEParserBaseVisitor<ExpressionResu
             }
             int opType = ctx.bool_operator().getStart().getType();
             try {
-                ExpressionResult result = BoolOp.doBoolOp(left, right, opType);;
+                ExpressionResult result = BoolOp.doBoolOp(left, right, opType);
                 if (ctx.parent == null ||
                     ctx.parent instanceof MQEParser.ParensOpContext ||
                     ctx.parent instanceof MQEParser.BoolOPContext) {

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/BoolOp.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/BoolOp.java
@@ -21,7 +21,6 @@ package org.apache.skywalking.mqe.rt.operation;
 import org.apache.skywalking.mqe.rt.exception.IllegalExpressionException;
 import org.apache.skywalking.mqe.rt.grammar.MQEParser;
 import org.apache.skywalking.oap.server.core.query.mqe.ExpressionResult;
-import org.apache.skywalking.oap.server.core.query.mqe.ExpressionResultType;
 
 public class BoolOp {
     public static ExpressionResult doBoolOp(ExpressionResult left,

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/BoolOp.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/BoolOp.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.mqe.rt.operation;
+
+import org.apache.skywalking.mqe.rt.exception.IllegalExpressionException;
+import org.apache.skywalking.mqe.rt.grammar.MQEParser;
+import org.apache.skywalking.oap.server.core.query.mqe.ExpressionResult;
+import org.apache.skywalking.oap.server.core.query.mqe.ExpressionResultType;
+
+public class BoolOp {
+    public static ExpressionResult doBoolOp(ExpressionResult left,
+                                            ExpressionResult right,
+                                            int opType) throws IllegalExpressionException {
+        if (!checkExpression(left)) {
+            throw new IllegalExpressionException(
+                "Bool Operation: The result of the left expression is not a compare result.");
+        }
+
+        if (!checkExpression(right)) {
+            throw new IllegalExpressionException(
+                "Bool Operation: The result of the right expression is not a compare result.");
+        }
+
+        try {
+            return LROp.doLROp(left, right, opType, BoolOp::boolOp);
+        } catch (IllegalExpressionException e) {
+            throw new IllegalExpressionException("Unsupported bool operation: " + e.getMessage());
+        }
+    }
+
+    //bool with bool
+    private static double boolOp(double leftValue, double rightValue, int opType) throws IllegalExpressionException {
+        // this should not happen, but just in case
+        if (!checkBool(leftValue)) {
+            throw new IllegalExpressionException("Bool Operation: The result of the left expression is not 1 or 0.");
+        }
+        if (!checkBool(rightValue)) {
+            throw new IllegalExpressionException("Bool Operation: The result of the right expression is not 1 or 0.");
+        }
+        switch (opType) {
+            case MQEParser.AND:
+                if (leftValue == 1 && rightValue == 1) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            case MQEParser.OR:
+                if (leftValue == 1 || rightValue == 1) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            default:
+                throw new IllegalExpressionException("Unsupported bool operation.");
+        }
+    }
+
+    private static boolean checkExpression(ExpressionResult result) {
+        return result.isBoolResult();
+    }
+
+    private static boolean checkBool(double v) {
+        int i = (int) v;
+        return i == 0 || i == 1;
+    }
+}

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/LROp.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/operation/LROp.java
@@ -33,7 +33,7 @@ import org.apache.skywalking.oap.server.core.query.type.KeyValue;
 @FunctionalInterface
 public interface LROp {
 
-    double apply(double left, double right, int opType);
+    double apply(double left, double right, int opType) throws IllegalExpressionException;
 
     static ExpressionResult doLROp(ExpressionResult left,
                                           ExpressionResult right,
@@ -162,8 +162,8 @@ public interface LROp {
             singleResult.getResults().get(0).getValues().size() != 1) {
             throw new IllegalExpressionException("Many to One, single result is empty or has more than one value.");
         }
-        manyResult.getResults().forEach(mqeValues -> {
-            mqeValues.getValues().forEach(mqeValue -> {
+        for (MQEValues mqeValues : manyResult.getResults()) {
+            for (MQEValue mqeValue : mqeValues.getValues()) {
                 if (!mqeValue.isEmptyValue()) {
                     double newValue = calculate.apply(
                         mqeValue.getDoubleValue(), singleResult.getResults()
@@ -173,8 +173,8 @@ public interface LROp {
                                                                .getDoubleValue(), opType);
                     mqeValue.setDoubleValue(newValue);
                 }
-            });
-        });
+            }
+        }
         return manyResult;
     }
 
@@ -186,8 +186,8 @@ public interface LROp {
             singleResult.getResults().get(0).getValues().size() != 1) {
             throw new IllegalExpressionException("One to Many, single result is empty or has more than one value.");
         }
-        manyResult.getResults().forEach(mqeValues -> {
-            mqeValues.getValues().forEach(mqeValue -> {
+        for (MQEValues mqeValues : manyResult.getResults()) {
+            for (MQEValue mqeValue : mqeValues.getValues()) {
                 if (!mqeValue.isEmptyValue()) {
                     double newValue = calculate.apply(
                         singleResult.getResults()
@@ -199,8 +199,8 @@ public interface LROp {
                     );
                     mqeValue.setDoubleValue(newValue);
                 }
-            });
-        });
+            }
+        }
         return manyResult;
     }
 

--- a/oap-server/mqe-rt/src/test/java/org/apache/skywalking/mqe/rt/BoolOpTest.java
+++ b/oap-server/mqe-rt/src/test/java/org/apache/skywalking/mqe/rt/BoolOpTest.java
@@ -52,11 +52,11 @@ public class BoolOpTest {
 
     @Test
     public void boolOpLabeledTest() throws IllegalExpressionException {
-        ExpressionResult left = mockData.newSingleLabeledResult(1,0);
+        ExpressionResult left = mockData.newSingleLabeledResult(1, 0);
         left.setBoolResult(true);
         left.getResults().get(1).getValues().get(0).setEmptyValue(false);
 
-        ExpressionResult right = mockData.newSingleLabeledResult(0,1);
+        ExpressionResult right = mockData.newSingleLabeledResult(0, 1);
         right.getResults().get(0).getValues().get(0).setEmptyValue(false);
         right.setBoolResult(true);
 
@@ -66,11 +66,11 @@ public class BoolOpTest {
         Assertions.assertEquals(0, andResult.getResults().get(1).getValues().get(0).getDoubleValue());
         Assertions.assertEquals(ExpressionResultType.SINGLE_VALUE, andResult.getType());
 
-        left = mockData.newSingleLabeledResult(1,0);
+        left = mockData.newSingleLabeledResult(1, 0);
         left.setBoolResult(true);
         left.getResults().get(1).getValues().get(0).setEmptyValue(false);
 
-        right = mockData.newSingleLabeledResult(0,1);
+        right = mockData.newSingleLabeledResult(0, 1);
         right.getResults().get(0).getValues().get(0).setEmptyValue(false);
         right.setBoolResult(true);
         ExpressionResult orResult = BoolOp.doBoolOp(left, right, MQEParser.OR);

--- a/oap-server/mqe-rt/src/test/java/org/apache/skywalking/mqe/rt/BoolOpTest.java
+++ b/oap-server/mqe-rt/src/test/java/org/apache/skywalking/mqe/rt/BoolOpTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.mqe.rt;
+
+import org.apache.skywalking.mqe.rt.exception.IllegalExpressionException;
+import org.apache.skywalking.mqe.rt.grammar.MQEParser;
+import org.apache.skywalking.mqe.rt.operation.BoolOp;
+import org.apache.skywalking.oap.server.core.query.mqe.ExpressionResult;
+import org.apache.skywalking.oap.server.core.query.mqe.ExpressionResultType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BoolOpTest {
+    private final MockData mockData = new MockData();
+
+    @Test
+    public void boolOpNoLabeledTest() throws IllegalExpressionException {
+        ExpressionResult left = mockData.newSingleResult(1);
+        left.setBoolResult(true);
+        ExpressionResult right = mockData.newSingleResult(0);
+        right.getResults().get(0).getValues().get(0).setEmptyValue(false);
+        right.setBoolResult(true);
+        ExpressionResult andResult = BoolOp.doBoolOp(left, right, MQEParser.AND);
+        Assertions.assertEquals(ExpressionResultType.SINGLE_VALUE, andResult.getType());
+
+        Assertions.assertEquals(0, andResult.getResults().get(0).getValues().get(0).getDoubleValue());
+        left = mockData.newSingleResult(1);
+        left.setBoolResult(true);
+        right = mockData.newSingleResult(0);
+        right.getResults().get(0).getValues().get(0).setEmptyValue(false);
+        right.setBoolResult(true);
+        ExpressionResult orResult = BoolOp.doBoolOp(left, right, MQEParser.OR);
+        Assertions.assertEquals(1, orResult.getResults().get(0).getValues().get(0).getDoubleValue());
+        Assertions.assertEquals(ExpressionResultType.SINGLE_VALUE, orResult.getType());
+    }
+
+    @Test
+    public void boolOpLabeledTest() throws IllegalExpressionException {
+        ExpressionResult left = mockData.newSingleLabeledResult(1,0);
+        left.setBoolResult(true);
+        left.getResults().get(1).getValues().get(0).setEmptyValue(false);
+
+        ExpressionResult right = mockData.newSingleLabeledResult(0,1);
+        right.getResults().get(0).getValues().get(0).setEmptyValue(false);
+        right.setBoolResult(true);
+
+        ExpressionResult andResult = BoolOp.doBoolOp(left, right, MQEParser.AND);
+
+        Assertions.assertEquals(0, andResult.getResults().get(0).getValues().get(0).getDoubleValue());
+        Assertions.assertEquals(0, andResult.getResults().get(1).getValues().get(0).getDoubleValue());
+        Assertions.assertEquals(ExpressionResultType.SINGLE_VALUE, andResult.getType());
+
+        left = mockData.newSingleLabeledResult(1,0);
+        left.setBoolResult(true);
+        left.getResults().get(1).getValues().get(0).setEmptyValue(false);
+
+        right = mockData.newSingleLabeledResult(0,1);
+        right.getResults().get(0).getValues().get(0).setEmptyValue(false);
+        right.setBoolResult(true);
+        ExpressionResult orResult = BoolOp.doBoolOp(left, right, MQEParser.OR);
+        Assertions.assertEquals(1, orResult.getResults().get(0).getValues().get(0).getDoubleValue());
+        Assertions.assertEquals(1, orResult.getResults().get(1).getValues().get(0).getDoubleValue());
+        Assertions.assertEquals(ExpressionResultType.SINGLE_VALUE, orResult.getType());
+    }
+}

--- a/test/e2e-v2/cases/alarm/alarm-settings.yml
+++ b/test/e2e-v2/cases/alarm/alarm-settings.yml
@@ -37,7 +37,7 @@ rules:
     hooks:
       - webhook.none
   comp_rule:
-    expression: sum((service_resp_time > 10) * (service_sla > 100)) >= 1
+    expression: sum((service_resp_time > 10) && (service_sla > 100)) >= 1
     period: 10
     message: Service {name} response time is more than 10ms and sla is more than 1%.
     tags:

--- a/test/e2e-v2/cases/alarm/expected/silence-after-graphql-critical.yml
+++ b/test/e2e-v2/cases/alarm/expected/silence-after-graphql-critical.yml
@@ -41,7 +41,7 @@ msgs:
         layer: GENERAL
       {{- end }}
     snapshot:
-      expression: sum((service_resp_time > 10) * (service_sla > 100)) >= 1
+      expression: sum((service_resp_time > 10) && (service_sla > 100)) >= 1
       metrics:
       {{- contains .snapshot.metrics }}
       - name: service_resp_time

--- a/test/e2e-v2/cases/alarm/expected/silence-before-graphql-critical.yml
+++ b/test/e2e-v2/cases/alarm/expected/silence-before-graphql-critical.yml
@@ -41,7 +41,7 @@ msgs:
         layer: GENERAL
       {{- end }}
     snapshot:
-      expression: sum((service_resp_time > 10) * (service_sla > 100)) >= 1
+      expression: sum((service_resp_time > 10) && (service_sla > 100)) >= 1
       metrics:
       {{- contains .snapshot.metrics }}
       - name: service_resp_time

--- a/test/e2e-v2/cases/mqe/expected/bool-OP.yml
+++ b/test/e2e-v2/cases/mqe/expected/bool-OP.yml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: SINGLE_VALUE
+results:
+  - metric:
+      labels: []
+    values:
+      - id: null
+        owner: null
+        value: "1"
+        traceid: null
+error: null
+debuggingtrace: null

--- a/test/e2e-v2/cases/mqe/mqe-cases.yaml
+++ b/test/e2e-v2/cases/mqe/mqe-cases.yaml
@@ -28,6 +28,14 @@ cases:
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="(service_cpm + 1) > 2" --service-name=e2e-service-provider
     expected: expected/compare-OP.yml
 
+  # bool-OP
+  # SINGLE_VALUE
+  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="avg(service_cpm + 1) > 2 && avg(service_sla/100) > 95" --service-name=e2e-service-provider
+    expected: expected/bool-OP.yml
+  # TIME_SERIES_VALUES
+  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="(service_cpm + 1) > 2 && (service_sla/100) > 95" --service-name=e2e-service-provider
+    expected: expected/compare-OP.yml
+
   # aggregation-OP
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="avg(service_sla/100)" --service-name=e2e-service-provider
     expected: expected/aggregation-OP.yml


### PR DESCRIPTION

- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [X] Update the documentation to include this new feature.
- [X] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
