### PR TITLE
Add E2E testing documentation to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,6 +452,51 @@ e2e trigger -c test/e2e-v2/cases/simple/jdk/e2e.yaml
 e2e verify -c test/e2e-v2/cases/simple/jdk/e2e.yaml
 ```
 
+## License Checks (skywalking-eyes)
+
+SkyWalking uses [Apache SkyWalking Eyes](https://github.com/apache/skywalking-eyes) for license header and dependency license checks. **License checks must pass before submitting a PR.**
+
+### Installation
+
+```bash
+# Install the same version used in CI
+go install github.com/apache/skywalking-eyes/cmd/license-eye@5b7ee1731d036b5aac68f8bd3fc9e6f98ada082e
+
+# Or via Homebrew (macOS)
+brew install license-eye
+```
+
+### Commands
+
+```bash
+# Check license headers in source files (fast, run before PR)
+license-eye header check
+
+# Fix missing license headers automatically
+license-eye header fix
+
+# Generate LICENSE file from dependencies
+license-eye dependency resolve --summary ./dist-material/release-docs/LICENSE.tpl
+
+# Check if LICENSE file needs update
+git diff -U0 ./dist-material/release-docs/LICENSE
+```
+
+### Configuration
+
+Configuration is in `.licenserc.yaml`:
+- Defines Apache-2.0 license header
+- Lists paths to ignore (e.g., `**/*.md`, `**/*.json`, generated files)
+- Configures dependency license mappings
+
+### CI Behavior
+
+The CI runs on **Linux (ubuntu-latest)** with two checks:
+1. **license-header**: Verifies all source files have proper Apache-2.0 headers
+2. **dependency-license**: Regenerates LICENSE file and fails if it differs from committed version
+
+**Important:** Some dependencies have platform-specific variants (Windows/macOS suffixes). The LICENSE file should reflect Linux dependencies since CI runs on Linux. If `dependency-license` fails and you're on macOS/Windows, ask maintainers to verify before committing LICENSE changes.
+
 ## Git Submodules
 
 The project uses submodules for protocol definitions and UI:


### PR DESCRIPTION
### Add E2E testing and license check documentation to CLAUDE.md

- [x] If this is non-trivial feature, paste the links/URLs to the design doc.
  - References: [skywalking-infra-e2e](https://github.com/apache/skywalking-infra-e2e), [skywalking-eyes](https://github.com/apache/skywalking-eyes)
- [x] Update the documentation to include this new feature.
  - This PR adds documentation to CLAUDE.md for AI assistants
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
  - N/A - documentation only
- [ ] If it's UI related, attach the screenshots below.
  - N/A

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
  - N/A - proactive documentation improvement
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
  - N/A - CLAUDE.md is for AI assistants, not user-facing changes

---

## Summary

Add comprehensive documentation to CLAUDE.md for running E2E tests and license checks locally.

### E2E Testing
- E2E tool installation with pinned CI version (`e7138da...`)
- Test structure and e2e.yaml configuration format
- Quick start guide with `SW_AGENT_JDK_VERSION=8` requirement
- Debugging workflow: keep containers running on failure, re-trigger/re-verify
- Rebuild detection using file timestamps (OAP, java-test-service, test cases)
- Stop e2e before rebuild, then restart

### License Checks (skywalking-eyes)
- Installation with pinned CI version (`5b7ee17...`)
- Commands: `license-eye header check`, `license-eye dependency resolve`
- CI runs on Linux - platform-specific dependencies may differ on macOS/Windows
- Must pass license checks before submitting PR

### PR Guidelines
- Always add `copilot` as reviewer
- Always read `.github/PULL_REQUEST_TEMPLATE` and use exact format with checkboxes