### PR TITLE
Fix duplicate calls in EndpointTopologyBuilder

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
+        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
+        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
+        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
+        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@b2a6639541b562fb0eff89b32b28c5f367023db6
+        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -14,6 +14,8 @@
 * Support MCP (Model Context Protocol) observability for Envoy AI Gateway: MCP metrics (request CPM/latency, method breakdown, backend breakdown, initialization latency, capabilities), MCP access log sampling (errors only), `ai_route_type` searchable log tag, and MCP dashboard tabs.
 * Add weighted handler support to `BatchQueue` adaptive partitioning. MAL metrics use weight 0.05 at L1 (vs 1.0 for OAL), reducing partition count and memory overhead when many MAL metric types are registered.
 * Fix missing `taskId` filter in pprof task log query and its JDBC/BanyanDB/Elasticsearch implementations.
+* Fix duplicate calls in `EndpointTopologyBuilder` — calls were not deduplicated unlike `ServiceTopologyBuilder`, causing duplicate entries when storage returns multiple records for the same relation.
+* Use `containsOnce` for topology dependency e2e expected files to enforce no-duplicate verification.
 
 #### UI
 

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -15,7 +15,8 @@
 * Add weighted handler support to `BatchQueue` adaptive partitioning. MAL metrics use weight 0.05 at L1 (vs 1.0 for OAL), reducing partition count and memory overhead when many MAL metric types are registered.
 * Fix missing `taskId` filter in pprof task log query and its JDBC/BanyanDB/Elasticsearch implementations.
 * Fix duplicate calls in `EndpointTopologyBuilder` — calls were not deduplicated unlike `ServiceTopologyBuilder`, causing duplicate entries when storage returns multiple records for the same relation.
-* Use `containsOnce` for topology dependency e2e expected files to enforce no-duplicate verification.
+* Use `containsOnce` and `noDuplicates` for topology dependency e2e expected files to enforce no-duplicate verification.
+* Bump infra-e2e to `ef073ad` to include `noDuplicates` pipe function support.
 
 #### UI
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/EndpointTopologyBuilder.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/EndpointTopologyBuilder.java
@@ -18,8 +18,10 @@
 
 package org.apache.skywalking.oap.server.core.query;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.skywalking.oap.server.core.analysis.IDManager;
 import org.apache.skywalking.oap.server.core.query.type.Call;
@@ -48,13 +50,17 @@ public class EndpointTopologyBuilder {
 
     EndpointTopology build(List<Call.CallDetail> serverSideCalls) {
         EndpointTopology topology = new EndpointTopology();
+        Map<String, Call> callMap = new HashMap<>();
         serverSideCalls.forEach(callDetail -> {
-            Call call = new Call();
-            call.setId(callDetail.getId());
-            call.setSource(callDetail.getSource());
-            call.setTarget(callDetail.getTarget());
-            call.addDetectPoint(DetectPoint.SERVER);
-            topology.getCalls().add(call);
+            if (!callMap.containsKey(callDetail.getId())) {
+                Call call = new Call();
+                call.setId(callDetail.getId());
+                call.setSource(callDetail.getSource());
+                call.setTarget(callDetail.getTarget());
+                call.addDetectPoint(DetectPoint.SERVER);
+                callMap.put(callDetail.getId(), call);
+                topology.getCalls().add(call);
+            }
         });
 
         Set<String> nodeIds = new HashSet<>();

--- a/test/e2e-v2/cases/browser/expected/dependency.yml
+++ b/test/e2e-v2/cases/browser/expected/dependency.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "provider-py"}}.1
   name: provider-py
   type: Python
@@ -30,7 +30,7 @@ nodes:
     - BROWSER
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "test-ui"}}.1
   sourcecomponents:
     - ajax

--- a/test/e2e-v2/cases/browser/expected/dependency.yml
+++ b/test/e2e-v2/cases/browser/expected/dependency.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "provider-py"}}.1
   name: provider-py
   type: Python
@@ -30,7 +30,7 @@ nodes:
     - BROWSER
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "test-ui"}}.1
   sourcecomponents:
     - ajax

--- a/test/e2e-v2/cases/cilium/expected/dependency-services.yml
+++ b/test/e2e-v2/cases/cilium/expected/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "productpage.default"}}.1
   name: productpage.default
   type: http
@@ -42,7 +42,7 @@ nodes:
     - CILIUM_SERVICE
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "productpage.default"}}.1
   sourcecomponents: []
   target: {{ b64enc "reviews.default"}}.1

