### PR TITLE
Fix LAL == and != numeric comparison bug

### DIFF
--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALValueCodegen.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALValueCodegen.java
@@ -95,18 +95,26 @@ final class LALValueCodegen {
                 (LALScriptModel.ComparisonCondition) cond;
             switch (cc.getOp()) {
                 case EQ:
-                    sb.append("java.util.Objects.equals(");
-                    generateValueAccessObj(sb, cc.getLeft(), cc.getLeftCast(), genCtx);
-                    sb.append(", ");
-                    generateConditionValue(sb, cc.getRight(), genCtx);
-                    sb.append(")");
+                    if (cc.getRight() instanceof LALScriptModel.NumberConditionValue) {
+                        generateNumericComparison(sb, cc, " == ", genCtx);
+                    } else {
+                        sb.append("java.util.Objects.equals(");
+                        generateValueAccessObj(sb, cc.getLeft(), cc.getLeftCast(), genCtx);
+                        sb.append(", ");
+                        generateConditionValue(sb, cc.getRight(), genCtx);
+                        sb.append(")");
+                    }
                     break;
                 case NEQ:
-                    sb.append("!java.util.Objects.equals(");
-                    generateValueAccessObj(sb, cc.getLeft(), cc.getLeftCast(), genCtx);
-                    sb.append(", ");
-                    generateConditionValue(sb, cc.getRight(), genCtx);
-                    sb.append(")");
+                    if (cc.getRight() instanceof LALScriptModel.NumberConditionValue) {
+                        generateNumericComparison(sb, cc, " != ", genCtx);
+                    } else {
+                        sb.append("!java.util.Objects.equals(");
+                        generateValueAccessObj(sb, cc.getLeft(), cc.getLeftCast(), genCtx);
+                        sb.append(", ");
+                        generateConditionValue(sb, cc.getRight(), genCtx);
+                        sb.append(")");
+                    }
                     break;
                 case GT:
                     generateNumericComparison(sb, cc, " > ", genCtx);

--- a/oap-server/analyzer/log-analyzer/src/test/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGeneratorBasicTest.java
+++ b/oap-server/analyzer/log-analyzer/src/test/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGeneratorBasicTest.java
@@ -75,9 +75,10 @@ class LALClassGeneratorBasicTest extends LALClassGeneratorTestBase {
     }
 
     @Test
-    void generateSourceReturnsJavaCode() {
-        final String source = generator.generateSource(
-            "filter { json {} sink {} }");
+    void compileAndVerifySourceReturnsJavaCode() throws Exception {
+        final String dsl = "filter { json {} sink {} }";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertNotNull(source);
         assertTrue(source.contains("filterSpec.json(ctx)"));
         assertTrue(source.contains("filterSpec.sink(ctx)"));

--- a/oap-server/analyzer/log-analyzer/src/test/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGeneratorConditionTest.java
+++ b/oap-server/analyzer/log-analyzer/src/test/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGeneratorConditionTest.java
@@ -40,13 +40,14 @@ class LALClassGeneratorConditionTest extends LALClassGeneratorTestBase {
     }
 
     @Test
-    void generateSourceTagFunctionEmitsTagValue() {
-        final String source = generator.generateSource(
-            "filter {\n"
+    void compileAndVerifyTagFunctionEmitsTagValue() throws Exception {
+        final String dsl = "filter {\n"
             + "  if (tag(\"LOG_KIND\") == \"SLOW_SQL\") {\n"
             + "    sink {}\n"
             + "  }\n"
-            + "}");
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains("h.tagValue(\"LOG_KIND\")"),
             "Expected tagValue call but got: " + source);
         assertTrue(source.contains("SLOW_SQL"));
@@ -93,14 +94,15 @@ class LALClassGeneratorConditionTest extends LALClassGeneratorTestBase {
     }
 
     @Test
-    void generateSourceSafeNavMethodEmitsSpecificHelper() {
-        final String source = generator.generateSource(
-            "filter {\n"
+    void compileAndVerifySafeNavMethodEmitsSpecificHelper() throws Exception {
+        final String dsl = "filter {\n"
             + "  json {}\n"
             + "  if (parsed?.flags?.toString()) {\n"
             + "    sink {}\n"
             + "  }\n"
-            + "}");
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains("h.toString("),
             "Expected toString helper for safe nav method but got: " + source);
         assertTrue(source.contains("h.isNotEmpty("),
@@ -139,6 +141,111 @@ class LALClassGeneratorConditionTest extends LALClassGeneratorTestBase {
             + "}");
     }
 
+    // ==================== Numeric equality/inequality ====================
+
+    @Test
+    void compileNeqNumericEmitsNumericOp() throws Exception {
+        final String dsl = "filter {\n"
+            + "  json {}\n"
+            + "  if (parsed?.code as Integer != 403) {\n"
+            + "    sink {}\n"
+            + "  }\n"
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
+        assertTrue(source.contains("!= 403L"),
+            "Expected numeric != but got: " + source);
+    }
+
+    @Test
+    void compileEqNumericEmitsNumericOp() throws Exception {
+        final String dsl = "filter {\n"
+            + "  json {}\n"
+            + "  if (parsed?.code as Integer == 200) {\n"
+            + "    sink {}\n"
+            + "  }\n"
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
+        assertTrue(source.contains("== 200L"),
+            "Expected numeric == but got: " + source);
+    }
+
+    @Test
+    void compileEqStringUsesObjectsEquals() throws Exception {
+        final String dsl = "filter {\n"
+            + "  json {}\n"
+            + "  if (parsed?.status == \"OK\") {\n"
+            + "    sink {}\n"
+            + "  }\n"
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
+        assertTrue(source.contains("java.util.Objects.equals("),
+            "Expected Objects.equals for string comparison but got: " + source);
+    }
+
+    @Test
+    void compileNeqStringUsesObjectsEquals() throws Exception {
+        final String dsl = "filter {\n"
+            + "  json {}\n"
+            + "  if (parsed?.status != \"ERROR\") {\n"
+            + "    sink {}\n"
+            + "  }\n"
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
+        assertTrue(source.contains("!java.util.Objects.equals("),
+            "Expected !Objects.equals for string != but got: " + source);
+    }
+
+    @Test
+    void compileNeqNumericWithLogicalAnd() throws Exception {
+        // Matches the envoy-als pattern that triggered the bug
+        final String dsl = "filter {\n"
+            + "  json {}\n"
+            + "  if (parsed?.code as Integer != 401"
+            + " && parsed?.code as Integer != 403) {\n"
+            + "    abort {}\n"
+            + "  }\n"
+            + "  sink {}\n"
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
+        assertTrue(source.contains("!= 401L"),
+            "Expected numeric != 401L but got: " + source);
+        assertTrue(source.contains("!= 403L"),
+            "Expected numeric != 403L but got: " + source);
+    }
+
+    @Test
+    void compileEqNullUsesObjectsEquals() throws Exception {
+        final String dsl = "filter {\n"
+            + "  json {}\n"
+            + "  if (parsed?.status == null) {\n"
+            + "    sink {}\n"
+            + "  }\n"
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
+        assertTrue(source.contains("java.util.Objects.equals("),
+            "Expected Objects.equals for null comparison but got: " + source);
+    }
+
+    @Test
+    void compileNeqNullUsesObjectsEquals() throws Exception {
+        final String dsl = "filter {\n"
+            + "  json {}\n"
+            + "  if (parsed?.status != null) {\n"
+            + "    sink {}\n"
+            + "  }\n"
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
+        assertTrue(source.contains("!java.util.Objects.equals("),
+            "Expected !Objects.equals for null != but got: " + source);
+    }
+
     // ==================== Else-if chain ====================
 
     @Test
@@ -159,9 +266,8 @@ class LALClassGeneratorConditionTest extends LALClassGeneratorTestBase {
     }
 
     @Test
-    void generateSourceElseIfEmitsNestedBranches() {
-        final String source = generator.generateSource(
-            "filter {\n"
+    void compileAndVerifyElseIfEmitsNestedBranches() throws Exception {
+        final String dsl = "filter {\n"
             + "  json {}\n"
             + "  if (parsed.a) {\n"
             + "    sink {}\n"
@@ -170,7 +276,9 @@ class LALClassGeneratorConditionTest extends LALClassGeneratorTestBase {
             + "  } else {\n"
             + "    sink {}\n"
             + "  }\n"
-            + "}");
+            + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains("else"),
             "Expected else branch but got: " + source);
         int ifCount = 0;

--- a/oap-server/analyzer/log-analyzer/src/test/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGeneratorDefTest.java
+++ b/oap-server/analyzer/log-analyzer/src/test/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGeneratorDefTest.java
@@ -33,16 +33,17 @@ class LALClassGeneratorDefTest extends LALClassGeneratorTestBase {
     // ==================== Source generation ====================
 
     @Test
-    void generateSourceDefWithToJson() {
-        final String source = generator.generateSource(
-            "filter {\n"
+    void compileAndVerifyDefWithToJson() throws Exception {
+        final String dsl = "filter {\n"
                 + "  json {}\n"
                 + "  extractor {\n"
                 + "    def config = toJson(parsed.metadata)\n"
                 + "    tag 'env': config?.get(\"env\")?.getAsString()\n"
                 + "  }\n"
                 + "  sink {}\n"
-                + "}");
+                + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains("com.google.gson.JsonObject _def_config"),
             "Expected JsonObject declaration but got:\n" + source);
         assertTrue(source.contains("h.toJsonObject("),
@@ -54,16 +55,17 @@ class LALClassGeneratorDefTest extends LALClassGeneratorTestBase {
     }
 
     @Test
-    void generateSourceDefWithToJsonArray() {
-        final String source = generator.generateSource(
-            "filter {\n"
+    void compileAndVerifyDefWithToJsonArray() throws Exception {
+        final String dsl = "filter {\n"
                 + "  json {}\n"
                 + "  extractor {\n"
                 + "    def items = toJsonArray(parsed.tags)\n"
                 + "    tag 'first': items?.get(0)?.getAsString()\n"
                 + "  }\n"
                 + "  sink {}\n"
-                + "}");
+                + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains("com.google.gson.JsonArray _def_items"),
             "Expected JsonArray declaration but got:\n" + source);
         assertTrue(source.contains("h.toJsonArray("),
@@ -73,9 +75,8 @@ class LALClassGeneratorDefTest extends LALClassGeneratorTestBase {
     }
 
     @Test
-    void generateSourceDefWithCondition() {
-        final String source = generator.generateSource(
-            "filter {\n"
+    void compileAndVerifyDefWithCondition() throws Exception {
+        final String dsl = "filter {\n"
                 + "  json {}\n"
                 + "  extractor {\n"
                 + "    def config = toJson(parsed.metadata)\n"
@@ -84,7 +85,9 @@ class LALClassGeneratorDefTest extends LALClassGeneratorTestBase {
                 + "    }\n"
                 + "  }\n"
                 + "  sink {}\n"
-                + "}");
+                + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains("_def_config == null") || source.contains("_def_config != null"),
             "Expected null check on _def_config but got:\n" + source);
         assertTrue(source.contains(".has(\"env\")"),
@@ -161,16 +164,17 @@ class LALClassGeneratorDefTest extends LALClassGeneratorTestBase {
     // ==================== Type cast on def ====================
 
     @Test
-    void generateSourceDefWithStringCast() {
-        final String source = generator.generateSource(
-            "filter {\n"
+    void compileAndVerifyDefWithStringCast() throws Exception {
+        final String dsl = "filter {\n"
                 + "  json {}\n"
                 + "  extractor {\n"
                 + "    def svc = parsed.service as String\n"
                 + "    tag 'svc': svc\n"
                 + "  }\n"
                 + "  sink {}\n"
-                + "}");
+                + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains("java.lang.String _def_svc"),
             "Expected String declaration but got:\n" + source);
         assertTrue(source.contains("(java.lang.String)"),
@@ -198,18 +202,19 @@ class LALClassGeneratorDefTest extends LALClassGeneratorTestBase {
     }
 
     @Test
-    void generateSourceDefWithQualifiedNameCast() {
+    void compileAndVerifyDefWithQualifiedNameCast() throws Exception {
         generator.setInputType(
             io.envoyproxy.envoy.data.accesslog.v3.HTTPAccessLogEntry.class);
-        final String source = generator.generateSource(
-            "filter {\n"
+        final String dsl = "filter {\n"
                 + "  extractor {\n"
                 + "    def common = parsed?.commonProperties"
                 + " as io.envoyproxy.envoy.data.accesslog.v3.AccessLogCommon\n"
                 + "    tag 'cluster': common?.upstreamCluster\n"
                 + "  }\n"
                 + "  sink {}\n"
-                + "}");
+                + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains(
                 "io.envoyproxy.envoy.data.accesslog.v3.AccessLogCommon _def_common"),
             "Expected AccessLogCommon declaration but got:\n" + source);
@@ -221,9 +226,8 @@ class LALClassGeneratorDefTest extends LALClassGeneratorTestBase {
     // ==================== Def variable as method argument ====================
 
     @Test
-    void generateSourceDefVarAsMethodArg() {
-        final String source = generator.generateSource(
-            "filter {\n"
+    void compileAndVerifyDefVarAsMethodArg() throws Exception {
+        final String dsl = "filter {\n"
                 + "  json {}\n"
                 + "  extractor {\n"
                 + "    def key = parsed.fieldName as String\n"
@@ -231,25 +235,25 @@ class LALClassGeneratorDefTest extends LALClassGeneratorTestBase {
                 + "    tag 'val': config?.get(key)?.getAsString()\n"
                 + "  }\n"
                 + "  sink {}\n"
-                + "}");
-        // _def_key = key (String), _def_config = config (JsonObject)
-        // config?.get(key) should generate _def_config.get(_def_key), not _def_config.get(null)
+                + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains(".get(_def_key)"),
             "Expected .get(_def_key) for def var arg but got:\n" + source);
     }
 
     @Test
-    void generateSourceBoolLiteralAsMethodArg() {
-        final String source = generator.generateSource(
-            "filter {\n"
+    void compileAndVerifyBoolLiteralAsMethodArg() throws Exception {
+        final String dsl = "filter {\n"
                 + "  json {}\n"
                 + "  extractor {\n"
                 + "    def config = toJson(parsed.metadata)\n"
                 + "    tag 'val': config?.get(\"key\")?.getAsBoolean()\n"
                 + "  }\n"
                 + "  sink {}\n"
-                + "}");
-        // getAsBoolean() has no args, just verify it compiles
+                + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains(".getAsBoolean()"),
             "Expected .getAsBoolean() call but got:\n" + source);
     }

--- a/oap-server/analyzer/log-analyzer/src/test/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGeneratorExtractorTest.java
+++ b/oap-server/analyzer/log-analyzer/src/test/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGeneratorExtractorTest.java
@@ -187,17 +187,18 @@ class LALClassGeneratorExtractorTest extends LALClassGeneratorTestBase {
     // ==================== Output field assignment ====================
 
     @Test
-    void compileOutputFieldAssignment() {
+    void compileOutputFieldAssignment() throws Exception {
         generator.setOutputType(TestOutputType.class);
-        final String source = generator.generateSource(
-            "filter {\n"
+        final String dsl = "filter {\n"
                 + "  json {}\n"
                 + "  extractor {\n"
                 + "    statement parsed.statement as String\n"
                 + "    latency parsed.latency as Long\n"
                 + "  }\n"
                 + "  sink {}\n"
-                + "}");
+                + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains(".setStatement("),
             "Expected direct setStatement() call but got: " + source);
         assertTrue(source.contains(".setLatency("),
@@ -213,16 +214,17 @@ class LALClassGeneratorExtractorTest extends LALClassGeneratorTestBase {
     }
 
     @Test
-    void compileOutputFieldWithOutputTypeValidation() {
+    void compileOutputFieldWithOutputTypeValidation() throws Exception {
         generator.setOutputType(TestOutputType.class);
-        final String source = generator.generateSource(
-            "filter {\n"
+        final String dsl = "filter {\n"
                 + "  json {}\n"
                 + "  extractor {\n"
                 + "    statement parsed.stmt as String\n"
                 + "  }\n"
                 + "  sink {}\n"
-                + "}");
+                + "}";
+        compileAndAssert(dsl);
+        final String source = generator.generateSource(dsl);
         assertTrue(source.contains(".setStatement("),
             "Expected direct setStatement() call but got: " + source);
     }


### PR DESCRIPTION
### Fix LAL `==` and `!=` with numeric literals using object equality instead of numeric comparison

- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

**Bug**: When LAL scripts use `==` or `!=` with numeric literals (e.g., `parsed?.response?.responseCode?.value as Integer != 403`), the compiler generated `java.util.Objects.equals(value, Long.valueOf(403L))`. This fails silently when the left side is a different boxed type (e.g., `Integer`) because `Integer.equals(Long)` is always `false` in Java — even when the numeric values are the same.

Meanwhile, `>`, `<`, `>=`, `<=` correctly used `generateNumericComparison()` with primitive comparison (`h.toLong(value) > 403L`).

**Fix**: `EQ`/`NEQ` with a `NumberConditionValue` right-hand side now route through `generateNumericComparison()` (producing `== 403L` / `!= 403L`). String, boolean, null, and value-access comparisons still use `Objects.equals()`.

Also ensures all LAL codegen unit tests both compile (bytecode validation) and assert generated source — previously some tests only asserted source without compiling.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).