### PR TITLE
Use containsOnce for metadata e2e expected files

### DIFF
--- a/test/e2e-v2/cases/activemq/expected/endpoint.yml
+++ b/test/e2e-v2/cases/activemq/expected/endpoint.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains .}}
+{{- containsOnce .}}
 - id: {{ b64enc "activemq::activemq-cluster" }}.1_{{ b64enc "testQueue" }}
   name: testQueue
 - id: {{ b64enc "activemq::activemq-cluster" }}.1_{{ b64enc "testTopic" }}

--- a/test/e2e-v2/cases/activemq/expected/instance.yml
+++ b/test/e2e-v2/cases/activemq/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: activemq-broker
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/activemq/expected/service.yml
+++ b/test/e2e-v2/cases/activemq/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "activemq::activemq-cluster" }}.1
   name: activemq::activemq-cluster
   group: activemq

--- a/test/e2e-v2/cases/alarm/expected/service.yml
+++ b/test/e2e-v2/cases/alarm/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/apisix/expected/instance.yml
+++ b/test/e2e-v2/cases/apisix/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  {{- contains . }}
+  {{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/apisix/expected/service.yml
+++ b/test/e2e-v2/cases/apisix/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "APISIX::showcase-apisix-service" }}.1
   name: APISIX::showcase-apisix-service
   shortname: showcase-apisix-service

--- a/test/e2e-v2/cases/aws/api-gateway/expected/service.yml
+++ b/test/e2e-v2/cases/aws/api-gateway/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  {{- contains . }}
+  {{- containsOnce . }}
 - id: {{ b64enc "aws-api-gateway::$default:6m85d5acx7" }}.1
   name: "aws-api-gateway::$default:6m85d5acx7"
   group: aws-api-gateway

--- a/test/e2e-v2/cases/aws/dynamodb/expected/service.yml
+++ b/test/e2e-v2/cases/aws/dynamodb/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "aws-dynamodb::xxxxxxxx" }}.1
   name: aws-dynamodb::xxxxxxxx
   group: aws-dynamodb

--- a/test/e2e-v2/cases/aws/eks/expected/endpoint.yml
+++ b/test/e2e-v2/cases/aws/eks/expected/endpoint.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains .}}
+{{- containsOnce .}}
 - id: {{ b64enc "aws-eks-cluster::SkyWalking" }}.1_{{ b64enc "kube-dns" }}
   name: kube-dns
 {{- end}}

--- a/test/e2e-v2/cases/aws/eks/expected/instance.yml
+++ b/test/e2e-v2/cases/aws/eks/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  {{- contains . }}
+  {{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name:  ip-172-31-10-158.ap-northeast-1.compute.internal
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/aws/eks/expected/service.yml
+++ b/test/e2e-v2/cases/aws/eks/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  {{- contains . }}
+  {{- containsOnce . }}
 - id: {{ b64enc "aws-eks-cluster::SkyWalking" }}.1
   name: aws-eks-cluster::SkyWalking
   group: aws-eks-cluster

--- a/test/e2e-v2/cases/aws/s3/expected/service.yml
+++ b/test/e2e-v2/cases/aws/s3/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  {{- contains . }}
+  {{- containsOnce . }}
 - id: {{ b64enc "aws-s3::skywalking" }}.1
   name: aws-s3::skywalking
   group: aws-s3

--- a/test/e2e-v2/cases/cilium/expected/dependency-services.yml
+++ b/test/e2e-v2/cases/cilium/expected/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "productpage.default"}}.1
   name: productpage.default
   type: http
@@ -42,7 +42,7 @@ nodes:
     - CILIUM_SERVICE
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "productpage.default"}}.1
   sourcecomponents: []
   target: {{ b64enc "reviews.default"}}.1

--- a/test/e2e-v2/cases/cilium/expected/service.yml
+++ b/test/e2e-v2/cases/cilium/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "details.default" }}.1
   name: details.default
   group: ""

--- a/test/e2e-v2/cases/clickhouse/expected/service.yml
+++ b/test/e2e-v2/cases/clickhouse/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  {{- contains . }}
+  {{- containsOnce . }}
 - id: {{ b64enc "clickhouse::clickhouse:8123" }}.1
   name: clickhouse::clickhouse:8123
   shortname: clickhouse:8123

--- a/test/e2e-v2/cases/cluster/expected/service.yml
+++ b/test/e2e-v2/cases/cluster/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "test-service" }}.1
   name: test-service
   group: ""

