### PR TITLE
Add self obs metrics for L1/L2 queue and persistent cache.

### DIFF
--- a/docs/en/api/metrics-query-expression.md
+++ b/docs/en/api/metrics-query-expression.md
@@ -440,19 +440,42 @@ TIME_SERIES_VALUES.
 
 ## Sort Operation
 ### SortValues Operation
-SortValues Operation takes an expression and sorts the values of the input expression result.
-
+SortValues Operation takes an expression used to sort and pick the top N label value groups, which according to
+the values of a given ExpressionResult and based on the specified order, limit and aggregation type.
+If the input expression is not a labeled result, it will retrurn the original expression result.
 Expression:
 ```text
-sort_values(Expression, <limit>, <order>)
+sort_values(Expression, <limit>, <order>, <aggregation_type>)
 ```
-- `limit` is the number of the sort results, should be a positive integer, if not specified, will return all results. Optional.
+- `limit` is the number of the sort results, should be a positive integer.
 - `order` is the order of the sort results. The value of `order` can be `asc` or `des`.
+-  `aggregation_type` is the type of the aggregation operation. The type can be `avg`, `sum`, `max`, `min`.
 
-For example:
-If we want to sort the `service_resp_time` metric values in descending order and get the top 10 values, we can use the following expression:
+For example, the following metrics in time series T1 and T2:
 ```text
-sort_values(service_resp_time, 10, des)
+T1:
+http_requests_total{service="api"}   160
+http_requests_total{service="web"}   120
+http_requests_total{service="auth"}  80
+
+T2:
+http_requests_total{service="api"}   100
+http_requests_total{service="web"}   180
+http_requests_total{service="auth"}  10
+```
+We can use SortValuesOp to pick the top 2 services with the most avg requests in descending order:
+```text
+sort_values(http_requests_total, 2, desc, avg)
+```
+The result will be:
+```text
+T1:
+http_requests_total{service="web"}   120
+http_requests_total{service="api"}   160
+
+T2:
+http_requests_total{service="web"}   180
+http_requests_total{service="api"}   100
 ```
 
 #### Result Type

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -4,6 +4,8 @@
 
 * Bump up BanyanDB dependency version(server and java-client) to 0.9.0.
 * Fix CVE-2025-54057, restrict and validate url for widgets.
+* Fix `MetricsPersistentWorker`, remove DataCarrier queue from `Hour/Day` dimensions metrics persistent process.
+  This is important to reduce memory cost and `Hour/Day` dimensions metrics persistent latency.
 
 #### OAP Server
 
@@ -47,7 +49,6 @@
 * Tracing Query Execution HTTP APIs: make the argument `service layer` optional.
 * GraphQL API: metadata, topology, log and trace support query by name.
 * [Break Change] MQE function `sort_values` sorts according to the aggregation result and labels rather than the simple time series values.
-* Fix `MetricsPersistentWorker`, remove DataCarrier queue from `Hour/Day` dimensions metrics persistent process.
 * Self Observability: add `metrics_aggregation_queue_used_percentage` and `metrics_persistent_collection_cached_size` metrics for the OAP server.
 
 #### UI

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -46,6 +46,9 @@
 * Add UI dashboard for Ruby runtime metrics.
 * Tracing Query Execution HTTP APIs: make the argument `service layer` optional.
 * GraphQL API: metadata, topology, log and trace support query by name.
+* [Break Change] MQE function `sort_values` sorts according to the aggregation result and labels rather than the simple time series values.
+* Fix `MetricsPersistentWorker`, remove DataCarrier queue from `Hour/Day` dimensions metrics persistent process.
+* Self Observability: add `metrics_aggregation_queue_used_percentage` and `metrics_persistent_collection_cached_size` metrics for the OAP server.
 
 #### UI
 
@@ -63,6 +66,7 @@
 * Fix the snapshot charts unable to display.
 * Bump vue-i18n from 9.14.3 to 9.14.5.
 * Fix split queries for topology to avoid page crash.
+* Self Observability ui-template: Add new panels for monitor `metrics aggregation queue used percentage` and `metrics persistent collection cached size`.
 
 #### Documentation
 

--- a/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQEParser.g4
+++ b/oap-server/mqe-grammar/src/main/antlr4/org/apache/skywalking/mqe/rt/grammar/MQEParser.g4
@@ -38,7 +38,7 @@ expression
     | topNOf L_PAREN topN (COMMA topN)* COMMA INTEGER COMMA order R_PAREN           #topNOfOP
     | relabels L_PAREN expression COMMA label COMMA replaceLabel R_PAREN #relablesOP
     | aggregateLabels L_PAREN expression COMMA aggregateLabelsFunc R_PAREN #aggregateLabelsOp
-    | sort_values L_PAREN expression (COMMA INTEGER)? COMMA order R_PAREN #sortValuesOP
+    | sort_values L_PAREN expression COMMA INTEGER COMMA order COMMA aggregation R_PAREN #sortValuesOP
     | sort_label_values L_PAREN expression COMMA order COMMA labelNameList R_PAREN #sortLabelValuesOP
     | baseline L_PAREN metric COMMA baseline_type R_PAREN #baselineOP
     ;

