### PR TITLE
Remove GroupBy.field_name from BanyanDB MeasureQuery request building

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -6,6 +6,7 @@
 * Add Zipkin Virtual GenAI e2e test. Use `zipkin_json` exporter to avoid protobuf dependency conflict
   between `opentelemetry-exporter-zipkin-proto-http` (protobuf~=3.12) and `opentelemetry-proto` (protobuf>=5.0).
 * Fix missing `taskId` filter and incorrect `IN` clause parameter binding in `JDBCJFRDataQueryDAO` and `JDBCPprofDataQueryDAO`.
+* Remove deprecated `GroupBy.field_name` from BanyanDB `MeasureQuery` request building (Phase 1 of staged removal across repos).
 
 #### UI
 

--- a/oap-server/server-library/library-banyandb-client/src/main/java/org/apache/skywalking/library/banyandb/v1/client/MeasureQuery.java
+++ b/oap-server/server-library/library-banyandb-client/src/main/java/org/apache/skywalking/library/banyandb/v1/client/MeasureQuery.java
@@ -182,7 +182,6 @@ public class MeasureQuery extends AbstractQuery<BanyandbMeasure.QueryRequest> {
                     throw new IllegalArgumentException("field name cannot be null or empty if aggregation is specified");
                 }
             } else {
-                groupByBuilder.setFieldName(this.aggregation.fieldName);
                 BanyandbMeasure.QueryRequest.Aggregation aggr = BanyandbMeasure.QueryRequest.Aggregation.newBuilder()
                         .setFunction(this.aggregation.aggregationType.function)
                         .setFieldName(this.aggregation.fieldName)


### PR DESCRIPTION
## What this PR does

Phase 1 of the staged removal described in #13779.

`QueryRequest.GroupBy.field_name` is not used by BanyanDB's query execution path. BanyanDB groups by `tag_projection`, not by `field_name`. Sending this field is misleading and should be removed.

This PR removes the single `groupByBuilder.setFieldName(this.aggregation.fieldName)` call in `MeasureQuery.build()`, so the `GroupBy` message now only carries `tag_projection`.

The `Aggregation.field_name` and `Top.field_name` fields are unrelated (they specify which field to aggregate on / sort by) and are intentionally left unchanged.

## Subsequent steps

- Phase 2: Remove `GroupBy.field_name` from the client proto repo.
- Phase 3: Remove the field from BanyanDB server.

## Related

Closes #13779 (Phase 1)