--- a/test/e2e-v2/cases/elasticsearch/expected/endpoint.yml
+++ b/test/e2e-v2/cases/elasticsearch/expected/endpoint.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains .}}
+{{- containsOnce .}}
 - id: {{ b64enc "elasticsearch::cluster-e2e" }}.1_{{ b64enc "e2e-index-0" }}
   name: e2e-index-0
 {{- end}}

--- a/test/e2e-v2/cases/elasticsearch/expected/instance.yml
+++ b/test/e2e-v2/cases/elasticsearch/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: node-e2e
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/elasticsearch/expected/service.yml
+++ b/test/e2e-v2/cases/elasticsearch/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "elasticsearch::cluster-e2e" }}.1
   name: elasticsearch::cluster-e2e
   group: elasticsearch

--- a/test/e2e-v2/cases/envoy-ai-gateway/expected/service.yml
+++ b/test/e2e-v2/cases/envoy-ai-gateway/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-ai-gateway" }}.1
   name: e2e-ai-gateway
   group: ""

--- a/test/e2e-v2/cases/flink/expected/endpoint.yml
+++ b/test/e2e-v2/cases/flink/expected/endpoint.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains .}}
+{{- containsOnce .}}
 - id: {{ b64enc "flink::flink-cluster" }}.1_{{ b64enc "Windowed_Join_Example" }}
   name: Windowed_Join_Example
 {{- end}}

--- a/test/e2e-v2/cases/flink/expected/instance.yml
+++ b/test/e2e-v2/cases/flink/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: taskmanager:9261
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/flink/expected/service.yml
+++ b/test/e2e-v2/cases/flink/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "flink::flink-cluster" }}.1
   name: flink::flink-cluster
   group: flink

--- a/test/e2e-v2/cases/gateway/expected/dependency-services-consumer.yml
+++ b/test/e2e-v2/cases/gateway/expected/dependency-services-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User" }}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - UNDEFINED
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/gateway/expected/dependency-services-provider.yml
+++ b/test/e2e-v2/cases/gateway/expected/dependency-services-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - VIRTUAL_DATABASE
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-provider" }}.1
   sourcecomponents:
     - h2-jdbc-driver

--- a/test/e2e-v2/cases/gateway/expected/service.yml
+++ b/test/e2e-v2/cases/gateway/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/go/expected/dependency-services-go.yml
+++ b/test/e2e-v2/cases/go/expected/dependency-services-go.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -37,7 +37,7 @@ nodes:
     - SO11Y_GO_AGENT
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/go/expected/service.yml
+++ b/test/e2e-v2/cases/go/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "localhost:-1" }}.0
   name: localhost:-1
   group: ""

--- a/test/e2e-v2/cases/istio/als/expected/dependency-services-instance-productpage.yml
+++ b/test/e2e-v2/cases/istio/als/expected/dependency-services-instance-productpage.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "e2e::reviews" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ notEmpty .target }}

--- a/test/e2e-v2/cases/istio/als/expected/dependency-services-productpage.yml
+++ b/test/e2e-v2/cases/istio/als/expected/dependency-services-productpage.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e::reviews"}}.1
   name: e2e::reviews
   type: http
@@ -42,7 +42,7 @@ nodes:
     - MESH
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e::istio-ingressgateway"}}.1
   sourcecomponents:
     - http

--- a/test/e2e-v2/cases/istio/als/expected/dependency-services-reviews.yml
+++ b/test/e2e-v2/cases/istio/als/expected/dependency-services-reviews.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e::reviews"}}.1
   name: e2e::reviews
   type: http
@@ -36,7 +36,7 @@ nodes:
     - MESH
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e::productpage"}}.1
   sourcecomponents:
     - http

--- a/test/e2e-v2/cases/istio/als/expected/service.yml
+++ b/test/e2e-v2/cases/istio/als/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e::details" }}.1
   name: e2e::details
   group: "e2e"

--- a/test/e2e-v2/cases/istio/ambient-als/expected/dependency-services-instance-productpage.yml
+++ b/test/e2e-v2/cases/istio/ambient-als/expected/dependency-services-instance-productpage.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "reviews.default" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ notEmpty .target }}

--- a/test/e2e-v2/cases/istio/ambient-als/expected/service.yml
+++ b/test/e2e-v2/cases/istio/ambient-als/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "details.default" }}.1
   name: details.default
   group: ""

--- a/test/e2e-v2/cases/istio/metrics/expected/dependency-services-productpage.yml
+++ b/test/e2e-v2/cases/istio/metrics/expected/dependency-services-productpage.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e::reviews"}}.1
   name: e2e::reviews
   type: null
