### PR TITLE
Shutdown DataCarrier own consume group if they share one BulkConsumePool

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -8,6 +8,7 @@
 * KubernetesCoordinator: make self instance return real pod IP address instead of `127.0.0.1`.
 * Enhance the alarm kernel with recovered status notification capability
 * Fix BrowserWebVitalsPerfData `clsTime` to `cls` and make it double type.
+* Shutdown DataCarrier own consume group if they share one BulkConsumePool.
 
 #### UI
 * Fix the missing icon in new native trace view.

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/BulkConsumePool.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/BulkConsumePool.java
@@ -78,7 +78,7 @@ public class BulkConsumePool implements ConsumerPool {
     @Override
     public void close(Channels channels) {
         for (MultipleChannelsConsumer consumer : allConsumers) {
-            consumer.shutdown();
+            consumer.close(channels);
         }
     }
 

--- a/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
+++ b/oap-server/server-library/library-datacarrier-queue/src/main/java/org/apache/skywalking/oap/server/library/datacarrier/consumer/MultipleChannelsConsumer.java
@@ -133,6 +133,28 @@ public class MultipleChannelsConsumer extends Thread {
         running = false;
     }
 
+    void close(Channels channels) {
+        Group group = null;
+        for (Group consumeTarget : consumeTargets) {
+            if (consumeTarget.channels == channels) {
+                group = consumeTarget;
+                break;
+            }
+        }
+        if (group == null) {
+            return;
+        }
+
+        ArrayList<Group> newList = new ArrayList<>();
+        for (Group consumeTarget : consumeTargets) {
+            if (consumeTarget.channels != channels) {
+                newList.add(consumeTarget);
+            }
+        }
+        consumeTargets = newList;
+        group.consumer.onExit();
+    }
+
     private static class Group {
         private Channels channels;
         private IConsumer consumer;


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

If multi DataCarriers share one `BulkConsumePool`, shuntdown channels should just remove their own workloads rather than shutdown all consumer threads. Because these threads are shared between all DataCarriers.

I'm not sure if this change aligns with the original semantics of the method `DataCarrier#shutdownConsumers`. Could you help me confirm?
