### PR TITLE
Revert: changes to e2e test trigger `times` (introduced in #13539)

### DIFF
--- a/test/e2e-v2/cases/apisix/otel-collector/e2e.yaml
+++ b/test/e2e-v2/cases/apisix/otel-collector/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://localhost:9089/info/
   method: GET
 

--- a/test/e2e-v2/cases/aws/api-gateway/e2e.yaml
+++ b/test/e2e-v2/cases/aws/api-gateway/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://localhost:9093/otel-metrics/send
   method: GET
 

--- a/test/e2e-v2/cases/aws/dynamodb/e2e.yaml
+++ b/test/e2e-v2/cases/aws/dynamodb/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://localhost:9093/otel-metrics/send
   method: GET
 

--- a/test/e2e-v2/cases/aws/eks/e2e.yaml
+++ b/test/e2e-v2/cases/aws/eks/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://localhost:9093/otel-metrics/send
   method: GET
 

--- a/test/e2e-v2/cases/aws/s3/e2e.yaml
+++ b/test/e2e-v2/cases/aws/s3/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://localhost:9093/otel-metrics/send
   method: GET
 

--- a/test/e2e-v2/cases/baseline/banyandb/e2e.yaml
+++ b/test/e2e-v2/cases/baseline/banyandb/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 30
   url: http://${provider_host}:${provider_9090}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/baseline/es/e2e.yaml
+++ b/test/e2e-v2/cases/baseline/es/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/baseline/es/es-sharding/e2e.yaml
+++ b/test/e2e-v2/cases/baseline/es/es-sharding/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 30
   url: http://${provider_host}:${provider_9090}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/exporter/kafka/e2e.yaml
+++ b/test/e2e-v2/cases/exporter/kafka/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/flink/e2e.yaml
+++ b/test/e2e-v2/cases/flink/e2e.yaml
@@ -32,7 +32,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${jobmanager_host}:${jobmanager_9260}/metrics
   method: GET
 

--- a/test/e2e-v2/cases/gateway/e2e.yaml
+++ b/test/e2e-v2/cases/gateway/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/go/e2e.yaml
+++ b/test/e2e-v2/cases/go/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/correlation
   method: POST
 

--- a/test/e2e-v2/cases/kafka/log/e2e.yaml
+++ b/test/e2e-v2/cases/kafka/log/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/logs/trigger
   method: GET
 

--- a/test/e2e-v2/cases/kafka/meter/e2e.yaml
+++ b/test/e2e-v2/cases/kafka/meter/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/kafka/simple-so11y/e2e.yaml
+++ b/test/e2e-v2/cases/kafka/simple-so11y/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/log/banyandb/e2e.yaml
+++ b/test/e2e-v2/cases/log/banyandb/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/logs/trigger
   method: GET
 

--- a/test/e2e-v2/cases/log/es/e2e.yaml
+++ b/test/e2e-v2/cases/log/es/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/logs/trigger
   method: GET
 

--- a/test/e2e-v2/cases/log/es/es-sharding/e2e.yaml
+++ b/test/e2e-v2/cases/log/es/es-sharding/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/logs/trigger
   method: GET
 

--- a/test/e2e-v2/cases/log/fluent-bit/e2e.yaml
+++ b/test/e2e-v2/cases/log/fluent-bit/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/logs/trigger
   method: GET
 

--- a/test/e2e-v2/cases/log/mysql/e2e.yaml
+++ b/test/e2e-v2/cases/log/mysql/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/logs/trigger
   method: GET
 

--- a/test/e2e-v2/cases/log/postgres/e2e.yaml
+++ b/test/e2e-v2/cases/log/postgres/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/logs/trigger
   method: GET
 

--- a/test/e2e-v2/cases/logql/e2e.yaml
+++ b/test/e2e-v2/cases/logql/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/lua/e2e.yaml
+++ b/test/e2e-v2/cases/lua/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider-entry_host}:${provider-entry_9090}/nginx/entry/info
   method: POST
 

--- a/test/e2e-v2/cases/menu/banyandb/e2e.yaml
+++ b/test/e2e-v2/cases/menu/banyandb/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/menu/es/e2e.yaml
+++ b/test/e2e-v2/cases/menu/es/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/menu/es/es-sharding/e2e.yaml
+++ b/test/e2e-v2/cases/menu/es/es-sharding/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/menu/mysql/e2e.yaml
+++ b/test/e2e-v2/cases/menu/mysql/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/menu/opensearch/e2e.yaml
+++ b/test/e2e-v2/cases/menu/opensearch/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/menu/postgres/e2e.yaml
+++ b/test/e2e-v2/cases/menu/postgres/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/meter/e2e.yaml
+++ b/test/e2e-v2/cases/meter/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/mqe/e2e.yaml
+++ b/test/e2e-v2/cases/mqe/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/nginx/e2e.yaml
+++ b/test/e2e-v2/cases/nginx/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${nginx_host}:${nginx_8080}/test
   method: POST
 

--- a/test/e2e-v2/cases/nodejs/e2e.yaml
+++ b/test/e2e-v2/cases/nodejs/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_5001}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/otlp-traces/e2e.yaml
+++ b/test/e2e-v2/cases/otlp-traces/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${frontend_host}:${frontend_8080}/api/products
   method: GET
 

--- a/test/e2e-v2/cases/php/e2e.yaml
+++ b/test/e2e-v2/cases/php/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 20
   url: http://${php_host}:${php_8080}/php/info
   method: POST
 

