### PR TITLE
Predicted value level declaration in baseline module

### DIFF
--- a/oap-server/metrics-baseline/src/main/proto/baseline.proto
+++ b/oap-server/metrics-baseline/src/main/proto/baseline.proto
@@ -87,6 +87,7 @@ message AlarmBaselinePredicatedValue {
     }
 }
 
+// The predicted value. It must be minute level. 
 message AlarmBaselineValue {
     // The predicted value.
     int64 value = 1;

--- a/oap-server/metrics-baseline/src/main/proto/baseline.proto
+++ b/oap-server/metrics-baseline/src/main/proto/baseline.proto
@@ -87,7 +87,7 @@ message AlarmBaselinePredicatedValue {
     }
 }
 
-// The predicted value. It must be minute level. 
+// The predicted value. The metric values provided within this baseline are at a minute-level granularity. For example, it includes metrics such as the number of visits per minute.
 message AlarmBaselineValue {
     // The predicted value.
     int64 value = 1;


### PR DESCRIPTION
The predicted value in the baseline statement must be at the minute level.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