--- a/test/e2e-v2/cases/gateway/expected/dependency-endpoint.yml
+++ b/test/e2e-v2/cases/gateway/expected/dependency-endpoint.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   name: POST:/users
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/gateway/expected/dependency-endpoint.yml
+++ b/test/e2e-v2/cases/gateway/expected/dependency-endpoint.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   name: POST:/users
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/gateway/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/gateway/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "gateway:80" }}.0_{{ b64enc "gateway:80" }}
   name: gateway:80
   serviceid: {{ b64enc "gateway:80" }}.0
@@ -36,7 +36,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "gateway:80" }}.0_{{ b64enc "gateway:80" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/gateway/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/gateway/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "gateway:80" }}.0_{{ b64enc "gateway:80" }}
   name: gateway:80
   serviceid: {{ b64enc "gateway:80" }}.0
@@ -36,7 +36,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "gateway:80" }}.0_{{ b64enc "gateway:80" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/gateway/expected/dependency-services-consumer.yml
+++ b/test/e2e-v2/cases/gateway/expected/dependency-services-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User" }}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - UNDEFINED
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/gateway/expected/dependency-services-provider.yml
+++ b/test/e2e-v2/cases/gateway/expected/dependency-services-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-provider" }}.1
   name: e2e-service-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - VIRTUAL_DATABASE
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-provider" }}.1
   sourcecomponents:
     - h2-jdbc-driver

--- a/test/e2e-v2/cases/go/expected/dependency-instance-go.yml
+++ b/test/e2e-v2/cases/go/expected/dependency-instance-go.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "go-service" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/go/expected/dependency-instance-go.yml
+++ b/test/e2e-v2/cases/go/expected/dependency-instance-go.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "go-service" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/go/expected/dependency-services-go.yml
+++ b/test/e2e-v2/cases/go/expected/dependency-services-go.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -37,7 +37,7 @@ nodes:
     - SO11Y_GO_AGENT
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/istio/als/expected/dependency-services-instance-productpage.yml
+++ b/test/e2e-v2/cases/istio/als/expected/dependency-services-instance-productpage.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "e2e::reviews" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ notEmpty .target }}

--- a/test/e2e-v2/cases/istio/als/expected/dependency-services-productpage.yml
+++ b/test/e2e-v2/cases/istio/als/expected/dependency-services-productpage.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e::reviews"}}.1
   name: e2e::reviews
   type: http
@@ -42,7 +42,7 @@ nodes:
     - MESH
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e::istio-ingressgateway"}}.1
   sourcecomponents:
     - http

--- a/test/e2e-v2/cases/istio/als/expected/dependency-services-reviews.yml
+++ b/test/e2e-v2/cases/istio/als/expected/dependency-services-reviews.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e::reviews"}}.1
   name: e2e::reviews
   type: http
@@ -36,7 +36,7 @@ nodes:
     - MESH
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e::productpage"}}.1
   sourcecomponents:
     - http

--- a/test/e2e-v2/cases/istio/ambient-als/expected/dependency-global-mesh.yml
+++ b/test/e2e-v2/cases/istio/ambient-als/expected/dependency-global-mesh.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "reviews.default"}}.1
   name: reviews.default
   type: http
@@ -54,7 +54,7 @@ nodes:
   {{- end }}
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "productpage.default"}}.1
   sourcecomponents:
     {{- contains .sourcecomponents }}

--- a/test/e2e-v2/cases/istio/ambient-als/expected/dependency-global-mesh.yml
+++ b/test/e2e-v2/cases/istio/ambient-als/expected/dependency-global-mesh.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "reviews.default"}}.1
   name: reviews.default
   type: http
@@ -54,7 +54,7 @@ nodes:
   {{- end }}
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "productpage.default"}}.1
   sourcecomponents:
     {{- contains .sourcecomponents }}

--- a/test/e2e-v2/cases/istio/ambient-als/expected/dependency-services-instance-productpage.yml
+++ b/test/e2e-v2/cases/istio/ambient-als/expected/dependency-services-instance-productpage.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "reviews.default" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ notEmpty .target }}

--- a/test/e2e-v2/cases/istio/metrics/expected/dependency-services-productpage.yml
+++ b/test/e2e-v2/cases/istio/metrics/expected/dependency-services-productpage.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e::reviews"}}.1
   name: e2e::reviews
   type: null
@@ -42,7 +42,7 @@ nodes:
     - MESH_DP
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e::istio-ingressgateway"}}.1
   sourcecomponents:
     - Unknown

