### PR TITLE
Bump infra-e2e to testcontainers-go v0.42.0 and remove deprecated compose version field

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
+        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
+        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
+        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
+        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@ef073adb8b9e148e4eaf3f905fa4e238ee5cc7d6
+        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
+        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
+        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
+        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
+        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
+        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
+        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
+        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
+        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
+        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
+        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
+        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
+        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
+        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
+        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
+        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
+        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
+        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
+        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
+        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@ae55dbaea5a8479ef0198f0877e2411e2c8af7a5
+        uses: apache/skywalking-infra-e2e@83f77bfa31f11a5527d62856f1800908e356e752
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
+        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
+        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
+        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
+        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@3bfab4eb463496108f1c88495582a8de8323c599
+        uses: apache/skywalking-infra-e2e@70eeedf549e1ce97ea93fa97ba349ab4ab894ce9
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
+        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
+        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
+        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
+        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@e9233e6376f4077d723717563eae1670f976f1de
+        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
+        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
+        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
+        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
+        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@dc2be59a3eb6b8707d0fd8b8dc779e5fafffb24d
+        uses: apache/skywalking-infra-e2e@1c3eb2aa3cce9038f0a54a1b00e7dd1f594d50ee
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
 services:
   elasticsearch:
     profiles:

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -1,6 +1,8 @@
 ## 10.5.0
 
 #### Project
+* Bump infra-e2e to testcontainers-go v0.42.0 (apache/skywalking-infra-e2e#146), which uses Docker Compose v2 plugin natively and removes docker-compose v1 dependency.
+* Remove deprecated `version` field from all docker-compose files for Compose v2 compatibility.
 
 #### OAP Server
 * Add Zipkin Virtual GenAI e2e test. Use `zipkin_json` exporter to avoid protobuf dependency conflict
@@ -21,7 +23,6 @@
 #### UI
 
 #### Documentation
-
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/issues?q=milestone:10.5.0)
 

--- a/test/e2e-v2/cases/activemq/docker-compose.yml
+++ b/test/e2e-v2/cases/activemq/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2.1"
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/alarm/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/alarm/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/alarm/es/docker-compose.yml
+++ b/test/e2e-v2/cases/alarm/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/alarm/es/es-sharding/docker-compose.yml
+++ b/test/e2e-v2/cases/alarm/es/es-sharding/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/alarm/mysql/docker-compose.yml
+++ b/test/e2e-v2/cases/alarm/mysql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   mysql:
     image: mysql/mysql-server:8.0.13

--- a/test/e2e-v2/cases/alarm/postgres/docker-compose.yml
+++ b/test/e2e-v2/cases/alarm/postgres/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   postgres:
     image: postgres:13

--- a/test/e2e-v2/cases/apisix/otel-collector/docker-compose.yml
+++ b/test/e2e-v2/cases/apisix/otel-collector/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/aws/api-gateway/docker-compose.yml
+++ b/test/e2e-v2/cases/aws/api-gateway/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/aws/dynamodb/docker-compose.yml
+++ b/test/e2e-v2/cases/aws/dynamodb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/aws/eks/docker-compose.yml
+++ b/test/e2e-v2/cases/aws/eks/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/aws/s3/docker-compose.yml
+++ b/test/e2e-v2/cases/aws/s3/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:
@@ -47,5 +45,3 @@ services:
 
 networks:
   e2e:
-
-

--- a/test/e2e-v2/cases/baseline/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/baseline/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/baseline/es/docker-compose.yml
+++ b/test/e2e-v2/cases/baseline/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/baseline/es/es-sharding/docker-compose.yml
+++ b/test/e2e-v2/cases/baseline/es/es-sharding/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/browser/docker-compose.yml
+++ b/test/e2e-v2/cases/browser/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/browser/es/docker-compose.yml
+++ b/test/e2e-v2/cases/browser/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/browser/es/es-sharding/docker-compose.yml
+++ b/test/e2e-v2/cases/browser/es/es-sharding/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/clickhouse/clickhouse-prometheus-endpoint/docker-compose.yml
+++ b/test/e2e-v2/cases/clickhouse/clickhouse-prometheus-endpoint/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/cluster/zk/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/cluster/zk/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zk:
     image: zookeeper:3.5

--- a/test/e2e-v2/cases/cluster/zk/es/docker-compose.yml
+++ b/test/e2e-v2/cases/cluster/zk/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zk:
     image: zookeeper:3.5

