### PR TITLE
Fix Virtual GenAI e2e test 404 due to Spring AI SDK change

### DIFF
--- a/test/e2e-v2/cases/virtual-genai/docker-compose.yml
+++ b/test/e2e-v2/cases/virtual-genai/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - e2e
     environment:
       OPENAI_API_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-      SPRING_AI_OPENAI_BASE_URL: http://provider:9090/llm
+      SPRING_AI_OPENAI_BASE_URL: http://provider:9090/llm/v1
       SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
       SW_LOGGING_OUTPUT: CONSOLE
       SW_AGENT_NAME: e2e-spring-ai


### PR DESCRIPTION
### Fix Virtual GenAI e2e test failure (HTTP 500 / 404)
- [x] Explain briefly why the bug exists and how to fix it.

The `spring-ai-examples` e2e service depends on Spring AI `2.0.0-SNAPSHOT`, which recently switched from its own REST client to the official `openai-java` SDK (v4.28.0). The old client appended `/v1/chat/completions` to the base URL; the new SDK appends only `/chat/completions` (it expects `/v1` to be part of the base URL).

With `SPRING_AI_OPENAI_BASE_URL=http://provider:9090/llm`, requests now go to `/llm/chat/completions` instead of `/llm/v1/chat/completions`, resulting in 404 from the mock provider (which causes the spring-ai-examples app to return 500).

**Fix:** Change the base URL to `http://provider:9090/llm/v1`.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).