--- a/test/e2e-v2/cases/lua/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/lua/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User_Service_Name" }}.1_{{ b64enc "User_Service_Instance_Name" }}
   name: User_Service_Instance_Name
   serviceid: {{ b64enc "User_Service_Name" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-entry-provider" }}.1_{{ b64enc "provider1" }}
   sourcecomponents: []
   target: {{ b64enc "User_Service_Name" }}.1_{{ b64enc "User_Service_Instance_Name" }}

--- a/test/e2e-v2/cases/lua/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/lua/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User_Service_Name" }}.1_{{ b64enc "User_Service_Instance_Name" }}
   name: User_Service_Instance_Name
   serviceid: {{ b64enc "User_Service_Name" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-entry-provider" }}.1_{{ b64enc "provider1" }}
   sourcecomponents: []
   target: {{ b64enc "User_Service_Name" }}.1_{{ b64enc "User_Service_Instance_Name" }}

--- a/test/e2e-v2/cases/lua/expected/dependency-services.yml
+++ b/test/e2e-v2/cases/lua/expected/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-entry-provider" }}.1
   name: e2e-service-entry-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-entry-provider" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/nodejs/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/nodejs/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "consumer" }}.1_{{ b64enc "consumer-instance" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}

--- a/test/e2e-v2/cases/nodejs/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/nodejs/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "consumer" }}.1_{{ b64enc "consumer-instance" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}

--- a/test/e2e-v2/cases/nodejs/expected/dependency-services-consumer-nodejs.yml
+++ b/test/e2e-v2/cases/nodejs/expected/dependency-services-consumer-nodejs.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User" }}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "consumer" }}.1
   sourcecomponents:
     - Axios

--- a/test/e2e-v2/cases/nodejs/expected/dependency-services-consumer.yml
+++ b/test/e2e-v2/cases/nodejs/expected/dependency-services-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "provider" }}.1
   name: provider
   type: Express
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/nodejs/expected/dependency-services-provider-nodejs.yml
+++ b/test/e2e-v2/cases/nodejs/expected/dependency-services-provider-nodejs.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "provider" }}.1
   name: provider
   type: Express
@@ -30,7 +30,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/php/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/php/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "php" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/php/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/php/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "php" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/php/expected/dependency-services-php.yml
+++ b/test/e2e-v2/cases/php/expected/dependency-services-php.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User" }}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "php" }}.1
   sourcecomponents:
     - cURL

--- a/test/e2e-v2/cases/php/expected/dependency-services-provider.yml
+++ b/test/e2e-v2/cases/php/expected/dependency-services-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "php" }}.1
   sourcecomponents:
     - cURL

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "productpage.default" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ notEmpty .target }}

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ notEmpty .id }}
   name: {{ notEmpty .name }}
   serviceid: {{ b64enc "productpage.default" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ notEmpty .source }}
   sourcecomponents: []
   target: {{ notEmpty .target }}

--- a/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-services.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/access_log/expected/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "productpage.default"}}.1
   name: productpage.default
   type: http
@@ -42,7 +42,7 @@ nodes:
     - K8S_SERVICE
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "productpage.default"}}.1
   sourcecomponents:
   {{- contains .sourcecomponents }}

--- a/test/e2e-v2/cases/profiling/ebpf/network/expected/dependency-processs.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/network/expected/dependency-processs.yml
@@ -25,7 +25,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{template "genProcessId" "service"}}
   name: service
   serviceid: {{ b64enc "service" }}.1
@@ -42,7 +42,7 @@ nodes:
   isreal: false
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{template "genProcessId" "service"}}
   sourcecomponents:
   {{- contains .sourcecomponents }}

--- a/test/e2e-v2/cases/profiling/ebpf/network/expected/dependency-processs.yml
+++ b/test/e2e-v2/cases/profiling/ebpf/network/expected/dependency-processs.yml
@@ -25,7 +25,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{template "genProcessId" "service"}}
   name: service
   serviceid: {{ b64enc "service" }}.1
@@ -42,7 +42,7 @@ nodes:
   isreal: false
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{template "genProcessId" "service"}}
   sourcecomponents:
   {{- contains .sourcecomponents }}

--- a/test/e2e-v2/cases/python/expected/dependency-instance-consumer-py.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-instance-consumer-py.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
   - source: {{ b64enc "consumer-py" }}.1_{{ b64enc "consumer-py-instance" }}
     sourcecomponents: []
     target: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}

--- a/test/e2e-v2/cases/python/expected/dependency-instance-consumer-py.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-instance-consumer-py.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
   - source: {{ b64enc "consumer-py" }}.1_{{ b64enc "consumer-py-instance" }}
     sourcecomponents: []
     target: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}

