### PR TITLE
Add unit tests for Elasticsearch profiling query DAOs

### DIFF
--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AsyncProfilerTaskLogQueryEsDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AsyncProfilerTaskLogQueryEsDAOTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.skywalking.library.elasticsearch.requests.search.Search;
+import org.apache.skywalking.library.elasticsearch.response.search.SearchResponse;
+import org.apache.skywalking.oap.server.core.profiling.asyncprofiler.storage.AsyncProfilerTaskLogRecord;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.IndexController;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AsyncProfilerTaskLogQueryEsDAOTest {
+
+    @Mock
+    private ElasticSearchClient client;
+
+    private AsyncProfilerTaskLogQueryEsDAO dao;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dao = new AsyncProfilerTaskLogQueryEsDAO(client, 100);
+        registerMergedTable(AsyncProfilerTaskLogRecord.INDEX_NAME, "records-all");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        removeMergedTable(AsyncProfilerTaskLogRecord.INDEX_NAME);
+    }
+
+    @Test
+    void getTaskLogList_inMergedTable_shouldIncludeTableNameAndTaskIdFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getTaskLogList("task-id-1");
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME);
+        assertThat(json).contains(AsyncProfilerTaskLogRecord.INDEX_NAME);
+        assertThat(json).contains(AsyncProfilerTaskLogRecord.TASK_ID);
+    }
+
+    @Test
+    void getTaskLogList_shouldIncludeSortByOperationTimeDesc() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getTaskLogList("task-id-1");
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(AsyncProfilerTaskLogRecord.OPERATION_TIME);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerMergedTable(String logicName, String physicalName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).put(logicName, physicalName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void removeMergedTable(String logicName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).remove(logicName);
+    }
+}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AsyncProfilerTaskQueryEsDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AsyncProfilerTaskQueryEsDAOTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.skywalking.library.elasticsearch.requests.search.Search;
+import org.apache.skywalking.library.elasticsearch.response.search.SearchResponse;
+import org.apache.skywalking.oap.server.core.profiling.asyncprofiler.storage.AsyncProfilerTaskRecord;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.IndexController;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AsyncProfilerTaskQueryEsDAOTest {
+
+    @Mock
+    private ElasticSearchClient client;
+
+    private AsyncProfilerTaskQueryEsDAO dao;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dao = new AsyncProfilerTaskQueryEsDAO(client, 100);
+        registerMergedTable(AsyncProfilerTaskRecord.INDEX_NAME, "records-all");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        removeMergedTable(AsyncProfilerTaskRecord.INDEX_NAME);
+    }
+
+    @Test
+    void getTaskList_inMergedTable_shouldIncludeTableNameFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getTaskList(null, null, null, null);
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME);
+        assertThat(json).contains(AsyncProfilerTaskRecord.INDEX_NAME);
+    }
+
+    @Test
+    void getTaskList_withServiceId_shouldIncludeServiceIdFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getTaskList("svc-1", null, null, null);
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(AsyncProfilerTaskRecord.SERVICE_ID);
+    }
+
+    @Test
+    void getById_inMergedTable_shouldIncludeTableNameAndTaskIdFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getById("task-id-1");
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME);
+        assertThat(json).contains(AsyncProfilerTaskRecord.INDEX_NAME);
+        assertThat(json).contains(AsyncProfilerTaskRecord.TASK_ID);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerMergedTable(String logicName, String physicalName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).put(logicName, physicalName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void removeMergedTable(String logicName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).remove(logicName);
+    }
+}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/JFRDataQueryEsDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/JFRDataQueryEsDAOTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.skywalking.library.elasticsearch.requests.search.Search;
+import org.apache.skywalking.library.elasticsearch.response.search.SearchResponse;
+import org.apache.skywalking.oap.server.core.profiling.asyncprofiler.storage.JFRProfilingDataRecord;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.IndexController;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JFRDataQueryEsDAOTest {
+
+    @Mock
+    private ElasticSearchClient client;
+
+    private JFRDataQueryEsDAO dao;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dao = new JFRDataQueryEsDAO(client);
+        registerMergedTable(JFRProfilingDataRecord.INDEX_NAME, "records-all");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        removeMergedTable(JFRProfilingDataRecord.INDEX_NAME);
+    }
+
+    @Test
+    void getByTaskIdAndInstancesAndEvent_inMergedTable_shouldIncludeTableNameFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getByTaskIdAndInstancesAndEvent("task-id-1", Collections.emptyList(), "EXECUTION_SAMPLE");
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME);
+        assertThat(json).contains(JFRProfilingDataRecord.INDEX_NAME);
+        assertThat(json).contains(JFRProfilingDataRecord.TASK_ID);
+        assertThat(json).contains(JFRProfilingDataRecord.EVENT_TYPE);
+    }
+
+    @Test
+    void getByTaskIdAndInstancesAndEvent_withInstanceIds_shouldIncludeInstanceIdFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getByTaskIdAndInstancesAndEvent("task-id-1", Arrays.asList("inst-1", "inst-2"), "EXECUTION_SAMPLE");
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(JFRProfilingDataRecord.INSTANCE_ID);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerMergedTable(String logicName, String physicalName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).put(logicName, physicalName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void removeMergedTable(String logicName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).remove(logicName);
+    }
+}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/PprofTaskLogQueryEsDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/PprofTaskLogQueryEsDAOTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.skywalking.library.elasticsearch.requests.search.Search;
+import org.apache.skywalking.library.elasticsearch.response.search.SearchResponse;
+import org.apache.skywalking.oap.server.core.profiling.pprof.storage.PprofTaskLogRecord;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.IndexController;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PprofTaskLogQueryEsDAOTest {
+
+    @Mock
+    private ElasticSearchClient client;
+
+    private PprofTaskLogQueryEsDAO dao;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dao = new PprofTaskLogQueryEsDAO(client, 100);
+        registerMergedTable(PprofTaskLogRecord.INDEX_NAME, "records-all");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        removeMergedTable(PprofTaskLogRecord.INDEX_NAME);
+    }
+
+    @Test
+    void getTaskLogList_inMergedTable_shouldIncludeTableNameAndTaskIdFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getTaskLogList("task-id-1");
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME);
+        assertThat(json).contains(PprofTaskLogRecord.INDEX_NAME);
+        assertThat(json).contains(PprofTaskLogRecord.TASK_ID);
+    }
+
+    @Test
+    void getTaskLogList_shouldIncludeSortByOperationTimeDesc() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getTaskLogList("task-id-1");
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(PprofTaskLogRecord.OPERATION_TIME);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerMergedTable(String logicName, String physicalName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).put(logicName, physicalName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void removeMergedTable(String logicName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).remove(logicName);
+    }
+}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/PprofTaskQueryEsDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/PprofTaskQueryEsDAOTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.skywalking.library.elasticsearch.requests.search.Search;
+import org.apache.skywalking.library.elasticsearch.response.search.SearchResponse;
+import org.apache.skywalking.oap.server.core.profiling.pprof.storage.PprofTaskRecord;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.IndexController;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PprofTaskQueryEsDAOTest {
+
+    @Mock
+    private ElasticSearchClient client;
+
+    private PprofTaskQueryEsDAO dao;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dao = new PprofTaskQueryEsDAO(client, 100);
+        registerMergedTable(PprofTaskRecord.INDEX_NAME, "records-all");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        removeMergedTable(PprofTaskRecord.INDEX_NAME);
+    }
+
+    @Test
+    void getTaskList_inMergedTable_shouldIncludeTableNameFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getTaskList(null, null, null, null);
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME);
+        assertThat(json).contains(PprofTaskRecord.INDEX_NAME);
+    }
+
+    @Test
+    void getTaskList_withServiceId_shouldIncludeServiceIdFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getTaskList("svc-1", null, null, null);
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(PprofTaskRecord.SERVICE_ID);
+    }
+
+    @Test
+    void getById_inMergedTable_shouldIncludeTableNameAndTaskIdFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class))).thenReturn(new SearchResponse());
+
+        dao.getById("task-id-1");
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture());
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME);
+        assertThat(json).contains(PprofTaskRecord.INDEX_NAME);
+        assertThat(json).contains(PprofTaskRecord.TASK_ID);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerMergedTable(String logicName, String physicalName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).put(logicName, physicalName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void removeMergedTable(String logicName) throws Exception {
+        final Field field = IndexController.LogicIndicesRegister.class.getDeclaredField("LOGIC_INDICES_CATALOG");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(null)).remove(logicName);
+    }
+}


