### PR TITLE
Fix CI E2E failures caused by Docker 29 on GitHub Actions runners

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -811,7 +811,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@upgrade-deps-and-migrate-deprecated-apis
+        uses: apache/skywalking-infra-e2e@e7138da4f9b7a25a169c9f8d995795d4d2e34bde
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -891,7 +891,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@upgrade-deps-and-migrate-deprecated-apis
+        uses: apache/skywalking-infra-e2e@e7138da4f9b7a25a169c9f8d995795d4d2e34bde
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -968,7 +968,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@upgrade-deps-and-migrate-deprecated-apis
+        uses: apache/skywalking-infra-e2e@e7138da4f9b7a25a169c9f8d995795d4d2e34bde
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -1047,7 +1047,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@upgrade-deps-and-migrate-deprecated-apis
+        uses: apache/skywalking-infra-e2e@e7138da4f9b7a25a169c9f8d995795d4d2e34bde
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1143,7 +1143,7 @@ jobs:
 #          fi
 #          docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
 #      - name: ${{ matrix.test.name }}
-#        uses: apache/skywalking-infra-e2e@upgrade-deps-and-migrate-deprecated-apis
+#        uses: apache/skywalking-infra-e2e@e7138da4f9b7a25a169c9f8d995795d4d2e34bde
 #        with:
 #          e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
 #      - if: ${{ failure() }}


### PR DESCRIPTION
### Fix CI E2E test failures caused by Docker 29 upgrade on GitHub Actions runners

- [ ] Explain briefly why the bug exists and how to fix it.

GitHub Actions runners upgraded to Docker 29, which enables containerd image store by default. This causes two problems:

1. **containerd v2.1.5 lowered the default file descriptor limit** from 1,048,576 to 1,024, causing applications like Elasticsearch to crash immediately at startup (ES requires at least 65,536).
2. **Docker 29 raised the minimum API version to 1.44**, while the current `skywalking-infra-e2e` tool uses Docker SDK API v1.41, causing `client version 1.41 is too old` errors.

This PR fixes both issues by:
- Disabling the containerd image store (`containerd-snapshotter: false`) in all Docker-related CI jobs, restoring the classic overlay2 storage driver and its default ulimits.
- Exporting `DOCKER_API_VERSION` from the server's supported version so the Docker SDK client negotiates correctly after restart.

Affected jobs: `docker` (image build), `e2e-test`, `e2e-test-istio`, `e2e-test-istio-ambient`, `e2e-test-java-versions`.

- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).