### PR TITLE
chore: add a warning log when connecting to ES takes too long

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -34,6 +34,7 @@
 * BanyanDB: Support custom `TopN pre-aggregation` rules configuration in file `bydb-topn.yml`.
 * refactor: implement OTEL handler with SPI for extensibility.
 * chore: add `toString` implementation for `StorageID`.
+* chore: add a warning log when connecting to ES takes too long.
 
 #### UI
 


### PR DESCRIPTION
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>. NO
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).


an example of the log:

```
2025-06-17 15:55:31,738 org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient 166 [armeria-common-worker-kqueue-3-2] WARN  [] - Connecting to ElasticSearch took 2620 ms, which is longer than expected and can impact performance.

```