### PR TITLE
Update infra-e2e to b2a6639 and fix duplicate expected entries

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@e26033e1faaf865899c486ffe17dabdf17b90aae
+        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@e26033e1faaf865899c486ffe17dabdf17b90aae
+        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@e26033e1faaf865899c486ffe17dabdf17b90aae
+        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@e26033e1faaf865899c486ffe17dabdf17b90aae
+        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@e26033e1faaf865899c486ffe17dabdf17b90aae
+        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/test/e2e-v2/cases/alarm/expected/silence-after-webhook.yml
+++ b/test/e2e-v2/cases/alarm/expected/silence-after-webhook.yml
@@ -34,34 +34,6 @@ messages:
     name: e2e-service-provider
     id0: ZTJlLXNlcnZpY2UtcHJvdmlkZXI=.1
     id1: ""
-    ruleName: service_percentile_rule
-    alarmMessage: Percentile response time of service e2e-service-provider alarm in 3 minutes of last 10 minutes, due to more than one condition of p50 > 100, p75 > 100, p90 > 100, p95 > 100, p99 > 100.
-    startTime: {{ gt .startTime 0 }}
-    recoveryTime: {{ le .recoveryTime 0 }}
-    tags:
-      - key: level
-        value: WARNING
-      - key: receivers
-        value: lisi
-  - scopeId: 1
-    scope: SERVICE
-    name: e2e-service-provider
-    id0: ZTJlLXNlcnZpY2UtcHJvdmlkZXI=.1
-    id1: ""
-    ruleName: comp_rule
-    alarmMessage: Service e2e-service-provider response time is more than 100ms and sla is more than 1%.
-    startTime: {{ gt .startTime 0 }}
-    recoveryTime: {{ le .recoveryTime 0 }}
-    tags:
-      - key: level
-        value: CRITICAL
-      - key: receivers
-        value: zhangsan
-  - scopeId: 1
-    scope: SERVICE
-    name: e2e-service-provider
-    id0: ZTJlLXNlcnZpY2UtcHJvdmlkZXI=.1
-    id1: ""
     ruleName: service_resp_time_rule
     alarmMessage: Response time of service e2e-service-provider is increase/decrease in 1 minutes of last 10 minutes.
     startTime: {{ gt .startTime 0 }}
@@ -90,71 +62,15 @@ messages:
     name: e2e-service-provider
     id0: ZTJlLXNlcnZpY2UtcHJvdmlkZXI=.1
     id1: ""
-    ruleName: comp_rule
-    alarmMessage: Service e2e-service-provider response time is more than 100ms and sla is more than 1%.
+    ruleName: service_percentile_rule
+    alarmMessage: Percentile response time of service e2e-service-provider alarm in 3 minutes of last 10 minutes, due to more than one condition of p50 > 100, p75 > 100, p90 > 100, p95 > 100, p99 > 100.
     startTime: {{ gt .startTime 0 }}
     recoveryTime: {{ le .recoveryTime 0 }}
     tags:
       - key: level
-        value: CRITICAL
+        value: WARNING
       - key: receivers
-        value: zhangsan
-  - scopeId: 1
-    scope: SERVICE
-    name: e2e-service-provider
-    id0: ZTJlLXNlcnZpY2UtcHJvdmlkZXI=.1
-    id1: ""
-    ruleName: comp_rule
-    alarmMessage: Service e2e-service-provider response time is more than 100ms and sla is more than 1%.
-    startTime: {{ gt .startTime 0 }}
-    recoveryTime: {{ le .recoveryTime 0 }}
-    tags:
-      - key: level
-        value: CRITICAL
-      - key: receivers
-        value: zhangsan
-  - scopeId: 1
-    scope: SERVICE
-    name: e2e-service-provider
-    id0: ZTJlLXNlcnZpY2UtcHJvdmlkZXI=.1
-    id1: ""
-    ruleName: comp_rule
-    alarmMessage: Service e2e-service-provider response time is more than 100ms and sla is more than 1%.
-    startTime: {{ gt .startTime 0 }}
-    recoveryTime: {{ le .recoveryTime 0 }}
-    tags:
-      - key: level
-        value: CRITICAL
-      - key: receivers
-        value: zhangsan
-  - scopeId: 1
-    scope: SERVICE
-    name: e2e-service-provider
-    id0: ZTJlLXNlcnZpY2UtcHJvdmlkZXI=.1
-    id1: ""
-    ruleName: comp_rule
-    alarmMessage: Service e2e-service-provider response time is more than 100ms and sla is more than 1%.
-    startTime: {{ gt .startTime 0 }}
-    recoveryTime: {{ le .recoveryTime 0 }}
-    tags:
-      - key: level
-        value: CRITICAL
-      - key: receivers
-        value: zhangsan
-  - scopeId: 1
-    scope: SERVICE
-    name: e2e-service-provider
-    id0: ZTJlLXNlcnZpY2UtcHJvdmlkZXI=.1
-    id1: ""
-    ruleName: comp_rule
-    alarmMessage: Service e2e-service-provider response time is more than 100ms and sla is more than 1%.
-    startTime: {{ gt .startTime 0 }}
-    recoveryTime: {{ le .recoveryTime 0 }}
-    tags:
-      - key: level
-        value: CRITICAL
-      - key: receivers
-        value: zhangsan
+        value: lisi
   - scopeId: 1
     scope: SERVICE
     name: e2e-service-provider

--- a/test/e2e-v2/cases/rover/process/istio/expected/service.yml
+++ b/test/e2e-v2/cases/rover/process/istio/expected/service.yml
@@ -51,16 +51,6 @@
     - MESH
     {{- end }}
   normal: true
-- id: {{ b64enc "ratings.default" }}.1
-  name: ratings.default
-  group: ""
-  shortname: ratings.default
-  layers:
-    {{- contains .layers }}
-    - MESH_DP
-    - MESH
-    {{- end }}
-  normal: true
 - id: {{ b64enc "istio-egressgateway.istio-system" }}.1
   name: istio-egressgateway.istio-system
   group: ""


### PR DESCRIPTION
### Update infra-e2e and fix duplicate expected entries

Bump `skywalking-infra-e2e` from `e26033e` to `b2a6639` (apache/skywalking-infra-e2e#143), which enforces distinct matching in `contains` — each actual item can only satisfy one expected entry.

Remove duplicate expected entries that only passed due to the old buggy behavior where a single actual item could satisfy multiple expected entries:
- `alarm/expected/silence-after-webhook.yml`: reduce from 11 to 5 entries (removed duplicate `service_percentile_rule` and `comp_rule` entries)
- `rover/process/istio/expected/service.yml`: remove duplicate `ratings.default` entry