### PR TITLE
Support OTLP/HTTP receiver for traces, logs, and metrics

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -769,7 +769,7 @@ jobs:
         if: matrix.test.docker != null
         run: docker build -t ${{ matrix.test.docker.name }} -f ${{ matrix.test.docker.base }}/${{ matrix.test.docker.file }} ${{ matrix.test.docker.base }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
+        uses: apache/skywalking-infra-e2e@0d91769411db83f6329633df810a36c6ea1a9b02
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}
@@ -843,7 +843,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ALS ${{ matrix.storage }}, ${{ matrix.analyzer }}, istio-${{ matrix.versions.istio }}, k8s-${{ matrix.versions.kubernetes }}
-        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
+        uses: apache/skywalking-infra-e2e@0d91769411db83f6329633df810a36c6ea1a9b02
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -915,7 +915,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
+        uses: apache/skywalking-infra-e2e@0d91769411db83f6329633df810a36c6ea1a9b02
         env:
           ISTIO_VERSION: ${{ matrix.versions.istio }}
           KUBERNETES_VERSION: ${{ matrix.versions.kubernetes }}
@@ -979,7 +979,7 @@ jobs:
         shell: bash
         run: ./mvnw -B -q -f test/e2e-v2/java-test-service/pom.xml clean package
       - name: Java version ${{ matrix.java-version }}
-        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
+        uses: apache/skywalking-infra-e2e@0d91769411db83f6329633df810a36c6ea1a9b02
         env:
           SW_AGENT_JDK_VERSION: ${{ matrix.java-version }}
         with:
@@ -1075,7 +1075,7 @@ jobs:
           fi
           docker compose -f ${BANYANDB_DATA_GENERATE_ROOT}/docker-compose.yml down -v
       - name: ${{ matrix.test.name }}
-        uses: apache/skywalking-infra-e2e@530f9976e4bf12b65a6604ea0efbeafabeeea2a3
+        uses: apache/skywalking-infra-e2e@0d91769411db83f6329633df810a36c6ea1a9b02
         with:
           e2e-file: $GITHUB_WORKSPACE/${{ matrix.test.config }}
       - if: ${{ failure() }}

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -28,6 +28,7 @@
 * LAL: add `sourceAttribute()` function for non-persistent OTLP resource attribute access in LAL scripts.
 * LAL: add `layer: auto` mode for dynamic layer assignment when `service.layer` is absent.
 * Add two-phase `SpanListener` SPI mechanism for extensible trace span processing. Refactor GenAI from hardcoded `SpanForward.processGenAILogic()` to `GenAISpanListener`.
+* Add OTLP/HTTP receiver support for traces, logs, and metrics (`/v1/traces`, `/v1/logs`, `/v1/metrics`). Supports both `application/x-protobuf` and `application/json` content types.
 
 #### UI
 

--- a/docs/en/setup/backend/otlp-trace.md
+++ b/docs/en/setup/backend/otlp-trace.md
@@ -1,9 +1,21 @@
 # OpenTelemetry Trace Format
 
