### PR TITLE
Fix Virtual GenAI e2e test failure by pinning Python dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,10 +419,10 @@
                             <phase>verify</phase>
                             <goals>
                                 <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.cyclonedx</groupId>
                     <artifactId>cyclonedx-maven-plugin</artifactId>

--- a/test/e2e-v2/script/dockerfile/Dockerfile-openai.python
+++ b/test/e2e-v2/script/dockerfile/Dockerfile-openai.python
@@ -23,15 +23,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir \
-    openai \
-    opentelemetry-api \
-    opentelemetry-sdk \
-    opentelemetry-instrumentation-openai \
-    opentelemetry-exporter-otlp-proto-grpc \
-    opentelemetry-exporter-zipkin-json \
-    opentelemetry-distro
-
-RUN opentelemetry-bootstrap --action=install
+    openai==2.31.0 \
+    opentelemetry-api==1.41.0 \
+    opentelemetry-sdk==1.41.0 \
+    opentelemetry-instrumentation==0.62b0 \
+    opentelemetry-instrumentation-openai==0.58.0 \
+    opentelemetry-exporter-otlp-proto-grpc==1.41.0 \
+    opentelemetry-exporter-zipkin-json==1.41.0 \
+    opentelemetry-distro==0.62b0
 
 COPY python/openai-call.py /openai-call.py
 


### PR DESCRIPTION
### Fix Virtual GenAI e2e test broken on master since April 9

- [x] Explain briefly why the bug exists and how to fix it.

**Root cause:** On April 9, `opentelemetry-sdk` updated to 1.41.0. The `opentelemetry-bootstrap --action=install` step in the Dockerfile auto-installs `opentelemetry-instrumentation-openai-v2==2.3b0` (the official OTel package), which is **incompatible** with OTel SDK 1.41.0 — it crashes with `TypeError: wrap_function_wrapper() got an unexpected keyword argument 'module'`. This silently kills all GenAI span attribute generation at runtime, so no `VIRTUAL_GENAI` service is ever created.

**Fix:**
1. **Remove `opentelemetry-bootstrap --action=install`** — it auto-installs the broken official package that conflicts with the working Traceloop instrumentation.
2. **Pin all Python dependency versions** — prevents future breakage from upstream releases.

**Verified locally** that Traceloop `opentelemetry-instrumentation-openai==0.58.0` with OTel SDK 1.41.0 produces all required span attributes:
- `gen_ai.response.model` ✅
- `gen_ai.provider.name` ✅
- `gen_ai.usage.input_tokens` ✅
- `gen_ai.usage.output_tokens` ✅

Also includes a minor indentation fix in `pom.xml` (gpg-plugin closing tags).

- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).