### PR TITLE
Reduce noisy log levels in health checker and batch queue

### DIFF
--- a/oap-server/server-health-checker/src/main/java/org/apache/skywalking/oap/server/health/checker/provider/HealthCheckerHttpService.java
+++ b/oap-server/server-health-checker/src/main/java/org/apache/skywalking/oap/server/health/checker/provider/HealthCheckerHttpService.java
@@ -35,11 +35,12 @@ public class HealthCheckerHttpService {
     @Get("/healthcheck")
     public HttpResponse healthcheck(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         final var status = healthQueryService.checkHealth();
-        log.info("Health status: {}", status);
 
         if (status.getScore() == 0) {
+            log.debug("Health status: {}", status);
             return HttpResponse.of(HttpStatus.OK);
         }
+        log.warn("Health status: {}", status);
         return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/oap-server/server-library/library-batch-queue/src/main/java/org/apache/skywalking/oap/server/library/batchqueue/BatchQueue.java
+++ b/oap-server/server-library/library-batch-queue/src/main/java/org/apache/skywalking/oap/server/library/batchqueue/BatchQueue.java
@@ -807,7 +807,7 @@ public class BatchQueue<T> {
             // Rebuild assignedPartitions from ownership array
             this.assignedPartitions = buildAssignmentsFromOwner(owner, taskCount, partitionCount);
 
-            log.info("BatchQueue[{}]: rebalanced {} partitions", name, moves.size());
+            log.debug("BatchQueue[{}]: rebalanced {} partitions", name, moves.size());
         } catch (final Throwable t) {
             log.error("BatchQueue[{}]: rebalance error", name, t);
         }


### PR DESCRIPTION
## Summary
- Health check endpoint: log at `debug` when healthy (score=0), `warn` when unhealthy (was `info` on every request)
- BatchQueue rebalance: downgrade from `info` to `debug` (routine operation that clutters logs)

## Test plan
- [ ] Verify health check endpoint returns 200/503 correctly
- [ ] Confirm log output at appropriate levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)