--- a/test/e2e-v2/cases/elasticsearch/docker-compose.yml
+++ b/test/e2e-v2/cases/elasticsearch/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/event/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/event/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/event/es/docker-compose.yml
+++ b/test/e2e-v2/cases/event/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/event/mysql/docker-compose.yml
+++ b/test/e2e-v2/cases/event/mysql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   mysql:
     image: mysql/mysql-server:8.0.13

--- a/test/e2e-v2/cases/exporter/kafka/docker-compose.yml
+++ b/test/e2e-v2/cases/exporter/kafka/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zookeeper:
     image: zookeeper:3.4

--- a/test/e2e-v2/cases/flink/docker-compose.yml
+++ b/test/e2e-v2/cases/flink/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3"
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/gateway/docker-compose.yml
+++ b/test/e2e-v2/cases/gateway/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zk:
     image: zookeeper:3.5

--- a/test/e2e-v2/cases/go/docker-compose.yml
+++ b/test/e2e-v2/cases/go/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/kafka/kafka-monitoring/docker-compose.yml
+++ b/test/e2e-v2/cases/kafka/kafka-monitoring/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/kafka/log/docker-compose.yml
+++ b/test/e2e-v2/cases/kafka/log/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zookeeper:
     image: zookeeper:3.4

--- a/test/e2e-v2/cases/kafka/meter/docker-compose.yml
+++ b/test/e2e-v2/cases/kafka/meter/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zookeeper:
     image: zookeeper:3.4

--- a/test/e2e-v2/cases/kafka/profile/docker-compose.yml
+++ b/test/e2e-v2/cases/kafka/profile/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zookeeper:
     image: zookeeper:3.4

--- a/test/e2e-v2/cases/kafka/simple-so11y/docker-compose.yml
+++ b/test/e2e-v2/cases/kafka/simple-so11y/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zookeeper:
     image: zookeeper:3.4

--- a/test/e2e-v2/cases/kong/docker-compose.yml
+++ b/test/e2e-v2/cases/kong/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/log/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/log/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/log/es/docker-compose.yml
+++ b/test/e2e-v2/cases/log/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:${ES_VERSION}

--- a/test/e2e-v2/cases/log/es/es-sharding/docker-compose.yml
+++ b/test/e2e-v2/cases/log/es/es-sharding/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:${ES_VERSION}

--- a/test/e2e-v2/cases/log/fluent-bit/docker-compose.yml
+++ b/test/e2e-v2/cases/log/fluent-bit/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:${ES_VERSION}

--- a/test/e2e-v2/cases/log/log-base-compose.yml
+++ b/test/e2e-v2/cases/log/log-base-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/log/mysql/docker-compose.yml
+++ b/test/e2e-v2/cases/log/mysql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   mysql:
     image: mysql/mysql-server:8.0.13

--- a/test/e2e-v2/cases/log/postgres/docker-compose.yml
+++ b/test/e2e-v2/cases/log/postgres/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   postgres:
     image: postgres:13

--- a/test/e2e-v2/cases/logql/docker-compose.yml
+++ b/test/e2e-v2/cases/logql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/lua/docker-compose.yml
+++ b/test/e2e-v2/cases/lua/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/mariadb/mariadb-slowsql/docker-compose.yaml
+++ b/test/e2e-v2/cases/mariadb/mariadb-slowsql/docker-compose.yaml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/menu/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/menu/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/menu/es/docker-compose.yml
+++ b/test/e2e-v2/cases/menu/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/menu/es/es-sharding/docker-compose.yml
+++ b/test/e2e-v2/cases/menu/es/es-sharding/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/menu/mysql/docker-compose.yml
+++ b/test/e2e-v2/cases/menu/mysql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   mysql:
     image: mysql/mysql-server:8.0.13

--- a/test/e2e-v2/cases/menu/opensearch/docker-compose.yml
+++ b/test/e2e-v2/cases/menu/opensearch/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   opensearch:
     image: opensearchproject/opensearch:${OPENSEARCH_VERSION}

--- a/test/e2e-v2/cases/menu/postgres/docker-compose.yml
+++ b/test/e2e-v2/cases/menu/postgres/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   postgres:
     image: postgres:13

--- a/test/e2e-v2/cases/meter/docker-compose.yml
+++ b/test/e2e-v2/cases/meter/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     environment:

--- a/test/e2e-v2/cases/mongodb/docker-compose.yml
+++ b/test/e2e-v2/cases/mongodb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/mqe/docker-compose.yml
+++ b/test/e2e-v2/cases/mqe/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/mysql/mysql-slowsql/docker-compose.yaml
+++ b/test/e2e-v2/cases/mysql/mysql-slowsql/docker-compose.yaml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/nginx/docker-compose.yml
+++ b/test/e2e-v2/cases/nginx/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/nodejs/docker-compose.yml
+++ b/test/e2e-v2/cases/nodejs/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/otlp-traces/docker-compose.yml
+++ b/test/e2e-v2/cases/otlp-traces/docker-compose.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.9'
 x-default-logging: &logging
   driver: "json-file"
   options:

