### PR TITLE
Optimize metrics cache loading when trace latency greater than cache timeout

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -74,6 +74,7 @@
 * Add `lock` when query the Alarm metrics window values.
 * Add a fail-safe mechanism to prevent traffic metrics inconsistent between in-memory and database server.
 * Add more clear logs when oap-cluster-internal data(metrics/traffic) format is inconsistent.
+* Optimize metrics cache loading when trace latency greater than cache timeout. 
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java
@@ -379,16 +379,16 @@ public class MetricsPersistentWorker extends PersistenceWorker<Metrics> implemen
 
         // When
         // (1) the time bucket of the server's latest stability status is provided
-        //     1.1 the OAP has booted successfully
-        //     1.2 the current dimensionality is in minute
-        //     1.3 the OAP cluster is rebalanced due to scaling
-        // (2) the metrics are from the time after the timeOfLatestStabilitySts
-        // (3) the metrics don't exist in the cache
-        // the kernel should NOT try to load it from the database.
+        //     1.1 The OAP has booted successfully
+        //     1.2 The current dimensionality is in minute(timeOfLatestStabilitySts = 0 for other dimensionalities)
+        //     1.3 The OAP cluster is rebalanced due to scaling
+        // (2) the metrics are from the time after the timeOfLatestStabilitySts.
+        // (3) the metrics don't exist in the cache.
+        //The kernel should NOT try to load it from the database.
         //
-        // Notice, about condition (2),
-        // for the specific minute of booted successfully, the metrics are expected to load from database when
-        // it doesn't exist in the cache.
+        // Notice, about the condition (2),
+        // For the specific minutes of metrics before booted, rebalanced(cluster) and expired from cache, 
+        // they are expected to load from the database when don't exist in the cache.
         if (timeOfLatestStabilitySts > 0 &&
             metrics.getTimeBucket() > timeOfLatestStabilitySts) {
             final long currentTimeMillis = System.currentTimeMillis();


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Optimize metrics cache loading when trace latency greater than cache timeout
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.


<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

When the trace endpoint get latency (exceeding SW_CORE_STORAGE_SESSION_TIMEOUT, default 70s), the OAP server will throw the following exception message. 
This is due to the metrics cache not being loaded correctly, resulting in the insertion of duplicate data (where an update should be). 
Loading history metrics before `SW_CORE_STORAGE_SESSION_TIMEOUT` introduces some performance overhead. However, considering this is an extreme scenario and rarely occurs, such overhead can be ignored. Additionally, this level of endpoint latency should be reflected by SkyWalking and should not be discarded.

```
2025-02-26 09:16:56,182 org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao.JDBCBatchDAO 81 [pool-5-thread-1] ERROR [] - [10.2.0-SNAPSHOT-e7901e1] Unique index or primary key violation: "PUBLIC.PRIMARY_KEY_52 ON PUBLIC.metrics_cpm_20250226(id) VALUES ( /* 6 */ 'service_instance_relation_server_cpm_202502260913_VXNlcg==.0_VXNlcg==-WW91cl9BcHBsaWNhdGlvbk5hbWU=.1_NDQxNzgxNWY0NjZlNDc4ZWJiODVkMzJmMmVlOTU3NDZAMTk4LjE4LjAuMQ==' )"; SQL statement:
INSERT INTO metrics_cpm_20250226(id,table_name,entity_id,value_,total,time_bucket) VALUES (?,?,?,?,?,?) [23505-212]
org.h2.jdbc.JdbcBatchUpdateException: Unique index or primary key violation: "PUBLIC.PRIMARY_KEY_52 ON PUBLIC.metrics_cpm_20250226(id) VALUES ( /* 6 */ 'service_instance_relation_server_cpm_202502260913_VXNlcg==.0_VXNlcg==-WW91cl9BcHBsaWNhdGlvbk5hbWU=.1_NDQxNzgxNWY0NjZlNDc4ZWJiODVkMzJmMmVlOTU3NDZAMTk4LjE4LjAuMQ==' )"; SQL statement:
INSERT INTO metrics_cpm_20250226(id,table_name,entity_id,value_,total,time_bucket) VALUES (?,?,?,?,?,?) [23505-212]
	at org.h2.jdbc.JdbcPreparedStatement.executeBatch(JdbcPreparedStatement.java:1269) ~[h2-2.1.212.jar:2.1.212]
	at com.zaxxer.hikari.pool.ProxyStatement.executeBatch(ProxyStatement.java:128) ~[HikariCP-3.1.0.jar:?]
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeBatch(HikariProxyPreparedStatement.java) ~[HikariCP-3.1.0.jar:?]
	at org.apache.skywalking.oap.server.storage.plugin.jdbc.BatchSQLExecutor.executeBatch(BatchSQLExecutor.java:85) ~[classes/:?]
	at org.apache.skywalking.oap.server.storage.plugin.jdbc.BatchSQLExecutor.invoke(BatchSQLExecutor.java:74) ~[classes/:?]
	at org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao.JDBCBatchDAO.lambda$flush$1(JDBCBatchDAO.java:78) ~[classes/:?]
	at java.util.HashMap.forEach(HashMap.java:1421) ~[?:?]
	at org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao.JDBCBatchDAO.flush(JDBCBatchDAO.java:75) ~[classes/:?]
	at org.apache.skywalking.oap.server.core.storage.PersistenceTimer.lambda$extractDataAndSave$3(PersistenceTimer.java:142) ~[classes/:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run$$$capture(CompletableFuture.java:1804) [?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```