--- a/test/e2e-v2/cases/profiling/ebpf/network/banyandb/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/network/banyandb/e2e.yaml
@@ -83,7 +83,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${service_service_host}:${service_service_80}/consumer
   method: GET
 

--- a/test/e2e-v2/cases/profiling/ebpf/network/es/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/network/es/e2e.yaml
@@ -82,7 +82,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${service_service_host}:${service_service_80}/consumer
   method: GET
 

--- a/test/e2e-v2/cases/profiling/ebpf/network/es/es-sharding/e2e.yaml
+++ b/test/e2e-v2/cases/profiling/ebpf/network/es/es-sharding/e2e.yaml
@@ -82,7 +82,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${service_service_host}:${service_service_80}/consumer
   method: GET
 

--- a/test/e2e-v2/cases/promql/e2e.yaml
+++ b/test/e2e-v2/cases/promql/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/python/e2e.yaml
+++ b/test/e2e-v2/cases/python/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer-py_host}:${consumer-py_9090}/test
   method: POST
 

--- a/test/e2e-v2/cases/satellite/native-protocols/e2e.yaml
+++ b/test/e2e-v2/cases/satellite/native-protocols/e2e.yaml
@@ -33,7 +33,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/info
   method: POST
 

--- a/test/e2e-v2/cases/simple/auth/e2e.yaml
+++ b/test/e2e-v2/cases/simple/auth/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/simple/jdk/e2e.yaml
+++ b/test/e2e-v2/cases/simple/jdk/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/simple/mtls/e2e.yaml
+++ b/test/e2e-v2/cases/simple/mtls/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/simple/ssl/e2e.yaml
+++ b/test/e2e-v2/cases/simple/ssl/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/so11y/e2e.yaml
+++ b/test/e2e-v2/cases/so11y/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/storage/banyandb/e2e.yaml
+++ b/test/e2e-v2/cases/storage/banyandb/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 5s
-  times: -1
+  times: 40
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/storage/banyandb/stages/e2e.yaml
+++ b/test/e2e-v2/cases/storage/banyandb/stages/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 5s
-  times: -1
+  times: 40
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/storage/banyandb/tls/e2e.yaml
+++ b/test/e2e-v2/cases/storage/banyandb/tls/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 5s
-  times: -1
+  times: 40
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/storage/es/e2e.yaml
+++ b/test/e2e-v2/cases/storage/es/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/storage/es/es-sharding/e2e.yaml
+++ b/test/e2e-v2/cases/storage/es/es-sharding/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/storage/mysql/e2e.yaml
+++ b/test/e2e-v2/cases/storage/mysql/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/storage/opensearch/e2e.yaml
+++ b/test/e2e-v2/cases/storage/opensearch/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/storage/postgres/e2e.yaml
+++ b/test/e2e-v2/cases/storage/postgres/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${consumer_host}:${consumer_9092}/users
   method: POST
   body: '{"id":"123","name":"skywalking"}'

--- a/test/e2e-v2/cases/virtual-mq/e2e.yaml
+++ b/test/e2e-v2/cases/virtual-mq/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${provider_host}:${provider_9090}/kafka/send
   method: GET
 

--- a/test/e2e-v2/cases/win/e2e.yaml
+++ b/test/e2e-v2/cases/win/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${sender_host}:${sender_9093}/otel-metrics/send
   method: GET
 

--- a/test/e2e-v2/cases/zipkin/banyandb/e2e.yaml
+++ b/test/e2e-v2/cases/zipkin/banyandb/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${frontend_host}:${frontend_8081}
   method: POST
 

--- a/test/e2e-v2/cases/zipkin/es/e2e.yaml
+++ b/test/e2e-v2/cases/zipkin/es/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${frontend_host}:${frontend_8081}
   method: POST
 

--- a/test/e2e-v2/cases/zipkin/es/es-sharding/e2e.yaml
+++ b/test/e2e-v2/cases/zipkin/es/es-sharding/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${frontend_host}:${frontend_8081}
   method: POST
 

--- a/test/e2e-v2/cases/zipkin/kafka/e2e.yaml
+++ b/test/e2e-v2/cases/zipkin/kafka/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${sender_host}:${sender_9093}/sendZipkinTrace2Kafka
   method: POST
 

--- a/test/e2e-v2/cases/zipkin/mysql/e2e.yaml
+++ b/test/e2e-v2/cases/zipkin/mysql/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${frontend_host}:${frontend_8081}
   method: POST
 

--- a/test/e2e-v2/cases/zipkin/opensearch/e2e.yaml
+++ b/test/e2e-v2/cases/zipkin/opensearch/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${frontend_host}:${frontend_8081}
   method: POST
 

--- a/test/e2e-v2/cases/zipkin/postgres/e2e.yaml
+++ b/test/e2e-v2/cases/zipkin/postgres/e2e.yaml
@@ -31,7 +31,7 @@ setup:
 trigger:
   action: http
   interval: 3s
-  times: -1
+  times: 10
   url: http://${frontend_host}:${frontend_8081}
   method: POST
 


### PR DESCRIPTION
## Change Overview ##
This PR reverts changes made to the trigger schedules in the E2E test configuration (e2e.yaml) by PR #13539, with the exception of adjustments related to alarm mechanisms. The configuration file is restored to its state prior to the merge of #13539.