### PR TITLE
BanyanDB: make `BanyanDBMetricsDAO` output `scan all blocks` info log only when the model is not `indexModel`.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -87,6 +87,8 @@
 | **Attach Listener**             | 1         | RUNNABLE                    | JVM attach listener thread.                                                                                                           |
 | **Total**                       | **158**   | -                           | -                                                                                                                                     |
 
+* BanyanDB: make `BanyanDBMetricsDAO` output `scan all blocks` info log only when the model is not `indexModel`.
+
 #### UI
 
 * Enhance the trace `List/Tree/Table` graph to support displaying multiple refs of spans and distinguishing different parents.

--- a/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetricsDAO.java
+++ b/oap-server/server-storage-plugin/storage-banyandb-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/banyandb/measure/BanyanDBMetricsDAO.java
@@ -121,7 +121,9 @@ public class BanyanDBMetricsDAO extends AbstractBanyanDBDAO implements IMetricsD
         if (begin != 0L || end != 0L) {
             timestampRange = new TimestampRange(begin, end);
         } else {
-            log.info("{}[{}] will scan all blocks", model.getName(), idStr);
+            if (!model.getBanyanDBModelExtension().isIndexMode()) {
+                log.info("{}[{}] will scan all blocks", model.getName(), idStr);
+            }
         }
 
         List<Metrics> metricsInStorage = new ArrayList<>(metrics.size());


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