--- a/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/MQEVisitorBase.java
+++ b/oap-server/mqe-rt/src/main/java/org/apache/skywalking/mqe/rt/MQEVisitorBase.java
@@ -23,7 +23,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiFunction;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -437,12 +436,9 @@ public abstract class MQEVisitorBase extends MQEParserBaseVisitor<ExpressionResu
         try {
             ExpressionResult result = visit(ctx.expression());
             int order = ctx.order().getStart().getType();
-            Optional<Integer> limit = Optional.empty();
-            if (ctx.INTEGER() != null) {
-                limit = Optional.of(Integer.valueOf(ctx.INTEGER().getText()));
-            }
+            int limit = Integer.parseInt(ctx.INTEGER().getText());
             try {
-                return SortValuesOp.doSortValuesOp(result, limit, order);
+                return SortValuesOp.doSortValuesOp(result, limit, order, MQEParser.AVG);
             } catch (IllegalExpressionException e) {
                 return getErrorResult(e.getMessage());
             }

--- a/oap-server/mqe-rt/src/test/java/org/apache/skywalking/mqe/rt/SortValuesOpTest.java
+++ b/oap-server/mqe-rt/src/test/java/org/apache/skywalking/mqe/rt/SortValuesOpTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.skywalking.mqe.rt;
 
-import java.util.Optional;
 import org.apache.skywalking.mqe.rt.exception.IllegalExpressionException;
 import org.apache.skywalking.mqe.rt.grammar.MQEParser;
 import org.apache.skywalking.mqe.rt.operation.SortValuesOp;
@@ -32,35 +31,64 @@ public class SortValuesOpTest {
     @Test
     public void sortValueTest() throws IllegalExpressionException {
         //no label
-        ExpressionResult des = SortValuesOp.doSortValuesOp(mockData.newSeriesNoLabeledResult(), Optional.of(3),
-                                                          MQEParser.DES);
-        Assertions.assertEquals(300, des.getResults().get(0).getValues().get(0).getDoubleValue());
-        Assertions.assertEquals(100, des.getResults().get(0).getValues().get(1).getDoubleValue());
-        ExpressionResult asc = SortValuesOp.doSortValuesOp(mockData.newSeriesNoLabeledResult(), Optional.of(3),
-                                                          MQEParser.ASC);
+        ExpressionResult des = SortValuesOp.doSortValuesOp(
+            mockData.newSeriesNoLabeledResult(), 3,
+            MQEParser.DES, MQEParser.AVG
+        );
+        Assertions.assertEquals(100, des.getResults().get(0).getValues().get(0).getDoubleValue());
+        Assertions.assertEquals(300, des.getResults().get(0).getValues().get(1).getDoubleValue());
+        ExpressionResult asc = SortValuesOp.doSortValuesOp(
+            mockData.newSeriesNoLabeledResult(), 3,
+            MQEParser.ASC, MQEParser.AVG
+        );
         Assertions.assertEquals(100, asc.getResults().get(0).getValues().get(0).getDoubleValue());
         Assertions.assertEquals(300, asc.getResults().get(0).getValues().get(1).getDoubleValue());
 
         //labeled
-        ExpressionResult desLabeled = SortValuesOp.doSortValuesOp(mockData.newSeriesLabeledResult(), Optional.of(3),
-                                                                 MQEParser.DES);
-        Assertions.assertEquals(300, desLabeled.getResults().get(0).getValues().get(0).getDoubleValue());
-        Assertions.assertEquals(100, desLabeled.getResults().get(0).getValues().get(1).getDoubleValue());
-        Assertions.assertEquals(301, desLabeled.getResults().get(1).getValues().get(0).getDoubleValue());
-        Assertions.assertEquals(101, desLabeled.getResults().get(1).getValues().get(1).getDoubleValue());
-        ExpressionResult ascLabeled = SortValuesOp.doSortValuesOp(mockData.newSeriesLabeledResult(), Optional.of(2),
-                                                                 MQEParser.ASC);
+        ExpressionResult desLabeled = SortValuesOp.doSortValuesOp(
+            mockData.newSeriesLabeledResult(), 3,
+            MQEParser.DES, MQEParser.AVG
+        );
+        Assertions.assertEquals(101, desLabeled.getResults().get(0).getValues().get(0).getDoubleValue());
+        Assertions.assertEquals(301, desLabeled.getResults().get(0).getValues().get(1).getDoubleValue());
+        Assertions.assertEquals("label", desLabeled.getResults().get(0).getMetric().getLabels().get(0).getKey());
+        Assertions.assertEquals("2", desLabeled.getResults().get(0).getMetric().getLabels().get(0).getValue());
+        Assertions.assertEquals("label2", desLabeled.getResults().get(0).getMetric().getLabels().get(1).getKey());
+        Assertions.assertEquals("21", desLabeled.getResults().get(0).getMetric().getLabels().get(1).getValue());
+        Assertions.assertEquals(100, desLabeled.getResults().get(1).getValues().get(0).getDoubleValue());
+        Assertions.assertEquals(300, desLabeled.getResults().get(1).getValues().get(1).getDoubleValue());
+        Assertions.assertEquals("label", desLabeled.getResults().get(1).getMetric().getLabels().get(0).getKey());
+        Assertions.assertEquals("1", desLabeled.getResults().get(1).getMetric().getLabels().get(0).getValue());
+        Assertions.assertEquals("label2", desLabeled.getResults().get(1).getMetric().getLabels().get(1).getKey());
+        Assertions.assertEquals("21", desLabeled.getResults().get(1).getMetric().getLabels().get(1).getValue());
+
+        ExpressionResult ascLabeled = SortValuesOp.doSortValuesOp(
+            mockData.newSeriesLabeledResult(), 3,
+            MQEParser.ASC, MQEParser.AVG
+        );
         Assertions.assertEquals(100, ascLabeled.getResults().get(0).getValues().get(0).getDoubleValue());
         Assertions.assertEquals(300, ascLabeled.getResults().get(0).getValues().get(1).getDoubleValue());
+        Assertions.assertEquals("label", ascLabeled.getResults().get(0).getMetric().getLabels().get(0).getKey());
+        Assertions.assertEquals("1", ascLabeled.getResults().get(0).getMetric().getLabels().get(0).getValue());
+        Assertions.assertEquals("label2", ascLabeled.getResults().get(0).getMetric().getLabels().get(1).getKey());
+        Assertions.assertEquals("21", ascLabeled.getResults().get(0).getMetric().getLabels().get(1).getValue());
         Assertions.assertEquals(101, ascLabeled.getResults().get(1).getValues().get(0).getDoubleValue());
         Assertions.assertEquals(301, ascLabeled.getResults().get(1).getValues().get(1).getDoubleValue());
+        Assertions.assertEquals("label", ascLabeled.getResults().get(1).getMetric().getLabels().get(0).getKey());
+        Assertions.assertEquals("2", ascLabeled.getResults().get(1).getMetric().getLabels().get(0).getValue());
+        Assertions.assertEquals("label2", ascLabeled.getResults().get(1).getMetric().getLabels().get(1).getKey());
+        Assertions.assertEquals("21", ascLabeled.getResults().get(1).getMetric().getLabels().get(1).getValue());
 
         //limit
-        ExpressionResult desLabeledLimit = SortValuesOp.doSortValuesOp(mockData.newSeriesLabeledResult(), Optional.of(1),
-                                                                      MQEParser.DES);
-        Assertions.assertEquals(1, desLabeledLimit.getResults().get(0).getValues().size());
-        Assertions.assertEquals(1, desLabeledLimit.getResults().get(1).getValues().size());
-        Assertions.assertEquals(300, desLabeledLimit.getResults().get(0).getValues().get(0).getDoubleValue());
-        Assertions.assertEquals(301, desLabeledLimit.getResults().get(1).getValues().get(0).getDoubleValue());
+        ExpressionResult desLabeledLimit = SortValuesOp.doSortValuesOp(
+            mockData.newSeriesLabeledResult(), 1,
+            MQEParser.DES, MQEParser.AVG
+        );
+        Assertions.assertEquals(101, desLabeledLimit.getResults().get(0).getValues().get(0).getDoubleValue());
+        Assertions.assertEquals(301, desLabeledLimit.getResults().get(0).getValues().get(1).getDoubleValue());
+        Assertions.assertEquals("label", desLabeledLimit.getResults().get(0).getMetric().getLabels().get(0).getKey());
+        Assertions.assertEquals("2", desLabeledLimit.getResults().get(0).getMetric().getLabels().get(0).getValue());
+        Assertions.assertEquals("label2", desLabeledLimit.getResults().get(0).getMetric().getLabels().get(1).getKey());
+        Assertions.assertEquals("21", desLabeledLimit.getResults().get(0).getMetric().getLabels().get(1).getValue());
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
@@ -55,6 +55,7 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
     private GaugeMetrics queuePercentageGauge;
     private long lastSendTime = 0;
     private final MetricStreamKind kind;
+    private int queueBufferSize;
 
     MetricsAggregateWorker(ModuleDefineHolder moduleDefineHolder,
                            AbstractWorker<Metrics> nextWorker,
@@ -106,6 +107,9 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
             new MetricsTag.Values(modelName, "1", kind.name())
         );
         this.l1FlushPeriod = l1FlushPeriod;
+        queueBufferSize = Arrays.stream(dataCarrier.getChannels().getBufferChannels())
+                                .mapToInt(QueueBuffer::getBufferSize)
+                                .sum();
     }
 
     /**
@@ -148,9 +152,6 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
     private class AggregatorConsumer implements IConsumer<Metrics> {
         @Override
         public void consume(List<Metrics> data) {
-            int queueBufferSize = Arrays.stream(dataCarrier.getChannels().getBufferChannels())
-                                        .mapToInt(QueueBuffer::getBufferSize)
-                                        .sum();
             int queueSize = data.size();
 
             queuePercentageGauge.setValue(Math.round(100 * (double) queueSize / queueBufferSize));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.analysis.worker;
 
+import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.core.UnexpectedException;
@@ -26,12 +27,14 @@ import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
 import org.apache.skywalking.oap.server.core.worker.AbstractWorker;
 import org.apache.skywalking.oap.server.library.datacarrier.DataCarrier;
 import org.apache.skywalking.oap.server.library.datacarrier.buffer.BufferStrategy;
+import org.apache.skywalking.oap.server.library.datacarrier.buffer.QueueBuffer;
 import org.apache.skywalking.oap.server.library.datacarrier.consumer.BulkConsumePool;
 import org.apache.skywalking.oap.server.library.datacarrier.consumer.ConsumerPoolFactory;
 import org.apache.skywalking.oap.server.library.datacarrier.consumer.IConsumer;
 import org.apache.skywalking.oap.server.library.module.ModuleDefineHolder;
 import org.apache.skywalking.oap.server.telemetry.TelemetryModule;
 import org.apache.skywalking.oap.server.telemetry.api.CounterMetrics;
+import org.apache.skywalking.oap.server.telemetry.api.GaugeMetrics;
 import org.apache.skywalking.oap.server.telemetry.api.MetricsCreator;
 import org.apache.skywalking.oap.server.telemetry.api.MetricsTag;
 
@@ -49,7 +52,9 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
     private final MergableBufferedData<Metrics> mergeDataCache;
     private CounterMetrics abandonCounter;
     private CounterMetrics aggregationCounter;
+    private GaugeMetrics queuePercentageGauge;
     private long lastSendTime = 0;
+    private final MetricStreamKind kind;
 
     MetricsAggregateWorker(ModuleDefineHolder moduleDefineHolder,
                            AbstractWorker<Metrics> nextWorker,
@@ -59,15 +64,16 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
         super(moduleDefineHolder);
         this.nextWorker = nextWorker;
         this.mergeDataCache = new MergableBufferedData();
+        this.kind = kind;
         String name = "METRICS_L1_AGGREGATION";
         int queueChannelSize = 2;
-        int queueBufferSize = 10_000;
+        int queueBufferSize = 10;
         if (MetricStreamKind.MAL == kind) {
             // In MAL meter streaming, the load of data flow is much less as they are statistics already,
             // but in OAL sources, they are raw data.
             // Set the buffer(size of queue) as 1/20 to reduce unnecessary resource costs.
             queueChannelSize = 1;
-            queueBufferSize = 1_000;
+            queueBufferSize = 10;
         }
         this.dataCarrier = new DataCarrier<>(
             "MetricsAggregateWorker." + modelName, name, queueChannelSize, queueBufferSize, BufferStrategy.IF_POSSIBLE);
@@ -85,14 +91,19 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
                                                           .provider()
                                                           .getService(MetricsCreator.class);
         abandonCounter = metricsCreator.createCounter(
-            "metrics_aggregator_abandon", "The abandon number of rows received in aggregation",
+            "metrics_aggregator_abandon", "The abandon number of rows received in aggregation.",
             new MetricsTag.Keys("metricName", "level", "dimensionality"),
             new MetricsTag.Values(modelName, "1", "minute")
         );
         aggregationCounter = metricsCreator.createCounter(
-            "metrics_aggregation", "The number of rows in aggregation",
+            "metrics_aggregation", "The number of rows in aggregation.",
             new MetricsTag.Keys("metricName", "level", "dimensionality"),
             new MetricsTag.Values(modelName, "1", "minute")
+        );
+        queuePercentageGauge = metricsCreator.createGauge(
+            "metrics_aggregation_queue_used_percentage", "The percentage of queue used in aggregation.",
+            new MetricsTag.Keys("metricName", "level", "kind"),
+            new MetricsTag.Values(modelName, "1", kind.name())
         );
         this.l1FlushPeriod = l1FlushPeriod;
     }
@@ -137,6 +148,12 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
     private class AggregatorConsumer implements IConsumer<Metrics> {
         @Override
         public void consume(List<Metrics> data) {
+            int queueBufferSize = Arrays.stream(dataCarrier.getChannels().getBufferChannels())
+                                        .mapToInt(QueueBuffer::getBufferSize)
+                                        .sum();
+            int queueSize = data.size();
+
+            queuePercentageGauge.setValue(Math.round(100 * (double) queueSize / queueBufferSize));
             MetricsAggregateWorker.this.onWork(data);
         }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
@@ -67,13 +67,13 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
         this.kind = kind;
         String name = "METRICS_L1_AGGREGATION";
         int queueChannelSize = 2;
-        int queueBufferSize = 10;
+        int queueBufferSize = 10_000;
         if (MetricStreamKind.MAL == kind) {
             // In MAL meter streaming, the load of data flow is much less as they are statistics already,
             // but in OAL sources, they are raw data.
             // Set the buffer(size of queue) as 1/20 to reduce unnecessary resource costs.
             queueChannelSize = 1;
-            queueBufferSize = 10;
+            queueBufferSize = 1_000;
         }
         this.dataCarrier = new DataCarrier<>(
             "MetricsAggregateWorker." + modelName, name, queueChannelSize, queueBufferSize, BufferStrategy.IF_POSSIBLE);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsAggregateWorker.java
@@ -55,7 +55,7 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
     private GaugeMetrics queuePercentageGauge;
     private long lastSendTime = 0;
     private final MetricStreamKind kind;
-    private int queueBufferSize;
+    private final int queueTotalSize;
 
     MetricsAggregateWorker(ModuleDefineHolder moduleDefineHolder,
                            AbstractWorker<Metrics> nextWorker,
@@ -107,9 +107,9 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
             new MetricsTag.Values(modelName, "1", kind.name())
         );
         this.l1FlushPeriod = l1FlushPeriod;
-        queueBufferSize = Arrays.stream(dataCarrier.getChannels().getBufferChannels())
-                                .mapToInt(QueueBuffer::getBufferSize)
-                                .sum();
+        queueTotalSize = Arrays.stream(dataCarrier.getChannels().getBufferChannels())
+                               .mapToInt(QueueBuffer::getBufferSize)
+                               .sum();
     }
 
     /**
@@ -152,9 +152,7 @@ public class MetricsAggregateWorker extends AbstractWorker<Metrics> {
     private class AggregatorConsumer implements IConsumer<Metrics> {
         @Override
         public void consume(List<Metrics> data) {
-            int queueSize = data.size();
-
-            queuePercentageGauge.setValue(Math.round(100 * (double) queueSize / queueBufferSize));
+            queuePercentageGauge.setValue(Math.round(100 * (double) data.size() / queueTotalSize));
             MetricsAggregateWorker.this.onWork(data);
         }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentMinWorker.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentMinWorker.java
@@ -42,10 +42,10 @@ import org.apache.skywalking.oap.server.telemetry.api.MetricsCreator;
 import org.apache.skywalking.oap.server.telemetry.api.MetricsTag;
 
 /**
- * MetricsPersistentWorkerMin is an extension of {@link MetricsPersistentWorker} and focuses on the Minute Metrics data persistent.
+ * MetricsPersistentMinWorker is an extension of {@link MetricsPersistentWorker} and focuses on the Minute Metrics data persistent.
  */
 @Slf4j
-public class MetricsPersistentWorkerMin extends MetricsPersistentWorker implements ServerStatusWatcher {
+public class MetricsPersistentMinWorker extends MetricsPersistentWorker implements ServerStatusWatcher {
     private final DataCarrier<Metrics> dataCarrier;
 
     /**
@@ -62,7 +62,7 @@ public class MetricsPersistentWorkerMin extends MetricsPersistentWorker implemen
     private final boolean isTestingTTL = "true".equalsIgnoreCase(System.getenv("TESTING_TTL"));
     private final int queueTotalSize;
 
-    MetricsPersistentWorkerMin(ModuleDefineHolder moduleDefineHolder, Model model, IMetricsDAO metricsDAO,
+    MetricsPersistentMinWorker(ModuleDefineHolder moduleDefineHolder, Model model, IMetricsDAO metricsDAO,
                                AbstractWorker<Metrics> nextAlarmWorker, AbstractWorker<ExportEvent> nextExportWorker,
                                MetricsTransWorker transWorker, boolean supportUpdate,
                                long storageSessionTimeout, int metricsDataTTL, MetricStreamKind kind) {
@@ -131,7 +131,7 @@ public class MetricsPersistentWorkerMin extends MetricsPersistentWorker implemen
         @Override
         public void consume(List<Metrics> data) {
             queuePercentageGauge.setValue(Math.round(100 * (double) data.size() / queueTotalSize));
-            MetricsPersistentWorkerMin.this.onWork(data);
+            MetricsPersistentMinWorker.this.onWork(data);
         }
 
         @Override

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorkerMin.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsPersistentWorkerMin.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.analysis.worker;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.UnexpectedException;
+import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
+import org.apache.skywalking.oap.server.core.exporter.ExportEvent;
+import org.apache.skywalking.oap.server.core.status.ServerStatusService;
+import org.apache.skywalking.oap.server.core.status.ServerStatusWatcher;
+import org.apache.skywalking.oap.server.core.storage.IMetricsDAO;
+import org.apache.skywalking.oap.server.core.storage.model.Model;
+import org.apache.skywalking.oap.server.core.worker.AbstractWorker;
+import org.apache.skywalking.oap.server.library.datacarrier.DataCarrier;
+import org.apache.skywalking.oap.server.library.datacarrier.buffer.QueueBuffer;
+import org.apache.skywalking.oap.server.library.datacarrier.consumer.BulkConsumePool;
+import org.apache.skywalking.oap.server.library.datacarrier.consumer.ConsumerPoolFactory;
+import org.apache.skywalking.oap.server.library.datacarrier.consumer.IConsumer;
+import org.apache.skywalking.oap.server.library.module.ModuleDefineHolder;
+import org.apache.skywalking.oap.server.telemetry.TelemetryModule;
+import org.apache.skywalking.oap.server.telemetry.api.GaugeMetrics;
+import org.apache.skywalking.oap.server.telemetry.api.MetricsCreator;
+import org.apache.skywalking.oap.server.telemetry.api.MetricsTag;
+
+/**
+ * MetricsPersistentWorkerMin is an extension of {@link MetricsPersistentWorker} and focuses on the Minute Metrics data persistent.
+ */
+@Slf4j
+public class MetricsPersistentWorkerMin extends MetricsPersistentWorker implements ServerStatusWatcher {
+    private final DataCarrier<Metrics> dataCarrier;
+
+    /**
+     * The percentage of queue used in aggregation
+     */
+    private final GaugeMetrics queuePercentageGauge;
+
+    /**
+     * @since 9.4.0
+     */
+    private final ServerStatusService serverStatusService;
+
+    // Not going to expose this as a configuration, only for testing purpose
+    private final boolean isTestingTTL = "true".equalsIgnoreCase(System.getenv("TESTING_TTL"));
+
+    MetricsPersistentWorkerMin(ModuleDefineHolder moduleDefineHolder, Model model, IMetricsDAO metricsDAO,
+                               AbstractWorker<Metrics> nextAlarmWorker, AbstractWorker<ExportEvent> nextExportWorker,
+                               MetricsTransWorker transWorker, boolean supportUpdate,
+                               long storageSessionTimeout, int metricsDataTTL, MetricStreamKind kind) {
+        super(
+            moduleDefineHolder, model, metricsDAO, nextAlarmWorker, nextExportWorker, transWorker, supportUpdate,
+            storageSessionTimeout, metricsDataTTL, kind
+        );
+
+        String name = "METRICS_L2_AGGREGATION";
+        int size = BulkConsumePool.Creator.recommendMaxSize() / 8;
+        if (size == 0) {
+            size = 1;
+        }
+        BulkConsumePool.Creator creator = new BulkConsumePool.Creator(name, size, 200);
+        try {
+            ConsumerPoolFactory.INSTANCE.createIfAbsent(name, creator);
+        } catch (Exception e) {
+            throw new UnexpectedException(e.getMessage(), e);
+        }
+
+        int bufferSize = 2000;
+        if (MetricStreamKind.MAL == kind) {
+            // In MAL meter streaming, the load of data flow is much less as they are statistics already,
+            // but in OAL sources, they are raw data.
+            // Set the buffer(size of queue) as 1/2 to reduce unnecessary resource costs.
+            bufferSize = 1000;
+        }
+        this.dataCarrier = new DataCarrier<>("MetricsPersistentWorker." + model.getName(), name, 1, bufferSize);
+        this.dataCarrier.consume(ConsumerPoolFactory.INSTANCE.get(name), new PersistentConsumer());
+
+        MetricsCreator metricsCreator = moduleDefineHolder.find(TelemetryModule.NAME)
+                                                          .provider()
+                                                          .getService(MetricsCreator.class);
+        queuePercentageGauge = metricsCreator.createGauge(
+            "metrics_aggregation_queue_used_percentage", "The percentage of queue used in aggregation.",
+            new MetricsTag.Keys("metricName", "level", "kind"),
+            new MetricsTag.Values(model.getName(), "2", kind.name())
+        );
+        serverStatusService = moduleDefineHolder.find(CoreModule.NAME).provider().getService(ServerStatusService.class);
+        serverStatusService.registerWatcher(this);
+    }
+
+    /**
+     * Accept all metrics data and push them into the queue for serial processing
+     */
+    @Override
+    public void in(Metrics metrics) {
+        final var isExpired = getMetricsDAO().isExpiredCache(getModel(), metrics, System.currentTimeMillis(), getMetricsDataTTL());
+        if (isExpired && !isTestingTTL) {
+            log.debug("Receiving expired metrics: {}, time: {}, ignored", metrics.id(), metrics.getTimeBucket());
+            return;
+        }
+        getAggregationCounter().inc();
+        dataCarrier.produce(metrics);
+    }
+
+    /**
+     * Metrics queue processor, merge the received metrics if existing one with same ID(s) and time bucket.
+     *
+     * ID is declared through {@link Object#hashCode()} and {@link Object#equals(Object)} as usual.
+     */
+    private class PersistentConsumer implements IConsumer<Metrics> {
+        @Override
+        public void consume(List<Metrics> data) {
+            int queueBufferSize = Arrays.stream(dataCarrier.getChannels().getBufferChannels())
+                                        .mapToInt(QueueBuffer::getBufferSize)
+                                        .sum();
+            int queueSize = data.size();
+
+            queuePercentageGauge.setValue(Math.round(100 * (double) queueSize / queueBufferSize));
+            MetricsPersistentWorkerMin.this.onWork(data);
+        }
+
+        @Override
+        public void onError(List<Metrics> data, Throwable t) {
+            log.error(t.getMessage(), t);
+        }
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsStreamProcessor.java
@@ -209,7 +209,7 @@ public class MetricsStreamProcessor implements StreamProcessor<Metrics> {
         AlarmNotifyWorker alarmNotifyWorker = new AlarmNotifyWorker(moduleDefineHolder);
         ExportMetricsWorker exportWorker = new ExportMetricsWorker(moduleDefineHolder);
 
-        MetricsPersistentWorker minutePersistentWorker = new MetricsPersistentWorker(
+        MetricsPersistentWorker minutePersistentWorker = new MetricsPersistentWorkerMin(
             moduleDefineHolder, model, metricsDAO, alarmNotifyWorker, exportWorker, transWorker,
             supportUpdate, storageSessionTimeout, metricsDataTTL, kind
         );

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsStreamProcessor.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/worker/MetricsStreamProcessor.java
@@ -209,7 +209,7 @@ public class MetricsStreamProcessor implements StreamProcessor<Metrics> {
         AlarmNotifyWorker alarmNotifyWorker = new AlarmNotifyWorker(moduleDefineHolder);
         ExportMetricsWorker exportWorker = new ExportMetricsWorker(moduleDefineHolder);
 
-        MetricsPersistentWorker minutePersistentWorker = new MetricsPersistentWorkerMin(
+        MetricsPersistentWorker minutePersistentWorker = new MetricsPersistentMinWorker(
             moduleDefineHolder, model, metricsDAO, alarmNotifyWorker, exportWorker, transWorker,
             supportUpdate, storageSessionTimeout, metricsDataTTL, kind
         );

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/mqe/Metadata.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/mqe/Metadata.java
@@ -23,9 +23,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.apache.skywalking.oap.server.core.query.type.KeyValue;
 
 @Data
+@EqualsAndHashCode
 public class Metadata {
     private List<KeyValue> labels  = new ArrayList<>();
 

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/DataCarrier.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/DataCarrier.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.oap.server.library.datacarrier;
 
 import java.util.Properties;
+import lombok.Getter;
 import org.apache.skywalking.oap.server.library.datacarrier.buffer.BufferStrategy;
 import org.apache.skywalking.oap.server.library.datacarrier.buffer.Channels;
 import org.apache.skywalking.oap.server.library.datacarrier.consumer.ConsumeDriver;
@@ -32,6 +33,7 @@ import org.apache.skywalking.oap.server.library.datacarrier.partition.SimpleRoll
  * DataCarrier main class. use this instance to set Producer/Consumer Model.
  */
 public class DataCarrier<T> {
+    @Getter
     private Channels<T> channels;
     private IDriver driver;
     private String name;

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/buffer/Channels.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/buffer/Channels.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.library.datacarrier.buffer;
 
+import lombok.Getter;
 import org.apache.skywalking.oap.server.library.datacarrier.partition.IDataPartitioner;
 
 /**
@@ -25,6 +26,7 @@ import org.apache.skywalking.oap.server.library.datacarrier.partition.IDataParti
  * buffer is full. The Default is BLOCKING <p> Created by wusheng on 2016/10/25.
  */
 public class Channels<T> {
+    @Getter
     private final QueueBuffer<T>[] bufferChannels;
     private IDataPartitioner<T> dataPartitioner;
     private final BufferStrategy strategy;

--- a/oap-server/server-starter/src/main/resources/otel-rules/oap.yaml
+++ b/oap-server/server-starter/src/main/resources/otel-rules/oap.yaml
@@ -66,6 +66,8 @@ metricsRules:
     exp: >
       metrics_aggregation.tagEqual('dimensionality', 'minute').sum(['service', 'host_name', 'level']).increase('PT1M')
       .tag({tags -> if (tags['level'] == '1') {tags.level = 'L1 aggregation'} }).tag({tags -> if (tags['level'] == '2') {tags.level = 'L2 aggregation'} })
+  - name: instance_metrics_aggregation_queue_used_percentage
+    exp: metrics_aggregation_queue_used_percentage.sum(['service', 'host_name', 'level', 'kind', 'metricName'])
   - name: instance_persistence_execute_percentile
     exp: persistence_timer_bulk_execute_latency.sum(['le', 'service', 'host_name']).increase('PT5M').histogram().histogram_percentile([50,70,90,99])
   - name: instance_persistence_prepare_percentile
@@ -78,6 +80,8 @@ metricsRules:
     exp: persistence_timer_bulk_prepare_latency_count.sum(['service', 'host_name']).increase('PT1M')
   - name: instance_metrics_persistent_cache
     exp: metrics_persistent_cache.sum(['service', 'host_name', 'status']).increase('PT1M')
+  - name: instance_metrics_persistent_collection_cached_size
+    exp: metrics_persistent_collection_cached_size.sum(['service', 'host_name', 'dimensionality', 'kind', 'metricName'])
   - name: jvm_thread_live_count
     exp: jvm_threads_current.sum(['service', 'host_name'])
   - name: jvm_thread_daemon_count

--- a/oap-server/server-starter/src/main/resources/ui-initialized-templates/so11y_oap/so11y-instance.json
+++ b/oap-server/server-starter/src/main/resources/ui-initialized-templates/so11y_oap/so11y-instance.json
@@ -461,6 +461,138 @@
                     "title": "Watermark Circuit Breaker Status",
                     "tips": "The status of circuit breaker listeners, 0 means all recovered from the breaks"
                   }
+                },
+                {
+                  "x": 12,
+                  "y": 52,
+                  "w": 12,
+                  "h": 13,
+                  "i": "22",
+                  "type": "Widget",
+                  "expressions": [
+                    "sort_values(meter_oap_instance_metrics_aggregation_queue_used_percentage{level='1',kind='OAL'},10,des,avg)"
+                  ],
+                  "graph": {
+                    "type": "Line",
+                    "step": false,
+                    "smooth": false,
+                    "showSymbol": true,
+                    "showXAxis": true,
+                    "showYAxis": true
+                  },
+                  "widget": {
+                    "title": "OAL L1 Aggregation Queue Percentage (%)"
+                  }
+                },
+                {
+                  "x": 0,
+                  "y": 65,
+                  "w": 12,
+                  "h": 13,
+                  "i": "23",
+                  "type": "Widget",
+                  "expressions": [
+                    "sort_values(meter_oap_instance_metrics_aggregation_queue_used_percentage{level='1',kind='MAL'},10,des,avg)"
+                  ],
+                  "widget": {
+                    "title": "MAL L1 Aggregation Queue Percentage (%)"
+                  },
+                  "graph": {
+                    "type": "Line",
+                    "step": false,
+                    "smooth": false,
+                    "showSymbol": true,
+                    "showXAxis": true,
+                    "showYAxis": true
+                  }
+                },
+                {
+                  "x": 12,
+                  "y": 65,
+                  "w": 12,
+                  "h": 13,
+                  "i": "24",
+                  "type": "Widget",
+                  "graph": {
+                    "type": "Line",
+                    "step": false,
+                    "smooth": false,
+                    "showSymbol": true,
+                    "showXAxis": true,
+                    "showYAxis": true
+                  },
+                  "expressions": [
+                    "sort_values(meter_oap_instance_metrics_aggregation_queue_used_percentage{level='2',kind='OAL'},10,des,avg)"
+                  ],
+                  "widget": {
+                    "title": "OAL L2 Aggregation Queue Percentage (%)"
+                  }
+                },
+                {
+                  "x": 0,
+                  "y": 78,
+                  "w": 12,
+                  "h": 13,
+                  "i": "25",
+                  "type": "Widget",
+                  "expressions": [
+                    "sort_values(meter_oap_instance_metrics_aggregation_queue_used_percentage{level='2',kind='OAL'},10,des,avg)"
+                  ],
+                  "graph": {
+                    "type": "Line",
+                    "step": false,
+                    "smooth": false,
+                    "showSymbol": true,
+                    "showXAxis": true,
+                    "showYAxis": true
+                  },
+                  "widget": {
+                    "title": "MAL L2 Aggregation Queue Percentage (%)"
+                  }
+                },
+                {
+                  "x": 12,
+                  "y": 78,
+                  "w": 12,
+                  "h": 13,
+                  "i": "26",
+                  "type": "Widget",
+                  "graph": {
+                    "type": "Line",
+                    "step": false,
+                    "smooth": false,
+                    "showSymbol": true,
+                    "showXAxis": true,
+                    "showYAxis": true
+                  },
+                  "expressions": [
+                    "sort_values(meter_oap_instance_metrics_persistent_collection_cached_size{dimensionality='minute',kind='OAL'},10,des,avg)"
+                  ],
+                  "widget": {
+                    "title": "OAL Min Metrics Persistent Collection Cached Size"
+                  }
+                },
+                {
+                  "x": 0,
+                  "y": 91,
+                  "w": 12,
+                  "h": 13,
+                  "i": "27",
+                  "type": "Widget",
+                  "expressions": [
+                    "sort_values(meter_oap_instance_metrics_persistent_collection_cached_size{dimensionality='minute',kind='MAL'},10,des,avg)"
+                  ],
+                  "graph": {
+                    "type": "Line",
+                    "step": false,
+                    "smooth": false,
+                    "showSymbol": true,
+                    "showXAxis": true,
+                    "showYAxis": true
+                  },
+                  "widget": {
+                    "title": "MAL Min Metrics Persistent Collection Cached Size"
+                  }
                 }
               ]
             },

--- a/test/e2e-v2/cases/mqe/mqe-cases.yaml
+++ b/test/e2e-v2/cases/mqe/mqe-cases.yaml
@@ -102,7 +102,7 @@ cases:
   # sort-value-OP
   - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="sort_values(service_percentile,2,asc,avg)" --service-name=e2e-service-provider
     expected: expected/sort-value-OP.yml
-  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="sort_values(service_percentile,des,avg)" --service-name=e2e-service-provider
+  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="sort_values(service_percentile,1,des,avg)" --service-name=e2e-service-provider
     expected: expected/sort-value-OP.yml
 
   # sort-label-value-OP

--- a/test/e2e-v2/cases/mqe/mqe-cases.yaml
+++ b/test/e2e-v2/cases/mqe/mqe-cases.yaml
@@ -100,9 +100,9 @@ cases:
 
   # sort-OP e2e used for test MQE expression, more tests can refer to the UT
   # sort-value-OP
-  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="sort_values(service_percentile,2,asc)" --service-name=e2e-service-provider
+  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="sort_values(service_percentile,2,asc,avg)" --service-name=e2e-service-provider
     expected: expected/sort-value-OP.yml
-  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="sort_values(service_percentile,des)" --service-name=e2e-service-provider
+  - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics exec --expression="sort_values(service_percentile,des,avg)" --service-name=e2e-service-provider
     expected: expected/sort-value-OP.yml
 
   # sort-label-value-OP


### PR DESCRIPTION
1. Self Observability: add `metrics_aggregation_queue_used_percentage` and `metrics_persistent_collection_cached_size` metrics for the OAP server.
2. [Break Change] MQE function `sort_values` sorts according to the aggregation result and labels rather than the simple time series values.
3. Fix `MetricsPersistentWorker`, remove DataCarrier queue from `Hour/Day` dimensions metrics persistent process.


- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

<img width="1424" height="840" alt="image" src="https://github.com/user-attachments/assets/7e081865-f7c6-4bb2-9b4e-725f102abfb8" />
