### PR TITLE
Fix 'seperated' typo in apm-webapp application.yml comment

### DIFF
--- a/apm-webapp/src/main/resources/application.yml
+++ b/apm-webapp/src/main/resources/application.yml
@@ -16,7 +16,7 @@
 
 serverPort: ${SW_SERVER_PORT:-8080}
 
-# Comma seperated list of OAP addresses.
+# Comma separated list of OAP addresses.
 oapServices: ${SW_OAP_ADDRESS:-http://localhost:12800}
 
 zipkinServices: ${SW_ZIPKIN_ADDRESS:-http://localhost:9412}


### PR DESCRIPTION
Comment-only fix in `apm-webapp/src/main/resources/application.yml`:

`Comma seperated list of OAP addresses.` -> `Comma separated list of OAP addresses.`