### PR TITLE
Fix missing isMergedTable check in ProfileTaskQueryEsDAO.getById()

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -10,7 +10,11 @@
 * Push `taskId` filter down to the storage layer in `IAsyncProfilerTaskLogQueryDAO`, removing in-memory filtering from `AsyncProfilerQueryService`.
 * Fix missing parentheses around OR conditions in `JDBCZipkinQueryDAO.getTraces()`, which caused the table filter to be bypassed for all but the first trace ID. Replaced with a proper `IN` clause.
 * Fix missing `and` keyword in `JDBCEBPFProfilingTaskDAO.getTaskRecord()` SQL query, which caused a syntax error on every invocation.
-* Fix duplicate `TABLE_COLUMN` condition in `JDBCMetadataQueryDAO.findEndpoint()`, which was binding the same parameter twice due to a copy-paste error.
+* Fix storage layer bugs in profiling DAOs and add unit test coverage for JDBC query DAOs.
+  Bug fixes: duplicate `TABLE_COLUMN` condition in `JDBCMetadataQueryDAO.findEndpoint()`,
+  wrong merged table check in `JFRDataQueryEsDAO` (used incorrect INDEX_NAME due to copy-paste),
+  and missing `isMergedTable` check in `ProfileTaskQueryEsDAO.getById()`.
+  Test additions: add unit tests for 21 JDBC query DAOs verifying SQL/WHERE clause construction.
 * Support MCP (Model Context Protocol) observability for Envoy AI Gateway: MCP metrics (request CPM/latency, method breakdown, backend breakdown, initialization latency, capabilities), MCP access log sampling (errors only), `ai_route_type` searchable log tag, and MCP dashboard tabs.
 * Add weighted handler support to `BatchQueue` adaptive partitioning. MAL metrics use weight 0.05 at L1 (vs 1.0 for OAL), reducing partition count and memory overhead when many MAL metric types are registered.
 * Fix missing `taskId` filter in pprof task log query and its JDBC/BanyanDB/Elasticsearch implementations.

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/ProfileTaskQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/ProfileTaskQueryEsDAO.java
@@ -101,9 +101,13 @@ public class ProfileTaskQueryEsDAO extends EsDAO implements IProfileTaskQueryDAO
         final String index =
             IndexController.LogicIndicesRegister.getPhysicalTableName(ProfileTaskRecord.INDEX_NAME);
 
-        final SearchBuilder search = Search.builder()
-                                           .query(Query.bool().must(Query.term(ProfileTaskRecord.TASK_ID, id)))
-                                           .size(1);
+        final BoolQueryBuilder query = Query.bool();
+        if (IndexController.LogicIndicesRegister.isMergedTable(ProfileTaskRecord.INDEX_NAME)) {
+            query.must(Query.term(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME, ProfileTaskRecord.INDEX_NAME));
+        }
+        query.must(Query.term(ProfileTaskRecord.TASK_ID, id));
+
+        final SearchBuilder search = Search.builder().query(query).size(1);
 
         final SearchResponse response = getClient().search(index, search.build());
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/ProfileTaskQueryEsDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/ProfileTaskQueryEsDAOTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.skywalking.library.elasticsearch.requests.search.Search;
+import org.apache.skywalking.library.elasticsearch.response.search.SearchResponse;
+import org.apache.skywalking.oap.server.core.profiling.trace.ProfileTaskRecord;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.IndexController;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProfileTaskQueryEsDAOTest {
+
+    @Mock
+    private ElasticSearchClient client;
+
+    private ProfileTaskQueryEsDAO dao;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dao = new ProfileTaskQueryEsDAO(client, 100);
+        registerMergedTable(ProfileTaskRecord.INDEX_NAME, "records-all");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        removeMergedTable(ProfileTaskRecord.INDEX_NAME);
+    }
+
+    @Test
+    void getById_inMergedTable_shouldIncludeTableNameFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getById("task-id-1");
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME);
+        assertThat(json).contains(ProfileTaskRecord.INDEX_NAME);
+        assertThat(json).contains(ProfileTaskRecord.TASK_ID);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerMergedTable(String logicName, String physicalName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).put(logicName, physicalName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void removeMergedTable(String logicName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).remove(logicName);
+    }
+}


### PR DESCRIPTION
## What's this PR about?

`ProfileTaskQueryEsDAO.getById()` was missing the `isMergedTable()` check that filters by `RECORD_TABLE_NAME` when the table is merged into a shared physical index.

`getTaskList()` in the same class correctly applies this filter, and both `AsyncProfilerTaskQueryEsDAO.getById()` and `PprofTaskQueryEsDAO.getById()` do as well. This was a copy-paste omission.

Without the fix, when `logicSharding=false` (default), all record tables are merged into `records-all`. Calling `getById(id)` would search across all record types without filtering by `record_table = profile_task`, which can return incorrect results if another record type happens to have the same ID.

**Before:**
```java
final SearchBuilder search = Search.builder()
    .query(Query.bool().must(Query.term(ProfileTaskRecord.TASK_ID, id)))
    .size(1);
```

**After (matching the pattern in AsyncProfilerTaskQueryEsDAO and PprofTaskQueryEsDAO):**
```java
final BoolQueryBuilder query = Query.bool();
if (IndexController.LogicIndicesRegister.isMergedTable(ProfileTaskRecord.INDEX_NAME)) {
    query.must(Query.term(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME, ProfileTaskRecord.INDEX_NAME));
}
query.must(Query.term(ProfileTaskRecord.TASK_ID, id));
final SearchBuilder search = Search.builder().query(query).size(1);
```

A unit test is included that verifies the `RECORD_TABLE_NAME` filter is present in the search query when the table is registered as merged.