--- a/test/e2e-v2/cases/python/expected/dependency-instance-provider-py-kafka.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-instance-provider-py-kafka.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "provider-py-kafka" }}.1_{{ b64enc "provider-py-kafka-instance" }}
   name: provider-py-kafka-instance
   serviceid: {{ b64enc "provider-py-kafka" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
   - source: {{ b64enc "consumer-py" }}.1_{{ b64enc "consumer-py-instance" }}
     sourcecomponents: []
     target: {{ b64enc "provider-py-kafka" }}.1_{{ b64enc "provider-py-kafka-instance" }}

--- a/test/e2e-v2/cases/python/expected/dependency-instance-provider-py-kafka.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-instance-provider-py-kafka.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "provider-py-kafka" }}.1_{{ b64enc "provider-py-kafka-instance" }}
   name: provider-py-kafka-instance
   serviceid: {{ b64enc "provider-py-kafka" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
   - source: {{ b64enc "consumer-py" }}.1_{{ b64enc "consumer-py-instance" }}
     sourcecomponents: []
     target: {{ b64enc "provider-py-kafka" }}.1_{{ b64enc "provider-py-kafka-instance" }}

--- a/test/e2e-v2/cases/python/expected/dependency-instance-provider-py.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-instance-provider-py.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
   - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
     sourcecomponents: []
     target: {{ b64enc "provider-py" }}.1_{{ b64enc "provider-py-instance" }}

--- a/test/e2e-v2/cases/python/expected/dependency-instance-provider-py.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-instance-provider-py.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
   - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
     sourcecomponents: []
     target: {{ b64enc "provider-py" }}.1_{{ b64enc "provider-py-instance" }}

--- a/test/e2e-v2/cases/python/expected/dependency-services-consumer-py.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-services-consumer-py.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User"}}.0
   name: User
   type: USER
@@ -42,7 +42,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "User"}}.0
   sourcecomponents: []
   target: {{ b64enc "consumer-py"}}.1

--- a/test/e2e-v2/cases/python/expected/dependency-services-provider-py.yml
+++ b/test/e2e-v2/cases/python/expected/dependency-services-provider-py.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-consumer"}}.1
   name: e2e-service-consumer
   type: Tomcat
@@ -30,7 +30,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer" }}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/satellite/native-protocols/expected/dependency-services.yml
+++ b/test/e2e-v2/cases/satellite/native-protocols/expected/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -30,7 +30,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/simple/expected/dependency-endpoint-consumer.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-endpoint-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User" }}.0_{{ b64enc "User" }}
   name: User
   serviceid: {{ b64enc "User" }}.0
@@ -36,7 +36,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "User" }}.0_{{ b64enc "User" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/simple/expected/dependency-endpoint-consumer.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-endpoint-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User" }}.0_{{ b64enc "User" }}
   name: User
   serviceid: {{ b64enc "User" }}.0
@@ -36,7 +36,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "User" }}.0_{{ b64enc "User" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/simple/expected/dependency-endpoint-provider.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-endpoint-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   name: POST:/users
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/simple/expected/dependency-endpoint-provider.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-endpoint-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   name: POST:/users
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/simple/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/simple/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/simple/expected/dependency-services-consumer.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-services-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User"}}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/simple/expected/dependency-services-provider.yml
+++ b/test/e2e-v2/cases/simple/expected/dependency-services-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - VIRTUAL_DATABASE
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/storage/expected/cold/dependency-endpoint.yml
+++ b/test/e2e-v2/cases/storage/expected/cold/dependency-endpoint.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "mock_a_service" }}.1_{{ b64enc "/dubbox-case/case/dubbox-rest/404-test" }}
   name: /dubbox-case/case/dubbox-rest/404-test
   serviceid: {{ b64enc "mock_a_service" }}.1
@@ -36,7 +36,7 @@ nodes:
   isreal: false
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "mock_a_service" }}.1_{{ b64enc "/dubbox-case/case/dubbox-rest/404-test" }}
   sourcecomponents: []
   target: {{ b64enc "mock_b_service" }}.1_{{ b64enc "org.skywaking.apm.testcase.dubbo.services.GreetServiceImpl.doBusiness()" }}

--- a/test/e2e-v2/cases/storage/expected/cold/dependency-endpoint.yml
+++ b/test/e2e-v2/cases/storage/expected/cold/dependency-endpoint.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "mock_a_service" }}.1_{{ b64enc "/dubbox-case/case/dubbox-rest/404-test" }}
   name: /dubbox-case/case/dubbox-rest/404-test
   serviceid: {{ b64enc "mock_a_service" }}.1
@@ -36,7 +36,7 @@ nodes:
   isreal: false
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "mock_a_service" }}.1_{{ b64enc "/dubbox-case/case/dubbox-rest/404-test" }}
   sourcecomponents: []
   target: {{ b64enc "mock_b_service" }}.1_{{ b64enc "org.skywaking.apm.testcase.dubbo.services.GreetServiceImpl.doBusiness()" }}