@@ -42,7 +42,7 @@ nodes:
     - MESH_DP
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e::istio-ingressgateway"}}.1
   sourcecomponents:
     - Unknown

--- a/test/e2e-v2/cases/istio/metrics/expected/service.yml
+++ b/test/e2e-v2/cases/istio/metrics/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e::istio-egressgateway" }}.1
   name: e2e::istio-egressgateway
   group: "e2e"

--- a/test/e2e-v2/cases/kafka/kafka-monitoring/expected/instance.yml
+++ b/test/e2e-v2/cases/kafka/kafka-monitoring/expected/instance.yml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-  {{- contains . }}
+  {{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: broker1:7071
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/kafka/kafka-monitoring/expected/service.yml
+++ b/test/e2e-v2/cases/kafka/kafka-monitoring/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  {{- contains . }}
+  {{- containsOnce . }}
 - id: {{ b64enc "kafka::kafka-cluster" }}.1
   name: kafka::kafka-cluster
   group: kafka

--- a/test/e2e-v2/cases/kafka/log/expected/service.yml
+++ b/test/e2e-v2/cases/kafka/log/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/kafka/meter/expected/service.yml
+++ b/test/e2e-v2/cases/kafka/meter/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/kong/expected/service.yml
+++ b/test/e2e-v2/cases/kong/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "kong::kong-cluster" }}.1
   name: kong::kong-cluster
   group: kong

--- a/test/e2e-v2/cases/log/expected/service.yml
+++ b/test/e2e-v2/cases/log/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/lua/expected/dependency-services.yml
+++ b/test/e2e-v2/cases/lua/expected/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-entry-provider" }}.1
   name: e2e-service-entry-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-entry-provider" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/lua/expected/service.yml
+++ b/test/e2e-v2/cases/lua/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-entry-provider" }}.1
   name: e2e-service-entry-provider
   group: ""

--- a/test/e2e-v2/cases/mariadb/expected/service.yml
+++ b/test/e2e-v2/cases/mariadb/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "mysql::db" }}.1
   name: mysql::db
   shortname: db

--- a/test/e2e-v2/cases/menu/expected/service.yml
+++ b/test/e2e-v2/cases/menu/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/meter/expected/service.yml
+++ b/test/e2e-v2/cases/meter/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "localhost:-1" }}.0
   name: localhost:-1
   group: ""

--- a/test/e2e-v2/cases/mongodb/expected/instance.yml
+++ b/test/e2e-v2/cases/mongodb/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: mongodb-exporter-1:9216
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/mongodb/expected/service.yml
+++ b/test/e2e-v2/cases/mongodb/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "mongodb::replset" }}.1
   name: mongodb::replset
   group: mongodb

--- a/test/e2e-v2/cases/mysql/expected/service.yml
+++ b/test/e2e-v2/cases/mysql/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "mysql::root[root]" }}.1
   name: mysql::root[root]
   shortname: root[root]

--- a/test/e2e-v2/cases/nginx/expected/service.yml
+++ b/test/e2e-v2/cases/nginx/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "nginx::e2e-test" }}.1
   name: nginx::e2e-test
   group: nginx

--- a/test/e2e-v2/cases/nodejs/expected/dependency-services-consumer-nodejs.yml
+++ b/test/e2e-v2/cases/nodejs/expected/dependency-services-consumer-nodejs.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User" }}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "consumer" }}.1
   sourcecomponents:
     - Axios

--- a/test/e2e-v2/cases/nodejs/expected/dependency-services-consumer.yml
+++ b/test/e2e-v2/cases/nodejs/expected/dependency-services-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "provider" }}.1
   name: provider
   type: Express
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/nodejs/expected/dependency-services-provider-nodejs.yml
+++ b/test/e2e-v2/cases/nodejs/expected/dependency-services-provider-nodejs.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "provider" }}.1
   name: provider
   type: Express
@@ -30,7 +30,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/nodejs/expected/service.yml
+++ b/test/e2e-v2/cases/nodejs/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "consumer" }}.1
   name: consumer
   group: ""

--- a/test/e2e-v2/cases/otlp-virtual-genai/expected/instance.yml
+++ b/test/e2e-v2/cases/otlp-virtual-genai/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: gpt-4.1-mini-2025-04-14
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/otlp-virtual-genai/expected/service.yml
+++ b/test/e2e-v2/cases/otlp-virtual-genai/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "openai" }}.0
   name: openai
   group: ""

