### PR TITLE
chore: add `toString` implementation for `StorageID`

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -31,6 +31,8 @@
 * Fix `disable.oal` does not work.
 * Enhance the stability of e2e PHP tests and update the PHP agent version.
 * Add component ID for the `dameng` JDBC driver.
+* refactor: implement OTEL handler with SPI for extensibility.
+* chore: add `toString` implementation for `StorageID`.
 
 #### UI
 
@@ -42,7 +44,6 @@
 * Implement the Status API on Settings page.
 * Bump vite from 6.2.6 to 6.3.4.
 * Enhance async profiling by adding shorter and custom duration options.
-* refactor: implement OTEL handler with SPI for extensibility.
 
 #### Documentation
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/StorageID.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/StorageID.java
@@ -129,6 +129,11 @@ public class StorageID {
         return Collections.unmodifiableList(fragments);
     }
 
+    @Override
+    public String toString() {
+        return build();
+    }
+
     @RequiredArgsConstructor
     @Getter
     @EqualsAndHashCode(of = {


### PR DESCRIPTION
to make the logs printed in the following line more clear which one is discarded

https://github.com/apache/skywalking/blob/43d79d9fec224036cc3cbc7185c9faa7ecd4838c/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorker.java#L196-L196

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>. NO
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
