### PR TITLE
Fix query continues profiling policies error when the policy is already in the cache

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -5,6 +5,7 @@
 #### OAP Server
 
 * BanyanDB: Support `hot/warm/cold` stages configuration.
+* Fix query continues profiling policies error when the policy is already in the cache.
 
 #### UI
 

--- a/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/ContinuousProfilingServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-ebpf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/ebpf/provider/handler/ContinuousProfilingServiceHandler.java
@@ -112,6 +112,12 @@ public class ContinuousProfilingServiceHandler extends ContinuousProfilingServic
                 }
             }
 
+            // if no service need to check from DB then return empty
+            if (serviceIdList.isEmpty()) {
+                sendEmptyCommands(responseObserver);
+                return;
+            }
+
             // query the policies which not in the cache
             final List<ContinuousProfilingPolicy> queriedFromDB = policyDAO.queryPolicies(serviceIdList);
             for (ContinuousProfilingPolicy dbPolicy : queriedFromDB) {


### PR DESCRIPTION

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