--- a/test/e2e-v2/cases/otlp-virtual-genai/docker-compose.yml
+++ b/test/e2e-v2/cases/otlp-virtual-genai/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3"
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/php/docker-compose.yml
+++ b/test/e2e-v2/cases/php/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/postgresql/postgres-exporter/docker-compose.yml
+++ b/test/e2e-v2/cases/postgresql/postgres-exporter/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/profiling/async-profiler/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/async-profiler/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/profiling/async-profiler/es/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/async-profiler/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/profiling/async-profiler/mysql/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/async-profiler/mysql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   mysql:
     image: mysql/mysql-server:8.0.13

--- a/test/e2e-v2/cases/profiling/pprof/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/pprof/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/profiling/pprof/es/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/pprof/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/profiling/pprof/mysql/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/pprof/mysql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   mysql:
     image: mysql/mysql-server:8.0.13

--- a/test/e2e-v2/cases/profiling/trace/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/profiling/trace/es/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/profiling/trace/es/es-sharding/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/es/es-sharding/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/profiling/trace/go/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/go/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/profiling/trace/mysql/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/mysql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   mysql:
     image: mysql/mysql-server:8.0.13

--- a/test/e2e-v2/cases/profiling/trace/opensearch/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/opensearch/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   opensearch:
     image: opensearchproject/opensearch:${OPENSEARCH_VERSION}

--- a/test/e2e-v2/cases/profiling/trace/postgres/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/postgres/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   postgres:
     image: postgres:13

--- a/test/e2e-v2/cases/promql/docker-compose.yml
+++ b/test/e2e-v2/cases/promql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:
@@ -60,7 +58,5 @@ services:
       service: banyandb
     ports:
       - 17912
-
-
 networks:
   e2e:

--- a/test/e2e-v2/cases/pulsar/docker-compose.yml
+++ b/test/e2e-v2/cases/pulsar/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/python/docker-compose.yml
+++ b/test/e2e-v2/cases/python/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zookeeper:
     image: zookeeper:3.4
@@ -155,8 +153,6 @@ services:
       timeout: 60s
       retries: 120
     entrypoint: ['python3', '/provider-kafka.py']
-
-
   consumer-py:
     build:
       context: .

--- a/test/e2e-v2/cases/rabbitmq/docker-compose.yml
+++ b/test/e2e-v2/cases/rabbitmq/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/redis/redis-exporter/docker-compose.yml
+++ b/test/e2e-v2/cases/redis/redis-exporter/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/rocketmq/docker-compose.yml
+++ b/test/e2e-v2/cases/rocketmq/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3"
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/satellite/native-protocols/docker-compose.yml
+++ b/test/e2e-v2/cases/satellite/native-protocols/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
 
   etcd:

--- a/test/e2e-v2/cases/simple/auth/docker-compose.yml
+++ b/test/e2e-v2/cases/simple/auth/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/simple/jdk/docker-compose.yml
+++ b/test/e2e-v2/cases/simple/jdk/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/simple/mtls/docker-compose.yml
+++ b/test/e2e-v2/cases/simple/mtls/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/simple/ssl/docker-compose.yml
+++ b/test/e2e-v2/cases/simple/ssl/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/so11y/docker-compose.yml
+++ b/test/e2e-v2/cases/so11y/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/storage/banyandb/data-generate/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/banyandb/data-generate/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     image: "ghcr.io/apache/skywalking-banyandb:${SW_BANYANDB_COMMIT}"

--- a/test/e2e-v2/cases/storage/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/storage/banyandb/stages/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/banyandb/stages/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   data-hot1:
     extends:
@@ -114,4 +112,3 @@ services:
 
 networks:
   e2e:
-

--- a/test/e2e-v2/cases/storage/banyandb/tls/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/banyandb/tls/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/storage/es/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:${ES_VERSION}

--- a/test/e2e-v2/cases/storage/es/es-sharding/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/es/es-sharding/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/storage/mysql/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/mysql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   mysql:
     image: mysql/mysql-server:8.0.13

--- a/test/e2e-v2/cases/storage/opensearch/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/opensearch/docker-compose.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2.1"
 services:
   opensearch:
     image: opensearchproject/opensearch:${OPENSEARCH_VERSION}