### PR DESCRIPTION
## What

Add unit test coverage for the `isMergedTable` guard condition and query construction in five Elasticsearch profiling query DAOs:

- `AsyncProfilerTaskQueryEsDAO` — `getTaskList()` with merged table filter and `serviceId` filter, `getById()` with merged table + `TASK_ID` filter
- `AsyncProfilerTaskLogQueryEsDAO` — `getTaskLogList()` with merged table, `TASK_ID` filter, and sort by `OPERATION_TIME`
- `PprofTaskQueryEsDAO` — `getTaskList()` with merged table and `serviceId`, `getById()` with merged table + `TASK_ID`
- `PprofTaskLogQueryEsDAO` — `getTaskLogList()` with merged table, `TASK_ID`, and sort
- `JFRDataQueryEsDAO` — `getByTaskIdAndInstancesAndEvent()` with merged table, `TASK_ID`, `EVENT_TYPE`, and optional `INSTANCE_ID` filter

## Why

When `logicSharding=false` (default in single-node deployments), all Record-type tables are merged into a single `records-all` physical index. Each query must include a `TABLE_COLUMN`/`RECORD_TABLE_NAME` filter to scope results to the correct logical table. These tests verify that the guard condition (`isMergedTable`) and the filter are wired correctly.

This follows the pattern established in `ProfileTaskQueryEsDAOTest` (introduced alongside the `ProfileTaskQueryEsDAO.getById()` fix).

## How the tests work

1. The `LOGIC_INDICES_CATALOG` static map in `IndexController.LogicIndicesRegister` is populated via reflection to simulate `logicSharding=false` for each DAO's index.
2. `ElasticSearchClient` is mocked; `ArgumentCaptor<Search>` captures the query sent to ES.
3. The captured `Search` object is serialized to JSON via Jackson and asserted to contain the expected field names.