### PR TITLE
OAP gRPC-Client support `Health Check` and [Break Change] `Health Check` make response 1 represents healthy, 0 represents unhealthy.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -36,6 +36,8 @@
 * chore: add `toString` implementation for `StorageID`.
 * chore: add a warning log when connecting to ES takes too long.
 * Fix the query time range in the metadata API.
+* OAP gRPC-Client support `Health Check`.
+* [Break Change] `Health Check` make response 1 represents healthy, 0 represents unhealthy.
 
 #### UI
 

--- a/docs/en/setup/backend/backend-health-check.md
+++ b/docs/en/setup/backend/backend-health-check.md
@@ -36,7 +36,7 @@ If the OAP server is healthy, the response should be
 {
   "data": {
     "checkHealth": {
-      "score": 0,
+      "score": 1,
       "details": ""
     }
   }
@@ -49,7 +49,7 @@ If some modules are unhealthy (e.g. storage H2 is down), then the result may loo
 {
   "data": {
     "checkHealth": {
-      "score": 1,
+      "score": 0,
       "details": "storage_h2,"
     }
   }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/type/HealthStatus.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/type/HealthStatus.java
@@ -26,7 +26,7 @@ import lombok.ToString;
 @Setter
 @ToString
 public class HealthStatus {
-    // score == 0 means healthy, otherwise it's unhealthy.
+    // score == 1 means healthy, otherwise it's unhealthy.
     private int score;
     private String details;
 }

--- a/oap-server/server-health-checker/src/main/java/org/apache/skywalking/oap/server/health/checker/provider/HealthCheckerHttpService.java
+++ b/oap-server/server-health-checker/src/main/java/org/apache/skywalking/oap/server/health/checker/provider/HealthCheckerHttpService.java
@@ -37,7 +37,7 @@ public class HealthCheckerHttpService {
         final var status = healthQueryService.checkHealth();
         log.info("Health status: {}", status);
 
-        if (status.getScore() == 0) {
+        if (status.getScore() == 1) {
             return HttpResponse.of(HttpStatus.OK);
         }
         return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);

--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/grpc/GRPCClient.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/grpc/GRPCClient.java
@@ -104,7 +104,7 @@ public class GRPCClient implements Client, HealthCheckable {
      * Must register a HealthChecker before calling connect() if you want to enable health check.
      * If the channel is shutdown by client side, the health check will not be performed.
      * Note: If you register a `org.apache.skywalking.oap.server.telemetry.api.HealthCheckMetrics` here
-     * or the metric name start with `org.apache.skywalking.oap.server.telemetry.api.MetricsCreator.HEALTH_METRIC_PREFIX`,
+     * and the metric name start with `org.apache.skywalking.oap.server.telemetry.api.MetricsCreator.HEALTH_METRIC_PREFIX`,
      * this healthy status will be included in the whole OAP health evaluate.
      * @param healthChecker HealthChecker to be registered.
      */

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/HealthCheckMetrics.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/HealthCheckMetrics.java
@@ -36,18 +36,18 @@ public class HealthCheckMetrics implements HealthChecker {
 
     @Override
     public void health() {
-        metrics.setValue(0);
+        metrics.setValue(1);
     }
 
     @Override
     public void unHealth(Throwable t) {
         log.error("Health check fails", t);
-        metrics.setValue(1);
+        metrics.setValue(0);
     }
 
     @Override
     public void unHealth(String reason) {
         log.warn("Health check fails. reason: {}", reason);
-        metrics.setValue(1);
+        metrics.setValue(0);
     }
 }

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/MetricsCreator.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/MetricsCreator.java
@@ -53,7 +53,7 @@ public interface MetricsCreator extends Service {
     default HealthCheckMetrics createHealthCheckerGauge(String name, MetricsTag.Keys tagKeys, MetricsTag.Values tagValues) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(name), "Require non-null or empty metric name");
         return new HealthCheckMetrics(createGauge(Strings.lenientFormat("%s%s", HEALTH_METRIC_PREFIX, name),
-            Strings.lenientFormat("%s health check", name),
+            Strings.lenientFormat("%s health check. 1 health, 0 not health, -1 unknown", name),
             tagKeys, tagValues));
     }
 


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
