### PR TITLE
Fix metrics comparison in promql with bool modifier

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -93,6 +93,7 @@
 * Remove method `appendMutant` from StorageID.
 * Fix otlp log handler reponse error and otlp span convert error.
 * Fix service_relation source layer in mq entry span analyse.
+* Fix metrics comparison in promql with bool modifier.
 
 #### UI
 

--- a/oap-server/server-query-plugin/promql-plugin/src/main/java/org/apache/skywalking/oap/query/promql/rt/PromQLExprQueryVisitor.java
+++ b/oap-server/server-query-plugin/promql-plugin/src/main/java/org/apache/skywalking/oap/query/promql/rt/PromQLExprQueryVisitor.java
@@ -203,12 +203,12 @@ public class PromQLExprQueryVisitor extends PromQLParserBaseVisitor<ParseResult>
                     return scalarResult;
                 }
             } else if (left.getResultType() == ParseResultType.METRICS_RANGE && right.getResultType() == ParseResultType.SCALAR) {
-                return matrixScalarCompareOp((MetricsRangeResult) left, (ScalarResult) right, opType);
+                return matrixScalarCompareOp((MetricsRangeResult) left, (ScalarResult) right, opType, boolModifier);
             } else if (left.getResultType() == ParseResultType.SCALAR && right.getResultType() == ParseResultType.METRICS_RANGE) {
-                return matrixScalarCompareOp((MetricsRangeResult) right, (ScalarResult) left, opType);
+                return matrixScalarCompareOp((MetricsRangeResult) right, (ScalarResult) left, opType, boolModifier);
             } else if (left.getResultType() == ParseResultType.METRICS_RANGE && right.getResultType() == ParseResultType.METRICS_RANGE) {
                 try {
-                    return matrixCompareOp((MetricsRangeResult) left, (MetricsRangeResult) right, opType);
+                    return matrixCompareOp((MetricsRangeResult) left, (MetricsRangeResult) right, opType, boolModifier);
                 } catch (IllegalExpressionException e) {
                     MetricsRangeResult result = new MetricsRangeResult();
                     result.setErrorType(ErrorType.BAD_DATA);

--- a/oap-server/server-query-plugin/promql-plugin/src/test/java/org/apache/skywalking/promql/rt/parser/PromQLExprQueryVisitorTest.java
+++ b/oap-server/server-query-plugin/promql-plugin/src/test/java/org/apache/skywalking/promql/rt/parser/PromQLExprQueryVisitorTest.java
@@ -133,6 +133,22 @@ public class PromQLExprQueryVisitorTest {
                 "service_cpm{service='serviceA', layer='GENERAL'} > 1",
                 ParseResultType.METRICS_RANGE,
                 List.of(new TimeValuePair(TIME_2023022012, "2"))
+            },
+            {
+                "MetricsScalarCompareOpWithBoolModifier",
+                PromQLApiHandler.QueryType.RANGE,
+                "service_cpm{service='serviceA', layer='GENERAL'} > bool 1",
+                ParseResultType.METRICS_RANGE,
+                List.of(new TimeValuePair(TIME_2023022010, "0"), new TimeValuePair(TIME_2023022011, "0"),
+                        new TimeValuePair(TIME_2023022012, "1"))
+            },
+            {
+                "MetricsMetricsCompareOpWithBoolModifier",
+                PromQLApiHandler.QueryType.RANGE,
+                "service_cpm{service='serviceA', layer='GENERAL'} > bool service_cpm{service='serviceA', layer='GENERAL'}",
+                ParseResultType.METRICS_RANGE,
+                List.of(new TimeValuePair(TIME_2023022010, "0"), new TimeValuePair(TIME_2023022011, "0"),
+                        new TimeValuePair(TIME_2023022012, "0"))
             }
         });
     }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix metrics comparison in promql with bool modifier
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

bool modifier after the operator, which will return 0 or 1 for the value rather than filtering.
This rule applies not only to comparisons between scalars but also to comparisons between metrics.

https://prometheus.io/docs/prometheus/latest/querying/operators/#comparison-binary-operators
