### PR TITLE
Fix meaningless service mesh metrics in none mesh environment

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -10,6 +10,7 @@
 * Fix BrowserWebVitalsPerfData `clsTime` to `cls` and make it double type.
 * Init `log-mal-rules` at module provider start stage to avoid re-init for every LAL.
 * Fail fast if SampleFamily is empty after MAL filter expression.
+* Fix meaningless service mesh metrics in none mesh environment.
 
 #### UI
 * Fix the missing icon in new native trace view.

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Endpoint.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Endpoint.java
@@ -88,7 +88,7 @@ public class Endpoint extends Source {
     private Map<String, String> originalTags;
     @Getter
     @Setter
-    private SideCar sideCar = new SideCar();
+    private SideCar sideCar;
     @Getter
     @Setter
     private Layer serviceLayer;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Service.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Service.java
@@ -83,7 +83,7 @@ public class Service extends Source {
     private Map<String, String> originalTags;
     @Getter
     @Setter
-    private SideCar sideCar = new SideCar();
+    private SideCar sideCar;
     @Getter
     @Setter
     private String tlsMode;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstance.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstance.java
@@ -85,7 +85,7 @@ public class ServiceInstance extends Source {
     private Map<String, String> originalTags;
     @Getter
     @Setter
-    private SideCar sideCar = new SideCar();
+    private SideCar sideCar;
 
     @Override
     public void prepare() {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceRelation.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceRelation.java
@@ -113,7 +113,7 @@ public class ServiceInstanceRelation extends Source {
     private String tlsMode;
     @Getter
     @Setter
-    private SideCar sideCar = new SideCar();
+    private SideCar sideCar;
 
     @Override
     public void prepare() {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceRelation.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceRelation.java
@@ -103,7 +103,7 @@ public class ServiceRelation extends Source {
     private String tlsMode;
     @Getter
     @Setter
-    private SideCar sideCar = new SideCar();
+    private SideCar sideCar;
 
     @Override
     public void prepare() {

--- a/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/TelemetryDataDispatcher.java
+++ b/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/TelemetryDataDispatcher.java
@@ -37,6 +37,7 @@ import org.apache.skywalking.oap.server.core.source.ServiceInstance;
 import org.apache.skywalking.oap.server.core.source.ServiceInstanceRelation;
 import org.apache.skywalking.oap.server.core.source.ServiceInstanceUpdate;
 import org.apache.skywalking.oap.server.core.source.ServiceRelation;
+import org.apache.skywalking.oap.server.core.source.SideCar;
 import org.apache.skywalking.oap.server.core.source.SourceReceiver;
 import org.apache.skywalking.oap.server.core.source.TCPService;
 import org.apache.skywalking.oap.server.core.source.TCPServiceInstance;
@@ -223,6 +224,7 @@ public class TelemetryDataDispatcher {
         service.setStatus(metrics.getStatus());
         service.setHttpResponseStatusCode(metrics.getResponseCode());
         service.setType(protocol2Type(metrics.getProtocol()));
+        service.setSideCar(new SideCar());
         service.getSideCar().setInternalErrorCode(metrics.getInternalErrorCode());
         service.getSideCar().setInternalRequestLatencyNanos(metrics.getInternalRequestLatencyNanos());
         service.getSideCar().setInternalResponseLatencyNanos(metrics.getInternalResponseLatencyNanos());
@@ -264,6 +266,7 @@ public class TelemetryDataDispatcher {
         serviceRelation.setDetectPoint(detectPointMapping(metrics.getDetectPoint()));
         serviceRelation.setComponentId(protocol2Component(metrics.getProtocol()));
         serviceRelation.setTlsMode(metrics.getTlsMode());
+        serviceRelation.setSideCar(new SideCar());
         serviceRelation.getSideCar().setInternalErrorCode(metrics.getInternalErrorCode());
         serviceRelation.getSideCar().setInternalRequestLatencyNanos(metrics.getInternalRequestLatencyNanos());
         serviceRelation.getSideCar().setInternalResponseLatencyNanos(metrics.getInternalResponseLatencyNanos());
@@ -303,6 +306,7 @@ public class TelemetryDataDispatcher {
         serviceInstance.setStatus(metrics.getStatus());
         serviceInstance.setHttpResponseStatusCode(metrics.getResponseCode());
         serviceInstance.setType(protocol2Type(metrics.getProtocol()));
+        serviceInstance.setSideCar(new SideCar());
         serviceInstance.getSideCar().setInternalErrorCode(metrics.getInternalErrorCode());
         serviceInstance.getSideCar().setInternalRequestLatencyNanos(metrics.getInternalRequestLatencyNanos());
         serviceInstance.getSideCar().setInternalResponseLatencyNanos(metrics.getInternalResponseLatencyNanos());
@@ -375,6 +379,7 @@ public class TelemetryDataDispatcher {
         serviceRelation.setDetectPoint(detectPointMapping(metrics.getDetectPoint()));
         serviceRelation.setComponentId(protocol2Component(metrics.getProtocol()));
         serviceRelation.setTlsMode(metrics.getTlsMode());
+        serviceRelation.setSideCar(new SideCar());
         serviceRelation.getSideCar().setInternalErrorCode(metrics.getInternalErrorCode());
         serviceRelation.getSideCar().setInternalRequestLatencyNanos(metrics.getInternalRequestLatencyNanos());
         serviceRelation.getSideCar().setInternalResponseLatencyNanos(metrics.getInternalResponseLatencyNanos());
@@ -417,6 +422,7 @@ public class TelemetryDataDispatcher {
         endpoint.setStatus(metrics.getStatus());
         endpoint.setHttpResponseStatusCode(metrics.getResponseCode());
         endpoint.setType(protocol2Type(metrics.getProtocol()));
+        endpoint.setSideCar(new SideCar());
         endpoint.getSideCar().setInternalErrorCode(metrics.getInternalErrorCode());
         endpoint.getSideCar().setInternalRequestLatencyNanos(metrics.getInternalRequestLatencyNanos());
         endpoint.getSideCar().setInternalResponseLatencyNanos(metrics.getInternalResponseLatencyNanos());

--- a/oap-server/server-starter/src/main/resources/oal/mesh.oal
+++ b/oap-server/server-starter/src/main/resources/oal/mesh.oal
@@ -16,21 +16,21 @@
  *
  */
 
-service_sidecar_internal_req_latency_nanos = from(Service.sideCar.internalRequestLatencyNanos).longAvg();
-service_sidecar_internal_resp_latency_nanos = from(Service.sideCar.internalResponseLatencyNanos).longAvg();
+service_sidecar_internal_req_latency_nanos = from(Service.sideCar.internalRequestLatencyNanos).filter(sideCar != null).longAvg();
+service_sidecar_internal_resp_latency_nanos = from(Service.sideCar.internalResponseLatencyNanos).filter(sideCar != null).longAvg();
 
-service_instance_sidecar_internal_req_latency_nanos = from(ServiceInstance.sideCar.internalRequestLatencyNanos).longAvg();
-service_instance_sidecar_internal_resp_latency_nanos = from(ServiceInstance.sideCar.internalResponseLatencyNanos).longAvg();
+service_instance_sidecar_internal_req_latency_nanos = from(ServiceInstance.sideCar.internalRequestLatencyNanos).filter(sideCar != null).longAvg();
+service_instance_sidecar_internal_resp_latency_nanos = from(ServiceInstance.sideCar.internalResponseLatencyNanos).filter(sideCar != null).longAvg();
 
-endpoint_sidecar_internal_req_latency_nanos = from(Endpoint.sideCar.internalRequestLatencyNanos).longAvg();
-endpoint_sidecar_internal_resp_latency_nanos = from(Endpoint.sideCar.internalResponseLatencyNanos).longAvg();
+endpoint_sidecar_internal_req_latency_nanos = from(Endpoint.sideCar.internalRequestLatencyNanos).filter(sideCar != null).longAvg();
+endpoint_sidecar_internal_resp_latency_nanos = from(Endpoint.sideCar.internalResponseLatencyNanos).filter(sideCar != null).longAvg();
 
-service_client_sidecar_internal_req_latency_nanos = from(ServiceRelation.sideCar.internalRequestLatencyNanos).filter(detectPoint == DetectPoint.CLIENT).longAvg();
-service_server_sidecar_internal_req_latency_nanos = from(ServiceRelation.sideCar.internalRequestLatencyNanos).filter(detectPoint == DetectPoint.SERVER).longAvg();
-service_client_sidecar_internal_resp_latency_nanos = from(ServiceRelation.sideCar.internalResponseLatencyNanos).filter(detectPoint == DetectPoint.CLIENT).longAvg();
-service_server_sidecar_internal_resp_latency_nanos = from(ServiceRelation.sideCar.internalResponseLatencyNanos).filter(detectPoint == DetectPoint.SERVER).longAvg();
+service_client_sidecar_internal_req_latency_nanos = from(ServiceRelation.sideCar.internalRequestLatencyNanos).filter(sideCar != null).filter(detectPoint == DetectPoint.CLIENT).longAvg();
+service_server_sidecar_internal_req_latency_nanos = from(ServiceRelation.sideCar.internalRequestLatencyNanos).filter(sideCar != null).filter(detectPoint == DetectPoint.SERVER).longAvg();
+service_client_sidecar_internal_resp_latency_nanos = from(ServiceRelation.sideCar.internalResponseLatencyNanos).filter(sideCar != null).filter(detectPoint == DetectPoint.CLIENT).longAvg();
+service_server_sidecar_internal_resp_latency_nanos = from(ServiceRelation.sideCar.internalResponseLatencyNanos).filter(sideCar != null).filter(detectPoint == DetectPoint.SERVER).longAvg();
 
-instance_client_sidecar_internal_req_latency_nanos = from(ServiceInstanceRelation.sideCar.internalRequestLatencyNanos).filter(detectPoint == DetectPoint.CLIENT).longAvg();
-instance_server_sidecar_internal_req_latency_nanos = from(ServiceInstanceRelation.sideCar.internalRequestLatencyNanos).filter(detectPoint == DetectPoint.SERVER).longAvg();
-instance_client_sidecar_internal_resp_latency_nanos = from(ServiceInstanceRelation.sideCar.internalResponseLatencyNanos).filter(detectPoint == DetectPoint.CLIENT).longAvg();
-instance_server_sidecar_internal_resp_latency_nanos = from(ServiceInstanceRelation.sideCar.internalResponseLatencyNanos).filter(detectPoint == DetectPoint.SERVER).longAvg();
+instance_client_sidecar_internal_req_latency_nanos = from(ServiceInstanceRelation.sideCar.internalRequestLatencyNanos).filter(sideCar != null).filter(detectPoint == DetectPoint.CLIENT).longAvg();
+instance_server_sidecar_internal_req_latency_nanos = from(ServiceInstanceRelation.sideCar.internalRequestLatencyNanos).filter(sideCar != null).filter(detectPoint == DetectPoint.SERVER).longAvg();
+instance_client_sidecar_internal_resp_latency_nanos = from(ServiceInstanceRelation.sideCar.internalResponseLatencyNanos).filter(sideCar != null).filter(detectPoint == DetectPoint.CLIENT).longAvg();
+instance_server_sidecar_internal_resp_latency_nanos = from(ServiceInstanceRelation.sideCar.internalResponseLatencyNanos).filter(sideCar != null).filter(detectPoint == DetectPoint.SERVER).longAvg();


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix meaningless service mesh metrics in none mesh environment
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

In no sidecar environment, service mesh metrics should not be generated.