-SkyWalking can receive traces from Traces in OTLP format and convert them to Zipkin Trace format eventually. 
+SkyWalking can receive traces in OTLP format and convert them to Zipkin Trace format eventually.
 For data analysis and queries related to Zipkin Trace, please [refer to the relevant documentation](./zipkin-trace.md#zipkin-query).
 
 OTLP Trace handler references the [Zipkin Exporter in the OpenTelemetry Collector](https://opentelemetry.io/docs/specs/otel/trace/sdk_exporters/zipkin/#summary) to convert the data format.
+
+## Supported Protocols
+
+Both **OTLP/gRPC** and **OTLP/HTTP** are supported for traces, logs, and metrics:
+
+| Signal  | OTLP/gRPC (port 11800)       | OTLP/HTTP (port 12800)  |
+|---------|------------------------------|-------------------------|
+| Traces  | gRPC `TraceService/Export`    | `POST /v1/traces`       |
+| Logs    | gRPC `LogsService/Export`     | `POST /v1/logs`         |
+| Metrics | gRPC `MetricsService/Export`  | `POST /v1/metrics`      |
+
+OTLP/HTTP supports both `application/x-protobuf` and `application/json` content types.
 
 ## Set up backend receiver
 

--- a/oap-server/server-receiver-plugin/aws-firehose-receiver/src/main/java/org/apache/skywalking/oap/server/receiver/aws/firehose/FirehoseHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/aws-firehose-receiver/src/main/java/org/apache/skywalking/oap/server/receiver/aws/firehose/FirehoseHTTPHandler.java
@@ -19,6 +19,7 @@ package org.apache.skywalking.oap.server.receiver.aws.firehose;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.annotation.Blocking;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.ConsumesJson;
 import com.linecorp.armeria.server.annotation.Default;
@@ -35,6 +36,7 @@ import org.apache.skywalking.oap.server.receiver.otel.otlp.OpenTelemetryMetricRe
 
 @Slf4j
 @AllArgsConstructor
+@Blocking
 public class FirehoseHTTPHandler {
     private final OpenTelemetryMetricRequestProcessor openTelemetryMetricRequestProcessor;
     private final String firehoseAccessKey;

--- a/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryLogHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryLogHTTPHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.oap.server.receiver.otel.otlp;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.annotation.Blocking;
+import com.linecorp.armeria.server.annotation.Consumes;
+import com.linecorp.armeria.server.annotation.ConsumesJson;
+import com.linecorp.armeria.server.annotation.Post;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * OTLP/HTTP handler for log data. Supports both protobuf and JSON encoding.
+ * Delegates processing to {@link OpenTelemetryLogHandler#processExport}.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class OpenTelemetryLogHTTPHandler {
+    private static final byte[] EMPTY_RESPONSE =
+        ExportLogsServiceResponse.getDefaultInstance().toByteArray();
+
+    private final OpenTelemetryLogHandler logHandler;
+
+    @Blocking
+    @Post("/v1/logs")
+    @Consumes("application/x-protobuf")
+    public HttpResponse collectProtobuf(AggregatedHttpRequest request) {
+        try {
+            final ExportLogsServiceRequest exportRequest =
+                ExportLogsServiceRequest.parseFrom(request.content().array());
+            logHandler.processExport(exportRequest);
+            return HttpResponse.of(HttpStatus.OK, MediaType.PROTOBUF, EMPTY_RESPONSE);
+        } catch (InvalidProtocolBufferException e) {
+            log.warn("Failed to parse OTLP/HTTP log request", e);
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            log.error("Failed to process OTLP/HTTP log request", e);
+            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Blocking
+    @Post("/v1/logs")
+    @ConsumesJson
+    public HttpResponse collectJson(AggregatedHttpRequest request) {
+        try {
+            final ExportLogsServiceRequest.Builder builder =
+                ExportLogsServiceRequest.newBuilder();
+            JsonFormat.parser().ignoringUnknownFields().merge(
+                request.contentUtf8(), builder);
+            logHandler.processExport(builder.build());
+            return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, "{}");
+        } catch (InvalidProtocolBufferException e) {
+            log.warn("Failed to parse OTLP/HTTP JSON log request", e);
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            log.error("Failed to process OTLP/HTTP JSON log request", e);
+            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryLogHandler.java
+++ b/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryLogHandler.java
@@ -36,7 +36,10 @@ import org.apache.skywalking.apm.network.logging.v3.TextLog;
 import org.apache.skywalking.oap.server.core.source.LogMetadataUtils;
 import org.apache.skywalking.oap.log.analyzer.v2.module.LogAnalyzerModule;
 import org.apache.skywalking.oap.log.analyzer.v2.provider.log.ILogAnalyzerService;
+import com.linecorp.armeria.common.HttpMethod;
+import java.util.Collections;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
+import org.apache.skywalking.oap.server.core.server.HTTPHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
 import org.apache.skywalking.oap.server.receiver.otel.Handler;
@@ -88,10 +91,26 @@ public class OpenTelemetryLogHandler
                                                          .provider()
                                                          .getService(GRPCHandlerRegister.class);
         grpcHandlerRegister.addHandler(this);
+
+        HTTPHandlerRegister httpHandlerRegister = manager.find(SharingServerModule.NAME)
+                                                         .provider()
+                                                         .getService(HTTPHandlerRegister.class);
+        httpHandlerRegister.addHandler(
+            new OpenTelemetryLogHTTPHandler(this),
+            Collections.singletonList(HttpMethod.POST));
     }
 
     @Override
     public void export(ExportLogsServiceRequest request, StreamObserver<ExportLogsServiceResponse> responseObserver) {
+        processExport(request);
+        responseObserver.onNext(ExportLogsServiceResponse.getDefaultInstance());
+        responseObserver.onCompleted();
+    }
+
+    /**
+     * Process an OTLP log export request. Shared by both gRPC and HTTP handlers.
+     */
+    void processExport(ExportLogsServiceRequest request) {
         request.getResourceLogsList().forEach(resourceLogs -> {
             final var resource = resourceLogs.getResource();
             final var attributes = resource
@@ -122,8 +141,6 @@ public class OpenTelemetryLogHandler
                     }
                 });
         });
-        responseObserver.onNext(ExportLogsServiceResponse.getDefaultInstance());
-        responseObserver.onCompleted();
     }
 
     private void doAnalysisQuietly(String service, String layer, String serviceInstance,

--- a/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricHTTPHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.oap.server.receiver.otel.otlp;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.annotation.Blocking;
+import com.linecorp.armeria.server.annotation.Consumes;
+import com.linecorp.armeria.server.annotation.ConsumesJson;
+import com.linecorp.armeria.server.annotation.Post;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * OTLP/HTTP handler for metric data. Supports both protobuf and JSON encoding.
+ * Delegates processing to {@link OpenTelemetryMetricRequestProcessor#processMetricsRequest}.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class OpenTelemetryMetricHTTPHandler {
+    private static final byte[] EMPTY_RESPONSE =
+        ExportMetricsServiceResponse.getDefaultInstance().toByteArray();
+
+    private final OpenTelemetryMetricRequestProcessor metricProcessor;
+
+    @Blocking
+    @Post("/v1/metrics")
+    @Consumes("application/x-protobuf")
+    public HttpResponse collectProtobuf(AggregatedHttpRequest request) {
+        try {
+            final ExportMetricsServiceRequest exportRequest =
+                ExportMetricsServiceRequest.parseFrom(request.content().array());
+            metricProcessor.processMetricsRequest(exportRequest);
+            return HttpResponse.of(HttpStatus.OK, MediaType.PROTOBUF, EMPTY_RESPONSE);
+        } catch (InvalidProtocolBufferException e) {
+            log.warn("Failed to parse OTLP/HTTP metric request", e);
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            log.error("Failed to process OTLP/HTTP metric request", e);
+            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Blocking
+    @Post("/v1/metrics")
+    @ConsumesJson
+    public HttpResponse collectJson(AggregatedHttpRequest request) {
+        try {
+            final ExportMetricsServiceRequest.Builder builder =
+                ExportMetricsServiceRequest.newBuilder();
+            JsonFormat.parser().ignoringUnknownFields().merge(
+                request.contentUtf8(), builder);
+            metricProcessor.processMetricsRequest(builder.build());
+            return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, "{}");
+        } catch (InvalidProtocolBufferException e) {
+            log.warn("Failed to parse OTLP/HTTP JSON metric request", e);
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            log.error("Failed to process OTLP/HTTP JSON metric request", e);
+            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricHandler.java
+++ b/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryMetricHandler.java
@@ -23,7 +23,10 @@ import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
 import lombok.extern.slf4j.Slf4j;
+import com.linecorp.armeria.common.HttpMethod;
+import java.util.Collections;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
+import org.apache.skywalking.oap.server.core.server.HTTPHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
 import org.apache.skywalking.oap.server.receiver.otel.Handler;
@@ -58,6 +61,13 @@ public class OpenTelemetryMetricHandler
                                                          .provider()
                                                          .getService(GRPCHandlerRegister.class);
         grpcHandlerRegister.addHandler(this);
+
+        HTTPHandlerRegister httpHandlerRegister = manager.find(SharingServerModule.NAME)
+                                                         .provider()
+                                                         .getService(HTTPHandlerRegister.class);
+        httpHandlerRegister.addHandler(
+            new OpenTelemetryMetricHTTPHandler(metricRequestProcessor),
+            Collections.singletonList(HttpMethod.POST));
     }
 
     @Override

--- a/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryTraceHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryTraceHTTPHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.oap.server.receiver.otel.otlp;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.annotation.Blocking;
+import com.linecorp.armeria.server.annotation.Consumes;
+import com.linecorp.armeria.server.annotation.ConsumesJson;
+import com.linecorp.armeria.server.annotation.Post;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * OTLP/HTTP handler for trace data. Supports both protobuf and JSON encoding.
+ * Delegates processing to {@link OpenTelemetryTraceHandler#processExport}.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class OpenTelemetryTraceHTTPHandler {
+    private static final byte[] EMPTY_RESPONSE =
+        ExportTraceServiceResponse.getDefaultInstance().toByteArray();
+
+    private final OpenTelemetryTraceHandler traceHandler;
+
+    @Blocking
+    @Post("/v1/traces")
+    @Consumes("application/x-protobuf")
+    public HttpResponse collectProtobuf(AggregatedHttpRequest request) {
+        try {
+            final ExportTraceServiceRequest exportRequest =
+                ExportTraceServiceRequest.parseFrom(request.content().array());
+            traceHandler.processExport(exportRequest);
+            return HttpResponse.of(HttpStatus.OK, MediaType.PROTOBUF, EMPTY_RESPONSE);
+        } catch (InvalidProtocolBufferException e) {
+            log.warn("Failed to parse OTLP/HTTP trace request", e);
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            log.error("Failed to process OTLP/HTTP trace request", e);
+            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Blocking
+    @Post("/v1/traces")
+    @ConsumesJson
+    public HttpResponse collectJson(AggregatedHttpRequest request) {
+        try {
+            final ExportTraceServiceRequest.Builder builder =
+                ExportTraceServiceRequest.newBuilder();
+            JsonFormat.parser().ignoringUnknownFields().merge(
+                request.contentUtf8(), builder);
+            traceHandler.processExport(builder.build());
+            return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, "{}");
+        } catch (InvalidProtocolBufferException e) {
+            log.warn("Failed to parse OTLP/HTTP JSON trace request", e);
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            log.error("Failed to process OTLP/HTTP JSON trace request", e);
+            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryTraceHandler.java
+++ b/oap-server/server-receiver-plugin/otel-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/otel/otlp/OpenTelemetryTraceHandler.java
@@ -35,7 +35,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.trace.SpanListenerManager;
 import org.apache.skywalking.oap.server.core.trace.SpanListenerResult;
+import com.linecorp.armeria.common.HttpMethod;
+import java.util.Collections;
 import org.apache.skywalking.oap.server.core.server.GRPCHandlerRegister;
+import org.apache.skywalking.oap.server.core.server.HTTPHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
 import org.apache.skywalking.oap.server.library.util.StringUtil;
@@ -107,10 +110,26 @@ public class OpenTelemetryTraceHandler
             .provider()
             .getService(GRPCHandlerRegister.class);
         grpcHandlerRegister.addHandler(this);
+
+        HTTPHandlerRegister httpHandlerRegister = manager.find(SharingServerModule.NAME)
+            .provider()
+            .getService(HTTPHandlerRegister.class);
+        httpHandlerRegister.addHandler(
+            new OpenTelemetryTraceHTTPHandler(this),
+            Collections.singletonList(HttpMethod.POST));
     }
 
     @Override
     public void export(ExportTraceServiceRequest request, StreamObserver<ExportTraceServiceResponse> responseObserver) {
+        processExport(request);
+        responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
+        responseObserver.onCompleted();
+    }
+
+    /**
+     * Process an OTLP trace export request. Shared by both gRPC and HTTP handlers.
+     */
+    void processExport(ExportTraceServiceRequest request) {
         final ArrayList<Span> result = new ArrayList<>();
 
         try (final var unused = getProcessHistogram().createTimer()) {
@@ -167,9 +186,6 @@ public class OpenTelemetryTraceHandler
                 getDroppedSpans().inc(result.size() - processedSpans.size());
             }
         }
-
-        responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
-        responseObserver.onCompleted();
     }
 
     private Span convertSpan(io.opentelemetry.proto.trace.v1.Span span, String serviceName, Map<String, String> resourceTags) {

--- a/oap-server/server-receiver-plugin/skywalking-browser-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/browser/provider/handler/rest/BrowserPerfServiceHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-browser-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/browser/provider/handler/rest/BrowserPerfServiceHTTPHandler.java
@@ -18,6 +18,7 @@
 package org.apache.skywalking.oap.server.receiver.browser.provider.handler.rest;
 
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.Blocking;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.network.common.v3.Commands;
@@ -46,6 +47,7 @@ import org.apache.skywalking.oap.server.telemetry.api.MetricsTag;
  * Collect and process the error log
  */
 @Slf4j
+@Blocking
 public class BrowserPerfServiceHTTPHandler {
     private final ModuleManager moduleManager;
     private final BrowserServiceModuleConfig config;

--- a/oap-server/server-receiver-plugin/skywalking-event-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/event/rest/EventRestServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-event-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/event/rest/EventRestServiceHandler.java
@@ -18,6 +18,7 @@
 package org.apache.skywalking.oap.server.receiver.event.rest;
 
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.Blocking;
 
 import java.util.List;
 
@@ -35,6 +36,7 @@ import org.apache.skywalking.oap.server.telemetry.api.MetricsCreator;
 import org.apache.skywalking.oap.server.telemetry.api.MetricsTag;
 
 @Slf4j
+@Blocking
 public class EventRestServiceHandler {
     private final HistogramMetrics histogram;
 

--- a/oap-server/server-receiver-plugin/skywalking-log-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/log/provider/handler/rest/LogReportServiceHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-log-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/log/provider/handler/rest/LogReportServiceHTTPHandler.java
@@ -18,6 +18,7 @@
 package org.apache.skywalking.oap.server.receiver.log.provider.handler.rest;
 
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.Blocking;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.network.common.v3.Commands;
@@ -33,6 +34,7 @@ import org.apache.skywalking.oap.server.telemetry.api.MetricsCreator;
 import org.apache.skywalking.oap.server.telemetry.api.MetricsTag;
 
 @Slf4j
+@Blocking
 public class LogReportServiceHTTPHandler {
     private final HistogramMetrics histogram;
 

--- a/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/rest/ManagementServiceHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-management-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v8/rest/ManagementServiceHTTPHandler.java
@@ -19,12 +19,14 @@
 package org.apache.skywalking.oap.server.receiver.register.provider.handler.v8.rest;
 
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.Blocking;
 import org.apache.skywalking.apm.network.common.v3.Commands;
 import org.apache.skywalking.apm.network.management.v3.InstancePingPkg;
 import org.apache.skywalking.apm.network.management.v3.InstanceProperties;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.receiver.register.provider.handler.v8.ManagementServiceHandler;
 
+@Blocking
 public class ManagementServiceHTTPHandler {
     private final ManagementServiceHandler handler;
 

--- a/oap-server/server-receiver-plugin/skywalking-telegraf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/telegraf/provider/handler/TelegrafServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-telegraf-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/telegraf/provider/handler/TelegrafServiceHandler.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.oap.server.receiver.telegraf.provider.handler;
 
 import com.google.common.collect.ImmutableMap;
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.Blocking;
 import com.linecorp.armeria.server.annotation.RequestConverter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.network.common.v3.Commands;
@@ -44,6 +45,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
+@Blocking
 public class TelegrafServiceHandler {
 
     private final HistogramMetrics histogram;

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/handler/v8/rest/TraceSegmentReportHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/handler/v8/rest/TraceSegmentReportHandler.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.oap.server.receiver.trace.provider.handler.v8.rest;
 
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.Blocking;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.apm.network.common.v3.Commands;
@@ -33,6 +34,7 @@ import org.apache.skywalking.oap.server.telemetry.api.MetricsCreator;
 import org.apache.skywalking.oap.server.telemetry.api.MetricsTag;
 
 @Slf4j
+@Blocking
 public class TraceSegmentReportHandler {
     private final ISegmentParserService segmentParserService;
     private final HistogramMetrics histogram;

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/ZipkinSpanHTTPHandler.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/ZipkinSpanHTTPHandler.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.oap.server.receiver.zipkin.handler;
 
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.server.annotation.Blocking;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -41,6 +42,7 @@ import zipkin2.codec.SpanBytesDecoder;
 import static java.util.Objects.nonNull;
 
 @Slf4j
+@Blocking
 public class ZipkinSpanHTTPHandler {
     private final HistogramMetrics histogram;
     private final CounterMetrics errorCounter;


### PR DESCRIPTION
### Add OTLP/HTTP endpoints for traces, logs, and metrics

SkyWalking's OTLP receiver previously only supported gRPC. Many OTLP sources prefer or require HTTP:
- The [OTel Swift SDK](https://github.com/open-telemetry/opentelemetry-swift) (iOS monitoring, [SWIP-11](https://github.com/apache/skywalking/discussions/13821)) uses OTLP/HTTP as its primary exporter
- The [SkyAPM Mini Program Monitor](https://github.com/SkyAPM/mini-program-monitor) for WeChat/Alipay mini programs sends telemetry via HTTP
- OTLP/HTTP is simpler and more proxy/firewall-friendly than gRPC for mobile and browser clients

Each existing OTLP gRPC handler now also registers an HTTP handler at startup:

| Endpoint | Content Types |
|----------|--------------|
| `POST /v1/traces` | `application/x-protobuf`, `application/json` |
| `POST /v1/logs` | `application/x-protobuf`, `application/json` |
| `POST /v1/metrics` | `application/x-protobuf`, `application/json` |

Processing logic extracted into shared `processExport()` methods called by both gRPC and HTTP handlers. No new configuration needed — HTTP endpoints are automatically available when the OTLP handler is enabled.

Also bumps infra-e2e to `0d91769` for Ryuk reaper bug fix.

- [x] If this is non-trivial feature, paste the links/URLs to the design doc.
  - SWIP-11: https://github.com/apache/skywalking/discussions/13821
  - OTLP/HTTP spec: https://opentelemetry.io/docs/specs/otlp/#otlphttp
  - SkyAPM Mini Program Monitor: https://github.com/SkyAPM/mini-program-monitor
- [x] Update the documentation to include this new feature.
  - `docs/en/setup/backend/otlp-trace.md` — added OTLP/HTTP protocol table
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).