### PR TITLE
Upgrade infra-e2e to fix Docker 29 containerd compatibility

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -204,22 +204,6 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - name: Disable containerd image store
-        shell: bash
-        run: |
-          DAEMON_JSON="/etc/docker/daemon.json"
-          if [ -f "$DAEMON_JSON" ]; then
-            sudo jq '. + {"features": {"containerd-snapshotter": false}}' "$DAEMON_JSON" \
-              | sudo tee "${DAEMON_JSON}.tmp" > /dev/null
-            sudo mv "${DAEMON_JSON}.tmp" "$DAEMON_JSON"
-          else
-            echo '{"features": {"containerd-snapshotter": false}}' \
-              | sudo tee "$DAEMON_JSON" > /dev/null
-          fi
-          sudo systemctl restart docker
-          docker version
-          docker info
-          echo "DOCKER_API_VERSION=$(docker version --format '{{.Server.APIVersion}}')" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@v4
         name: Download distribution tar
         with:
@@ -755,22 +739,6 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - name: Disable containerd image store
-        shell: bash
-        run: |
-          DAEMON_JSON="/etc/docker/daemon.json"
-          if [ -f "$DAEMON_JSON" ]; then
-            sudo jq '. + {"features": {"containerd-snapshotter": false}}' "$DAEMON_JSON" \
-              | sudo tee "${DAEMON_JSON}.tmp" > /dev/null
-            sudo mv "${DAEMON_JSON}.tmp" "$DAEMON_JSON"
-          else
-            echo '{"features": {"containerd-snapshotter": false}}' \
-              | sudo tee "$DAEMON_JSON" > /dev/null
-          fi
-          sudo systemctl restart docker
-          docker version
-          docker info
-          echo "DOCKER_API_VERSION=$(docker version --format '{{.Server.APIVersion}}')" >> "$GITHUB_ENV"
       - run: grep -v '^#' test/e2e-v2/script/env >> "$GITHUB_ENV"
       - uses: apache/skywalking-cli/actions/setup@master
         with:
@@ -855,22 +823,6 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - name: Disable containerd image store
-        shell: bash
-        run: |
-          DAEMON_JSON="/etc/docker/daemon.json"
-          if [ -f "$DAEMON_JSON" ]; then
-            sudo jq '. + {"features": {"containerd-snapshotter": false}}' "$DAEMON_JSON" \
-              | sudo tee "${DAEMON_JSON}.tmp" > /dev/null
-            sudo mv "${DAEMON_JSON}.tmp" "$DAEMON_JSON"
-          else
-            echo '{"features": {"containerd-snapshotter": false}}' \
-              | sudo tee "$DAEMON_JSON" > /dev/null
-          fi
-          sudo systemctl restart docker
-          docker version
-          docker info
-          echo "DOCKER_API_VERSION=$(docker version --format '{{.Server.APIVersion}}')" >> "$GITHUB_ENV"
       - run: grep -v '^#' test/e2e-v2/script/env >> "$GITHUB_ENV"
       - uses: apache/skywalking-cli/actions/setup@master
         with:
@@ -932,22 +884,6 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - name: Disable containerd image store
-        shell: bash
-        run: |
-          DAEMON_JSON="/etc/docker/daemon.json"
-          if [ -f "$DAEMON_JSON" ]; then
-            sudo jq '. + {"features": {"containerd-snapshotter": false}}' "$DAEMON_JSON" \
-              | sudo tee "${DAEMON_JSON}.tmp" > /dev/null
-            sudo mv "${DAEMON_JSON}.tmp" "$DAEMON_JSON"
-          else
-            echo '{"features": {"containerd-snapshotter": false}}' \
-              | sudo tee "$DAEMON_JSON" > /dev/null
-          fi
-          sudo systemctl restart docker
-          docker version
-          docker info
-          echo "DOCKER_API_VERSION=$(docker version --format '{{.Server.APIVersion}}')" >> "$GITHUB_ENV"
       - run: grep -v '^#' test/e2e-v2/script/env >> "$GITHUB_ENV"
       - uses: apache/skywalking-cli/actions/setup@master
         with:
@@ -1004,22 +940,6 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - name: Disable containerd image store
-        shell: bash
-        run: |
-          DAEMON_JSON="/etc/docker/daemon.json"
-          if [ -f "$DAEMON_JSON" ]; then
-            sudo jq '. + {"features": {"containerd-snapshotter": false}}' "$DAEMON_JSON" \
-              | sudo tee "${DAEMON_JSON}.tmp" > /dev/null
-            sudo mv "${DAEMON_JSON}.tmp" "$DAEMON_JSON"
-          else
-            echo '{"features": {"containerd-snapshotter": false}}' \
-              | sudo tee "$DAEMON_JSON" > /dev/null
-          fi
-          sudo systemctl restart docker
-          docker version
-          docker info
-          echo "DOCKER_API_VERSION=$(docker version --format '{{.Server.APIVersion}}')" >> "$GITHUB_ENV"
       - run: grep -v '^#' test/e2e-v2/script/env >> "$GITHUB_ENV"
       - uses: apache/skywalking-cli/actions/setup@master
         with:


### PR DESCRIPTION
### Fix E2E test failures caused by Docker 29 on GitHub Actions runners

- [ ] Explain briefly why the bug exists and how to fix it.

GitHub Actions runners upgraded to Docker 29, which:
1. Enables containerd image store by default. containerd v2.1.5 lowered the default file descriptor limit from 1,048,576 to 1,024, causing applications like Elasticsearch to crash at startup.
2. Raised the minimum Docker API version to 1.44, while the current infra-e2e uses API v1.41.

The fix is in `skywalking-infra-e2e` [8c21e43](https://github.com/apache/skywalking-infra-e2e/commit/8c21e43e241a32a54bdf8eeceb9099eb27e5e9b4), which disables the containerd image store and negotiates the Docker API version internally before running docker compose.

This PR:
1. Reverts the previous workaround (88ca648) that added containerd disable steps directly in the workflow.
2. Bumps the infra-e2e commit to `8c21e43` which handles the fix internally.

- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).