--- a/test/e2e-v2/cases/storage/expected/cold/dependency-instance.yml
+++ b/test/e2e-v2/cases/storage/expected/cold/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "mock_a_service" }}.1_{{ b64enc "mock_a_service_instance" }}
   name: mock_a_service_instance
   serviceid: {{ b64enc "mock_a_service" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "mock_a_service" }}.1_{{ b64enc "mock_a_service_instance" }}
   sourcecomponents: []
   target: {{ b64enc "mock_b_service" }}.1_{{ b64enc "mock_b_service_instance" }}

--- a/test/e2e-v2/cases/storage/expected/cold/dependency-instance.yml
+++ b/test/e2e-v2/cases/storage/expected/cold/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "mock_a_service" }}.1_{{ b64enc "mock_a_service_instance" }}
   name: mock_a_service_instance
   serviceid: {{ b64enc "mock_a_service" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "mock_a_service" }}.1_{{ b64enc "mock_a_service_instance" }}
   sourcecomponents: []
   target: {{ b64enc "mock_b_service" }}.1_{{ b64enc "mock_b_service_instance" }}

--- a/test/e2e-v2/cases/storage/expected/cold/dependency-services.yml
+++ b/test/e2e-v2/cases/storage/expected/cold/dependency-services.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User"}}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "mock_a_service"}}.1
   sourcecomponents:
     - Dubbo

--- a/test/e2e-v2/cases/storage/expected/dependency-endpoint-consumer.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-endpoint-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User" }}.0_{{ b64enc "User" }}
   name: User
   serviceid: {{ b64enc "User" }}.0
@@ -36,7 +36,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "User" }}.0_{{ b64enc "User" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/storage/expected/dependency-endpoint-consumer.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-endpoint-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "User" }}.0_{{ b64enc "User" }}
   name: User
   serviceid: {{ b64enc "User" }}.0
@@ -36,7 +36,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "User" }}.0_{{ b64enc "User" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/storage/expected/dependency-endpoint-provider.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-endpoint-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   name: POST:/users
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/storage/expected/dependency-endpoint-provider.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-endpoint-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   name: POST:/users
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "POST:/users" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "POST:/users" }}

--- a/test/e2e-v2/cases/storage/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- contains .nodes }}
+{{- containsOnce .nodes }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- contains .calls }}
+{{- containsOnce .calls }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/storage/expected/dependency-instance.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-instance.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   name: consumer1
   serviceid: {{ b64enc "e2e-service-consumer" }}.1
@@ -30,7 +30,7 @@ nodes:
   isreal: true
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer" }}.1_{{ b64enc "consumer1" }}
   sourcecomponents: []
   target: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/test/e2e-v2/cases/storage/expected/dependency-services-consumer.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-services-consumer.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "User"}}.0
   name: User
   type: USER
@@ -36,7 +36,7 @@ nodes:
     - GENERAL
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate

--- a/test/e2e-v2/cases/storage/expected/dependency-services-provider.yml
+++ b/test/e2e-v2/cases/storage/expected/dependency-services-provider.yml
@@ -15,7 +15,7 @@
 
 debuggingtrace: null
 nodes:
-{{- containsOnce .nodes }}
+{{- containsOnce (.nodes | noDuplicates) }}
 - id: {{ b64enc "e2e-service-provider"}}.1
   name: e2e-service-provider
   type: Tomcat
@@ -36,7 +36,7 @@ nodes:
     - VIRTUAL_DATABASE
 {{- end }}
 calls:
-{{- containsOnce .calls }}
+{{- containsOnce (.calls | noDuplicates) }}
 - source: {{ b64enc "e2e-service-consumer"}}.1
   sourcecomponents:
     - SpringRestTemplate


### PR DESCRIPTION
### Fix duplicate calls in endpoint topology query results
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

`EndpointTopologyBuilder.build()` created a new `Call` for every `CallDetail` without deduplication.
Unlike `ServiceTopologyBuilder` which uses a `HashMap<String, Call>` to deduplicate by relation ID,
`EndpointTopologyBuilder` blindly added every record — causing duplicate call entries when storage
returns multiple records for the same endpoint relation.

The fix adds the same `HashMap<String, Call>` dedup pattern. E2E expected files are also updated
from `contains` to `containsOnce` with `| noDuplicates` for topology nodes and calls to enforce
strict 1:1 matching and catch any duplicates. Infra-e2e bumped to `ef073ad` to include the
`noDuplicates` pipe function.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).