### PR TITLE
MQE: fix multiple labeled metric query and make it won't get result if no label value compose is match.

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -20,7 +20,7 @@
 * Remove `bydb.dependencies.properties` and set the compatible BanyanDB API version number in `${SW_STORAGE_BANYANDB_COMPATIBLE_SERVER_API_VERSIONS}`
 * Fix trace profiling query time range condition.
 * Fix BanyanDB time range overflow in profile thread snapshot query.
-* MQE: fix multiple labeled metric query and make it won't get result if no label value compose is match.
+* MQE: fix multiple labeled metric query and ensure no results are returned if no label value combinations match.
 
 #### UI
 * Fix the missing icon in new native trace view.

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IMetricsQueryDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IMetricsQueryDAO.java
@@ -191,7 +191,7 @@ public interface IMetricsQueryDAO extends DAO {
                     });
                     if (!keySet.isEmpty()) {
                         keySets.add(keySet);
-                    } else { // only all query labels match, can get result
+                    } else { // If any query label has no matches, clear all keySets so that no results are returned
                         keySets.clear();
                     }
                 }


### PR DESCRIPTION
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