--- a/test/e2e-v2/cases/storage/postgres/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/postgres/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   postgres:
     image: postgres:13

--- a/test/e2e-v2/cases/traceql/skywalking/docker-compose.yml
+++ b/test/e2e-v2/cases/traceql/skywalking/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/traceql/zipkin/docker-compose.yml
+++ b/test/e2e-v2/cases/traceql/zipkin/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     extends:
@@ -77,4 +75,3 @@ services:
 
 networks:
   e2e:
-

--- a/test/e2e-v2/cases/ttl/es/docker-compose.yml
+++ b/test/e2e-v2/cases/ttl/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:${ES_VERSION}

--- a/test/e2e-v2/cases/virtual-genai/docker-compose.yml
+++ b/test/e2e-v2/cases/virtual-genai/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3"
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/virtual-mq/docker-compose.yml
+++ b/test/e2e-v2/cases/virtual-mq/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/vm/prometheus-node-exporter/docker-compose.yml
+++ b/test/e2e-v2/cases/vm/prometheus-node-exporter/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/vm/telegraf/docker-compose.yml
+++ b/test/e2e-v2/cases/vm/telegraf/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/vm/zabbix/docker-compose.yml
+++ b/test/e2e-v2/cases/vm/zabbix/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/win/docker-compose.yml
+++ b/test/e2e-v2/cases/win/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/zipkin-virtual-genai/docker-compose.yml
+++ b/test/e2e-v2/cases/zipkin-virtual-genai/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3"
-
 services:
   oap:
     extends:

--- a/test/e2e-v2/cases/zipkin/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/zipkin/banyandb/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   banyandb:
     extends:

--- a/test/e2e-v2/cases/zipkin/docker-compose-brave.yml
+++ b/test/e2e-v2/cases/zipkin/docker-compose-brave.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   frontend:
     image: ghcr.io/openzipkin/brave-example:armeria

--- a/test/e2e-v2/cases/zipkin/es/docker-compose.yml
+++ b/test/e2e-v2/cases/zipkin/es/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/zipkin/es/es-sharding/docker-compose.yml
+++ b/test/e2e-v2/cases/zipkin/es/es-sharding/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   es:
     image: elastic/elasticsearch:8.18.8

--- a/test/e2e-v2/cases/zipkin/kafka/docker-compose.yml
+++ b/test/e2e-v2/cases/zipkin/kafka/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   zookeeper:
     image: zookeeper:3.4

--- a/test/e2e-v2/cases/zipkin/mysql/docker-compose.yml
+++ b/test/e2e-v2/cases/zipkin/mysql/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   mysql:
     image: mysql/mysql-server:8.0.13

--- a/test/e2e-v2/cases/zipkin/opensearch/docker-compose.yml
+++ b/test/e2e-v2/cases/zipkin/opensearch/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   opensearch:
     image: opensearchproject/opensearch:1.2.0

--- a/test/e2e-v2/cases/zipkin/postgres/docker-compose.yml
+++ b/test/e2e-v2/cases/zipkin/postgres/docker-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   postgres:
     image: postgres:13

--- a/test/e2e-v2/script/docker-compose/base-compose.yml
+++ b/test/e2e-v2/script/docker-compose/base-compose.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
-
 services:
   oap:
     image: skywalking/oap:latest


### PR DESCRIPTION
### Adopt infra-e2e testcontainers-go v0.42.0 migration

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).

**Changes:**
- Bump `skywalking-infra-e2e` to `530f997` (merged apache/skywalking-infra-e2e#146), which migrates
  testcontainers-go from v0.11.1 to v0.42.0, using Docker Compose v2 plugin natively and removing
  docker-compose v1 dependency.
- Remove deprecated `version` field from all docker-compose files (Compose v2 ignores it with a warning).

**What the infra-e2e change does:**
- Migrates testcontainers-go v0.11.1 → v0.42.0, using native `compose.NewDockerComposeWith` API
- Deletes ~686 lines of custom `DockerContainer`/`DockerProvider` reimplementation
- Removes docker-compose v1 binary installation from CI `action.yaml`
- Adds TCP port waiting after `docker compose up -d` (matching old behavior)
- Restores `DOCKER_API_VERSION` negotiation for Docker 29+ compatibility
- User-facing contract (e2e.yaml format, env vars, log paths, CLI) is preserved

**Compatibility:**
- `extends` in compose files: supported since Compose v2.20.0 ✓
- `depends_on` with `condition: service_healthy`: supported natively in Compose v2 ✓
- GitHub Actions `ubuntu-latest` and `ubuntu-24.04` both ship Docker with Compose v2 plugin ✓