### PR TITLE
Migrate tj-actions/changed-files to dorny/paths-filter

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -107,55 +107,49 @@ jobs:
     if: github.event_name != 'schedule'
     timeout-minutes: 10
     outputs:
-      oap: ${{ steps.filter-oap.outputs.any_modified }}
-      pom: ${{ steps.filter-pom.outputs.any_modified }}
-      ui: ${{ steps.filter-ui.outputs.any_modified }}
+      oap: ${{ steps.filter.outputs.oap }}
+      pom: ${{ steps.filter.outputs.pom }}
+      ui: ${{ steps.filter.outputs.ui }}
     steps:
       - uses: actions/checkout@v4 # required for push event
         with:
           fetch-depth: 0
           submodules: true
-      - name: Filter OAP
-        id: filter-oap
-        # The GHA version is pinned by infra (2024-03-17)
-        uses: tj-actions/changed-files@v43.0.0
+      - name: Filter
+        id: filter
+        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         with:
-          files_ignore: |
-            **/*.{md,txt}
-            skywalking-ui/**
-            .asf.yaml
-            .dlc.json
-            .gitignore
-            .licenserc.yaml
-            codeStyle.xml
-            HEADER
-            LICENSE
-            NOTICE
-            docs/**
-            .github/workflows/codeql.yaml
-            .github/ISSUE_TEMPLATE/**
-            .github/PULL_REQUEST_TEMPLATE
-            dist-material/release-docs/**
-            component-libraries.yml
-      - name: Filter POM
-        id: filter-pom
-        uses: tj-actions/changed-files@v43.0.0
-        with:
-          files: |
-            **/pom.xml
-      - name: Filter UI
-        id: filter-ui
-        uses: tj-actions/changed-files@v43.0.0
-        with:
-          files: |
-            skywalking-ui/**
+          list-files: 'shell'
+          filters: |
+            oap:
+            - '!**/*.md'
+            - '!**/*.txt'
+            - '!skywalking-ui/**'
+            - '!.asf.yaml'
+            - '!.dlc.json'
+            - '!.gitignore'
+            - '!.licenserc.yaml'
+            - '!codeStyle.xml'
+            - '!HEADER'
+            - '!LICENSE'
+            - '!NOTICE'
+            - '!docs/**'
+            - '!.github/workflows/codeql.yaml'
+            - '!.github/ISSUE_TEMPLATE/**'
+            - '!.github/PULL_REQUEST_TEMPLATE'
+            - '!dist-material/release-docs/**'
+            - '!component-libraries.yml'
+            pom:
+            - '**/pom.xml'
+            ui: # dorny/paths-filter doesn't support submodule changes detection, anyway keep it here to remind us of https://github.com/dorny/paths-filter/issues/143
+            - 'skywalking-ui/**'
       - name: List all modified files
-        if: steps.filter-oap.outputs.any_modified == 'true' || steps.filter-ui.outputs.any_modified == 'true' || steps.filter-pom.outputs.any_modified == 'true'
+        if: steps.filter.outputs.oap == 'true' || steps.filter.outputs.pom == 'true' || steps.filter.outputs.pom == 'true'
         run: |
           echo "Files that have changed or modified:"
-          echo "OAP: ${{ steps.filter-oap.outputs.all_changed_and_modified_files }}"
-          echo "POM: ${{ steps.filter-pom.outputs.all_changed_and_modified_files }}"
-          echo "UI: ${{ steps.filter-ui.outputs.all_changed_and_modified_files }}"
+          echo "OAP: ${{ steps.filter.outputs.oap_files }}"
+          echo "POM: ${{ steps.filter.outputs.pom_files }}"
+          echo "UI: ${{ steps.filter.outputs.ui_files }}"
 
   dist-tar:
     if: |

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -16,6 +16,7 @@
 * [Breaking Change] Bump up BanyanDB server version to 0.8.0. This version is not compatible with the previous 
   versions. Please upgrade the BanyanDB server to 0.8.0 before upgrading OAP to 10.2.0.
 * Bump up nodejs to v22.14.0 for the latest UI(booster-ui) compiling. 
+* Migrate tj-actions/changed-files to dorny/paths-filter.
 
 #### OAP Server
 


### PR DESCRIPTION
This is not an 100% equivalent to previous because dorny/paths-filter doesn’t support submodule detection, see https://github.com/dorny/paths-filter/issues/143