### PR TITLE
Prevent traffic metrics inconsistent between in-memory and database server.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -71,6 +71,7 @@
 * Bump up netty to 4.11.118 to fix CVE-2025-24970.
 * Add `Get Alarm Runtime Status` API.
 * Add `lock` when query the Alarm metrics window values.
+* Add a fail-safe mechanism to prevent traffic metrics inconsistent between in-memory and database server.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
@@ -107,7 +107,7 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> implemen
                             long storageSessionTimeout, int metricsDataTTL, MetricStreamKind kind) {
         super(moduleDefineHolder, new ReadWriteSafeCache<>(new MergableBufferedData(), new MergableBufferedData()));
         this.model = model;
-        this.sessionCache = new MetricsSessionCache(storageSessionTimeout);
+        this.sessionCache = new MetricsSessionCache(storageSessionTimeout, supportUpdate);
         this.metricsDAO = metricsDAO;
         this.nextAlarmWorker = Optional.ofNullable(nextAlarmWorker);
         this.nextExportWorker = Optional.ofNullable(nextExportWorker);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsSessionCache.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsSessionCache.java
@@ -78,7 +78,7 @@ public class MetricsSessionCache {
 
     /**
      * This method relies on the response of database flush callback.
-     * Push the data into the in-memory cache for all metrics except {@link MetricsExtension#supportUpdate()} labelled
+     * Push the data into the in-memory cache for all metrics except {@link MetricsExtension#supportUpdate()} labeled
      * as false.
      * Because those data(e.g. {@link ServiceTraffic}) is one-time writing in the whole TTL period, and some
      * database(e.g. BanyanDB) has in-memory cache at the server side to improve performance but trade off the 100%

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsSessionCache.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsSessionCache.java
@@ -85,7 +85,7 @@ public class MetricsSessionCache {
      * eventual consistency of writing, which means database server could respond
      * {@link SessionCacheCallback#onInsertCompleted()} but ends of writing failure caused by crashing.
      * This fail-safe mechanism would require the cache of this kind of metric must be read through
-     * {@link IMetricsDAO#multiGet(Model, List)} which guaranteed data existing.
+     * {@link IMetricsDAO#multiGet(Model, List)} which guaranteed data existence.
      */
     public void cacheAfterFlush(Metrics metrics) {
         if (supportUpdate) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/SessionCacheCallback.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/SessionCacheCallback.java
@@ -40,7 +40,7 @@ public class SessionCacheCallback {
         if (isFailed) {
             return;
         }
-        sessionCache.put(metrics);
+        sessionCache.cacheAfterFlush(metrics);
     }
 
     public void onUpdateFailure() {


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

This method relies on the response of database flush callback.
Push the data into the in-memory cache for all metrics except {@link MetricsExtension#supportUpdate()} labeled as false.
Because those data(e.g. {@link ServiceTraffic}) is one-time writing in the whole TTL period, and some database(e.g. BanyanDB) has in-memory cache at the server side to improve performance but trade off the 100% eventual consistency of writing, which means database server could respond {@link SessionCacheCallback#onInsertCompleted()} but ends of writing failure caused by crashing.
This fail-safe mechanism would require the cache of this kind of metric must be read through {@link IMetricsDAO#multiGet(Model, List)} which guaranteed data existence.