--- a/test/e2e-v2/cases/php/expected/dependency-services-php.yml
+++ b/test/e2e-v2/cases/php/expected/dependency-services-php.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User" }}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "php" }}.1
   sourcecomponents:
     - cURL

--- a/test/e2e-v2/cases/php/expected/dependency-services-provider.yml
+++ b/test/e2e-v2/cases/php/expected/dependency-services-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "php" }}.1
   sourcecomponents:
     - cURL

--- a/test/e2e-v2/cases/php/expected/service.yml
+++ b/test/e2e-v2/cases/php/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/postgresql/expected/service.yml
+++ b/test/e2e-v2/cases/postgresql/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "postgresql::postgres:5432" }}.1
   name: postgresql::postgres:5432
   shortname: postgres:5432

--- a/test/e2e-v2/cases/profiling/async-profiler/expected/service.yml
+++ b/test/e2e-v2/cases/profiling/async-profiler/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-services.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "productpage.default"}}.1
   name: productpage.default
   type: http
@@ -42,7 +42,7 @@ nodes:
     - K8S_SERVICE
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "productpage.default"}}.1
   sourcecomponents:
   {{- contains .sourcecomponents }}

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/service.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "details.default" }}.1
   name: details.default
   group: ""

--- a/test/e2e-v2/cases/profiling/ebpf/continuous/expected/instance.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/continuous/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "sqrt" }}.1_{{ b64enc "test-instance" }}
   name: test-instance
   attributes: []

--- a/test/e2e-v2/cases/profiling/ebpf/continuous/expected/service.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/continuous/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "sqrt" }}.1
   name: sqrt
   group: ""

--- a/test/e2e-v2/cases/profiling/ebpf/network/expected/service.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/network/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "nginx" }}.1
   name: nginx
   group: ""

--- a/test/e2e-v2/cases/profiling/ebpf/offcpu/expected/instance.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/offcpu/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "file" }}.1_{{ b64enc "test-instance" }}
   name: test-instance
   attributes: []

--- a/test/e2e-v2/cases/profiling/ebpf/offcpu/expected/service.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/offcpu/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "file" }}.1
   name: file
   group: ""

--- a/test/e2e-v2/cases/profiling/ebpf/oncpu/expected/instance.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/oncpu/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "sqrt" }}.1_{{ b64enc "test-instance" }}
   name: test-instance
   attributes: []

--- a/test/e2e-v2/cases/profiling/ebpf/oncpu/expected/service.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/oncpu/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "sqrt" }}.1
   name: sqrt
   group: ""

--- a/test/e2e-v2/cases/profiling/pprof/expected/service.yml
+++ b/test/e2e-v2/cases/profiling/pprof/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "go-service" }}.1
   name: go-service
   group: ""

--- a/test/e2e-v2/cases/profiling/trace/expected/service.yml
+++ b/test/e2e-v2/cases/profiling/trace/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/pulsar/expected/service.yml
+++ b/test/e2e-v2/cases/pulsar/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "pulsar::pulsar-cluster" }}.1
   name: pulsar::pulsar-cluster
   group: pulsar

--- a/test/e2e-v2/cases/python/expected/dependency-services-consumer-py.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-services-consumer-py.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User"}}.0
   name: User
   type: USER
@@ -42,7 +42,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "User"}}.0
   sourcecomponents: []
   target: {{ b64enc "consumer-py"}}.1

--- a/test/e2e-v2/cases/python/expected/dependency-services-provider-py.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-services-provider-py.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-consumer"}}.1
   name: e2e-service-consumer
   type: Tomcat
@@ -30,7 +30,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/python/expected/service.yml
+++ b/test/e2e-v2/cases/python/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "provider-py" }}.1
   name: provider-py
   group: ""

--- a/test/e2e-v2/cases/rabbitmq/expected/instance.yml
+++ b/test/e2e-v2/cases/rabbitmq/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: rmq0:15692
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/rabbitmq/expected/service.yml
+++ b/test/e2e-v2/cases/rabbitmq/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "rabbitmq::rabbitmq-cluster" }}.1
   name: rabbitmq::rabbitmq-cluster
   group: rabbitmq

--- a/test/e2e-v2/cases/redis/expected/service.yml
+++ b/test/e2e-v2/cases/redis/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "redis::root[root]" }}.1
   name: redis::root[root]
   shortname: root[root]

