### PR TITLE
Drop empty value tag in searchable tags

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -10,6 +10,7 @@
 * Fix BrowserWebVitalsPerfData `clsTime` to `cls` and make it double type.
 * Init `log-mal-rules` at module provider start stage to avoid re-init for every LAL.
 * Fail fast if SampleFamily is empty after MAL filter expression.
+* Drop segment tag for searchable tags if the tag value is an empty string.
 
 #### UI
 * Fix the missing icon in new native trace view.

--- a/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/SegmentAnalysisListener.java
+++ b/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/SegmentAnalysisListener.java
@@ -151,6 +151,12 @@ public class SegmentAnalysisListener implements FirstAnalysisListener, EntryAnal
         span.getTagsList().forEach(tag -> {
             if (searchableTagKeys.getSearchableTags().contains(tag.getKey())) {
                 final Tag spanTag = new Tag(tag.getKey(), tag.getValue());
+                if (StringUtil.isEmpty(spanTag.getValue())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Segment tag : {} value is empty, dropped", spanTag);
+                    }
+                    return;
+                }
                 if (tag.getValue().length()  > Tag.TAG_LENGTH || spanTag.toString().length() > Tag.TAG_LENGTH) {
                     if (log.isDebugEnabled()) {
                         log.debug("Segment tag : {} length > : {}, dropped", spanTag, Tag.TAG_LENGTH);


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix <bug description or the bug issue number or bug issue link>
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.



<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

When using tag auto-complete, if searchable tags have null values, the following error happens. The fix checks empty value in tag, so no searchable tag with empty value is pushed to storage.  
```
{
    "errors": [
        {
            "message": "The field at path '/tagValues[0]' was declared as a non null type, but the code involved in retrieving data has wrongly returned a null value.  The graphql specification requires that the parent field be set to null, or if that is non nullable that it bubble up null to its parent and so on. The non-nullable type is 'String' within parent type '[String!]'",
            "path": [
                "tagValues",
                0
            ],
            "extensions": {
                "classification": "NullValueInNonNullableField"
            }
        }
    ],
    "data": {
        "tagValues": null
    }
}
```




