### PR TITLE
Add unit tests for 8 more JDBC query DAOs (inline SQL)

### DIFF
--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCAsyncProfilerTaskLogQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCAsyncProfilerTaskLogQueryDAOTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
+
+import org.apache.skywalking.oap.server.core.profiling.asyncprofiler.storage.AsyncProfilerTaskLogRecord;
+import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JDBCAsyncProfilerTaskLogQueryDAOTest {
+
+    @Mock
+    private JDBCClient jdbcClient;
+    @Mock
+    private TableHelper tableHelper;
+
+    private JDBCAsyncProfilerTaskLogQueryDAO dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new JDBCAsyncProfilerTaskLogQueryDAO(jdbcClient, tableHelper);
+    }
+
+    @Test
+    void getTaskLogList_shouldContainTableColumnAndTaskIdFilter() throws Exception {
+        when(tableHelper.getTablesWithinTTL(AsyncProfilerTaskLogRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("async_profiler_task_log"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTaskLogList("task-123");
+
+        assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(capturedSql.get()).contains(AsyncProfilerTaskLogRecord.TASK_ID + " = ?");
+    }
+
+    @Test
+    void getTaskLogList_shouldContainOrderByOperationTimeDesc() throws Exception {
+        when(tableHelper.getTablesWithinTTL(AsyncProfilerTaskLogRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("async_profiler_task_log"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTaskLogList("task-1");
+
+        assertThat(capturedSql.get()).contains("order by " + AsyncProfilerTaskLogRecord.OPERATION_TIME + " desc");
+    }
+}

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCAsyncProfilerTaskQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCAsyncProfilerTaskQueryDAOTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
+
+import org.apache.skywalking.oap.server.core.profiling.asyncprofiler.storage.AsyncProfilerTaskRecord;
+import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JDBCAsyncProfilerTaskQueryDAOTest {
+
+    @Mock
+    private JDBCClient jdbcClient;
+    @Mock
+    private TableHelper tableHelper;
+
+    private JDBCAsyncProfilerTaskQueryDAO dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new JDBCAsyncProfilerTaskQueryDAO(jdbcClient, tableHelper);
+    }
+
+    @Test
+    void getTaskList_withServiceId_shouldIncludeServiceIdFilter() throws Exception {
+        when(tableHelper.getTablesWithinTTL(AsyncProfilerTaskRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("async_profiler_task"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTaskList("service-1", null, null, null);
+
+        assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(capturedSql.get()).contains(AsyncProfilerTaskRecord.SERVICE_ID + "=?");
+    }
+
+    @Test
+    void getTaskList_withoutServiceId_shouldNotIncludeServiceIdFilter() throws Exception {
+        when(tableHelper.getTablesWithinTTL(AsyncProfilerTaskRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("async_profiler_task"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTaskList(null, null, null, null);
+
+        assertThat(capturedSql.get()).doesNotContain(AsyncProfilerTaskRecord.SERVICE_ID);
+    }
+
+    @Test
+    void getTaskList_shouldAlwaysOrderByCreateTimeDesc() throws Exception {
+        when(tableHelper.getTablesWithinTTL(AsyncProfilerTaskRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("async_profiler_task"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTaskList(null, null, null, null);
+
+        assertThat(capturedSql.get()).contains("ORDER BY " + AsyncProfilerTaskRecord.CREATE_TIME + " DESC");
+    }
+
+    @Test
+    void getTaskList_withLimit_shouldIncludeLimitClause() throws Exception {
+        when(tableHelper.getTablesWithinTTL(AsyncProfilerTaskRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("async_profiler_task"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTaskList(null, null, null, 10);
+
+        assertThat(capturedSql.get()).contains("LIMIT 10");
+    }
+
+    @Test
+    void getById_shouldContainTableColumnAndTaskIdWithLimit() throws Exception {
+        when(tableHelper.getTablesWithinTTL(AsyncProfilerTaskRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("async_profiler_task"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return null;
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getById("task-id-1");
+
+        assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(capturedSql.get()).contains(AsyncProfilerTaskRecord.TASK_ID + "=?");
+        assertThat(capturedSql.get()).contains("LIMIT 1");
+    }
+}

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCContinuousProfilingPolicyDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCContinuousProfilingPolicyDAOTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
+
+import org.apache.skywalking.oap.server.core.profiling.continuous.storage.ContinuousProfilingPolicy;
+import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JDBCContinuousProfilingPolicyDAOTest {
+
+    @Mock
+    private JDBCClient jdbcClient;
+    @Mock
+    private TableHelper tableHelper;
+
+    private JDBCContinuousProfilingPolicyDAO dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new JDBCContinuousProfilingPolicyDAO(jdbcClient, tableHelper);
+    }
+
+    @Test
+    void queryPolicies_shouldContainTableColumnAndServiceIdInClause() throws Exception {
+        when(tableHelper.getTablesWithinTTL(ContinuousProfilingPolicy.INDEX_NAME))
+            .thenReturn(Collections.singletonList("continuous_profiling_policy"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryPolicies(Arrays.asList("svc-1", "svc-2"));
+
+        assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(capturedSql.get()).contains(ContinuousProfilingPolicy.SERVICE_ID + " in (?,?)");
+    }
+
+    @Test
+    void queryPolicies_withSingleServiceId_shouldContainSinglePlaceholder() throws Exception {
+        when(tableHelper.getTablesWithinTTL(ContinuousProfilingPolicy.INDEX_NAME))
+            .thenReturn(Collections.singletonList("continuous_profiling_policy"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryPolicies(Collections.singletonList("svc-1"));
+
+        assertThat(capturedSql.get()).contains(ContinuousProfilingPolicy.SERVICE_ID + " in (?)");
+    }
+}

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCMetricsQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCMetricsQueryDAOTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
+
+import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
+import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JDBCMetricsQueryDAOTest {
+
+    @Mock
+    private JDBCClient jdbcClient;
+    @Mock
+    private TableHelper tableHelper;
+
+    private JDBCMetricsQueryDAO dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new JDBCMetricsQueryDAO(jdbcClient, tableHelper);
+    }
+
+    @Test
+    void buildMetricsValueSql_shouldContainSelectWithAggAndEntityId() {
+        final StringBuilder sql = dao.buildMetricsValueSql("avg", "value", "metrics_table");
+
+        assertThat(sql.toString()).contains("select " + Metrics.ENTITY_ID + " id");
+        assertThat(sql.toString()).contains("avg(value) result");
+        assertThat(sql.toString()).contains("from metrics_table");
+        assertThat(sql.toString()).contains("where");
+    }
+
+    @Test
+    void buildMetricsValueSql_withDifferentOp_shouldReflectInSQL() {
+        final StringBuilder sql = dao.buildMetricsValueSql("sum", "latency", "service_metrics");
+
+        assertThat(sql.toString()).contains("sum(latency) result");
+        assertThat(sql.toString()).contains("from service_metrics");
+    }
+
+    @Test
+    void readLabeledMetricsValuesWithoutEntity_shouldContainTableColumnAndTimeBucket() throws Exception {
+        when(tableHelper.getTablesForRead(anyString(), any(Long.class), any(Long.class)))
+            .thenReturn(Collections.singletonList("metrics_table"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return null;
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        try {
+            dao.readLabeledMetricsValuesWithoutEntity(
+                "service_resp_time", "value", Collections.emptyList(),
+                buildDuration());
+        } catch (Exception ignored) {
+            // ValueColumnMetadata not initialized, but SQL is already captured
+        }
+
+        assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(capturedSql.get()).contains(Metrics.TIME_BUCKET + " >= ?");
+        assertThat(capturedSql.get()).contains(Metrics.TIME_BUCKET + " <= ?");
+        assertThat(capturedSql.get()).contains("limit");
+    }
+
+    private org.apache.skywalking.oap.server.core.query.input.Duration buildDuration() {
+        final var duration = new org.apache.skywalking.oap.server.core.query.input.Duration();
+        duration.setStart("2023-01-01 0000");
+        duration.setEnd("2023-01-02 0000");
+        duration.setStep(org.apache.skywalking.oap.server.core.query.enumeration.Step.MINUTE);
+        return duration;
+    }
+}

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCPprofTaskLogQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCPprofTaskLogQueryDAOTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
+
+import org.apache.skywalking.oap.server.core.profiling.pprof.storage.PprofTaskLogRecord;
+import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JDBCPprofTaskLogQueryDAOTest {
+
+    @Mock
+    private JDBCClient jdbcClient;
+    @Mock
+    private TableHelper tableHelper;
+
+    private JDBCPprofTaskLogQueryDAO dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new JDBCPprofTaskLogQueryDAO(jdbcClient, tableHelper);
+    }
+
+    @Test
+    void getTaskLogList_shouldContainTableColumnAndTaskIdFilter() throws Exception {
+        when(tableHelper.getTablesWithinTTL(PprofTaskLogRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("pprof_task_log"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTaskLogList("task-123");
+
+        assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(capturedSql.get()).contains(PprofTaskLogRecord.TASK_ID + " = ?");
+    }
+
+    @Test
+    void getTaskLogList_shouldContainOrderByOperationTimeDesc() throws Exception {
+        when(tableHelper.getTablesWithinTTL(PprofTaskLogRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("pprof_task_log"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTaskLogList("task-1");
+
+        assertThat(capturedSql.get()).contains("order by " + PprofTaskLogRecord.OPERATION_TIME + " desc");
+    }
+
+    @Test
+    void getTaskLogList_withBlankTaskId_shouldReturnEmptyList() throws Exception {
+        assertThat(dao.getTaskLogList("")).isEmpty();
+        assertThat(dao.getTaskLogList(null)).isEmpty();
+    }
+}

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCProfileTaskLogQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCProfileTaskLogQueryDAOTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
+
+import org.apache.skywalking.oap.server.core.profiling.trace.ProfileTaskLogRecord;
+import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.SQLAndParameters;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JDBCProfileTaskLogQueryDAOTest {
+
+    private static final String TABLE = "profile_task_log";
+
+    @Mock
+    private JDBCClient jdbcClient;
+    @Mock
+    private TableHelper tableHelper;
+
+    private JDBCProfileTaskLogQueryDAO dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new JDBCProfileTaskLogQueryDAO(jdbcClient, tableHelper);
+    }
+
+    @Test
+    void buildSQL_shouldContainTableColumnCondition() {
+        final SQLAndParameters result = dao.buildSQL(TABLE);
+
+        assertThat(result.sql()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(result.parameters()).contains(ProfileTaskLogRecord.INDEX_NAME);
+    }
+
+    @Test
+    void buildSQL_shouldContainOrderByOperationTimeDesc() {
+        final SQLAndParameters result = dao.buildSQL(TABLE);
+
+        assertThat(result.sql()).contains("ORDER BY " + ProfileTaskLogRecord.OPERATION_TIME + " DESC");
+    }
+}

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCServiceLabelQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCServiceLabelQueryDAOTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
+
+import org.apache.skywalking.oap.server.core.analysis.manual.process.ServiceLabelRecord;
+import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JDBCServiceLabelQueryDAOTest {
+
+    @Mock
+    private JDBCClient jdbcClient;
+    @Mock
+    private TableHelper tableHelper;
+
+    private JDBCServiceLabelQueryDAO dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new JDBCServiceLabelQueryDAO(jdbcClient, tableHelper);
+    }
+
+    @Test
+    void queryAllLabels_shouldContainTableColumnAndServiceId() throws Exception {
+        when(tableHelper.getTablesWithinTTL(ServiceLabelRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("service_label"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryAllLabels("svc-1");
+
+        assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(capturedSql.get()).contains(ServiceLabelRecord.SERVICE_ID + " = ?");
+    }
+
+    @Test
+    void queryAllLabels_shouldSelectLabelColumn() throws Exception {
+        when(tableHelper.getTablesWithinTTL(ServiceLabelRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("service_label"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryAllLabels("svc-1");
+
+        assertThat(capturedSql.get()).contains("select " + ServiceLabelRecord.LABEL);
+    }
+}

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCSpanAttachedEventQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCSpanAttachedEventQueryDAOTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
+
+import org.apache.skywalking.oap.server.core.analysis.manual.spanattach.SWSpanAttachedEventRecord;
+import org.apache.skywalking.oap.server.core.analysis.manual.spanattach.SpanAttachedEventRecord;
+import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JDBCSpanAttachedEventQueryDAOTest {
+
+    @Mock
+    private JDBCClient jdbcClient;
+    @Mock
+    private TableHelper tableHelper;
+
+    private JDBCSpanAttachedEventQueryDAO dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new JDBCSpanAttachedEventQueryDAO(jdbcClient, tableHelper);
+    }
+
+    @Test
+    void queryZKSpanAttachedEvents_shouldContainTableColumnAndTraceIdInClause() throws Exception {
+        when(tableHelper.getTablesWithinTTL(SpanAttachedEventRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("span_attached_event"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryZKSpanAttachedEvents(Arrays.asList("trace-1", "trace-2"), null);
+
+        assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(capturedSql.get()).contains(SpanAttachedEventRecord.RELATED_TRACE_ID + " in (?,?)");
+    }
+
+    @Test
+    void queryZKSpanAttachedEvents_shouldContainOrderByStartTime() throws Exception {
+        when(tableHelper.getTablesWithinTTL(SpanAttachedEventRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("span_attached_event"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryZKSpanAttachedEvents(Arrays.asList("trace-1"), null);
+
+        assertThat(capturedSql.get()).contains("order by " + SpanAttachedEventRecord.START_TIME_SECOND);
+        assertThat(capturedSql.get()).contains(SpanAttachedEventRecord.START_TIME_NANOS);
+    }
+
+    @Test
+    void querySWSpanAttachedEvents_shouldContainTableColumnAndTraceIdInClause() throws Exception {
+        when(tableHelper.getTablesWithinTTL(SWSpanAttachedEventRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("sw_span_attached_event"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.querySWSpanAttachedEvents(Arrays.asList("trace-a", "trace-b", "trace-c"), null);
+
+        assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
+        assertThat(capturedSql.get()).contains(SWSpanAttachedEventRecord.RELATED_TRACE_ID + " in (?,?,?)");
+    }
+}


### PR DESCRIPTION
## What's this PR about?

Adds unit tests for 8 JDBC query DAOs that use inline SQL or private \`buildSQL\` methods, requiring Mockito SQL capture.

With the previous rounds (#13800, #13802, #13808), DAO test coverage goes from 18/39 (46%) to 26/39 (67%).

## Tests

| DAO | Approach | Tests |
|-----|----------|-------|
| JDBCMetricsQueryDAO | protected \`buildMetricsValueSql()\` + Mockito capture | select with aggregation op, TABLE_COLUMN + TIME_BUCKET range + limit |
| JDBCServiceLabelQueryDAO | Mockito capture | TABLE_COLUMN + SERVICE_ID filter, LABEL column in select |
| JDBCSpanAttachedEventQueryDAO | Mockito capture | ZK/SW methods: trace ID IN clause, order by start_time asc |
| JDBCProfileTaskLogQueryDAO | protected \`buildSQL()\` | TABLE_COLUMN + INDEX_NAME param, ORDER BY OPERATION_TIME DESC |
| JDBCPprofTaskLogQueryDAO | Mockito capture | TABLE_COLUMN + TASK_ID filter, ORDER BY OPERATION_TIME desc, blank taskId returns empty |
| JDBCContinuousProfilingPolicyDAO | Mockito capture | TABLE_COLUMN + SERVICE_ID IN clause, single vs multiple placeholders |
| JDBCAsyncProfilerTaskLogQueryDAO | Mockito capture | TABLE_COLUMN + TASK_ID filter, ORDER BY OPERATION_TIME desc |
| JDBCAsyncProfilerTaskQueryDAO | Mockito capture | conditional SERVICE_ID/LIMIT, ORDER BY CREATE_TIME DESC, getById with TASK_ID + LIMIT 1 |