--- a/test/e2e-v2/cases/rocketmq/expected/endpoint.yml
+++ b/test/e2e-v2/cases/rocketmq/expected/endpoint.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains .}}
+{{- containsOnce .}}
 - id: {{ b64enc "rocketmq::rocketmq-cluster" }}.1_{{ b64enc "TopicTest" }}
   name: TopicTest
 {{- end}}

--- a/test/e2e-v2/cases/rocketmq/expected/instance.yml
+++ b/test/e2e-v2/cases/rocketmq/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: rocketmq-broker-1
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/rocketmq/expected/service.yml
+++ b/test/e2e-v2/cases/rocketmq/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "rocketmq::rocketmq-cluster" }}.1
   name: rocketmq::rocketmq-cluster
   group: rocketmq

--- a/test/e2e-v2/cases/rover/process/istio/expected/service.yml
+++ b/test/e2e-v2/cases/rover/process/istio/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "details.default" }}.1
   name: details.default
   group: ""

--- a/test/e2e-v2/cases/satellite/native-protocols/expected/dependency-services.yml
+++ b/test/e2e-v2/cases/satellite/native-protocols/expected/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -30,7 +30,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/satellite/native-protocols/expected/service.yml
+++ b/test/e2e-v2/cases/satellite/native-protocols/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/simple/expected/dependency-services-consumer.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-services-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User"}}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/simple/expected/dependency-services-provider.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-services-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - VIRTUAL_DATABASE
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/simple/expected/service.yml
+++ b/test/e2e-v2/cases/simple/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/so11y/expected/service.yml
+++ b/test/e2e-v2/cases/so11y/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/storage/expected/cold/dependency-services.yml
+++ b/test/e2e-v2/cases/storage/expected/cold/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User"}}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "mock_a_service"}}.1
   sourcecomponents:
     - Dubbo

--- a/test/e2e-v2/cases/storage/expected/dependency-services-consumer.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-services-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User"}}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/storage/expected/dependency-services-provider.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-services-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - VIRTUAL_DATABASE
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/storage/expected/service.yml
+++ b/test/e2e-v2/cases/storage/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   group: ""

--- a/test/e2e-v2/cases/virtual-genai/expected/instance.yml
+++ b/test/e2e-v2/cases/virtual-genai/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: gpt-4.1-mini-2025-04-14
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/virtual-genai/expected/service.yml
+++ b/test/e2e-v2/cases/virtual-genai/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "openai" }}.0
   name: openai
   group: ""

--- a/test/e2e-v2/cases/virtual-mq/expected/service.yml
+++ b/test/e2e-v2/cases/virtual-mq/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "kafka:9092" }}.0
   name: kafka:9092
   group: ""

--- a/test/e2e-v2/cases/vm/expected/service.yml
+++ b/test/e2e-v2/cases/vm/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "vm-service" }}.1
   name: vm-service
   shortname: vm-service

--- a/test/e2e-v2/cases/win/expected/service.yml
+++ b/test/e2e-v2/cases/win/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  {{- contains . }}
+  {{- containsOnce . }}
 - id: {{ b64enc "10.211.55.3" }}.1
   name: 10.211.55.3
   group: ""

--- a/test/e2e-v2/cases/zipkin-virtual-genai/expected/instance.yml
+++ b/test/e2e-v2/cases/zipkin-virtual-genai/expected/instance.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ notEmpty .id }}
   name: gpt-4.1-mini-2025-04-14
   instanceuuid: {{ notEmpty .instanceuuid }}

--- a/test/e2e-v2/cases/zipkin-virtual-genai/expected/service.yml
+++ b/test/e2e-v2/cases/zipkin-virtual-genai/expected/service.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- contains . }}
+{{- containsOnce . }}
 - id: {{ b64enc "openai" }}.0
   name: openai
   group: ""


### PR DESCRIPTION
### Use containsOnce for stricter metadata verification in e2e tests

Migrate outer-level `contains` to `containsOnce` in 101 expected files:
- **57 service.yml** — exact service names and IDs
- **15 instance.yml** — known service instances
- **5 endpoint.yml** — exact endpoint names
- **24 topology files** — aggregated nodes and calls (no duplicates)

`containsOnce` uses backtracking for optimal 1:1 assignment between expected and actual entries, ensuring each actual item matches exactly one expected entry. This is more precise than greedy `contains` for metadata where we know exactly which entries should exist.

Inner nested `contains` (`.layers`, `.tags`, etc.) are left unchanged.

**Verified locally** with the locally-built infra-e2e binary against mock data for service, instance, and topology patterns.

- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).