### PR TITLE
docs: cover BanyanDB 0.10.0 upgrade notes (partial #13777)

### DIFF
--- a/docs/en/banyandb/upgrade-0.10.md
+++ b/docs/en/banyandb/upgrade-0.10.md
@@ -1,0 +1,103 @@
+# Upgrading to BanyanDB 0.10.0
+
+This page summarizes the BanyanDB 0.10.0 changes that affect SkyWalking OAP operators and integrators.
+For the full upstream change list, see the [BanyanDB 0.10.0 release notes](https://github.com/apache/skywalking-banyandb/releases/tag/v0.10.0)
+and the upstream [Upgrading to 0.10](https://skywalking.apache.org/docs/skywalking-banyandb/latest/operation/upgrade/) guide.
+
+## Compatibility
+
+OAP defaults to BanyanDB **API version 0.10**. The compatible API versions are exposed via:
+
+```
+${SW_STORAGE_BANYANDB_COMPATIBLE_SERVER_API_VERSIONS:"0.10"}
+```
+
+The corresponding BanyanDB server release is **0.10.x**. Refer to the
+[API versions mapping](https://skywalking.apache.org/docs/skywalking-banyandb/latest/installation/versions/)
+for the OAP/BanyanDB compatibility matrix.
+
+If the running BanyanDB server reports an incompatible API version, OAP refuses to start with:
+
+```
+... ERROR [] - ... Incompatible BanyanDB server API version: 0.x. But accepted versions: 0.y
+```
+
+## Breaking changes that affect SkyWalking deployments
+
+### 1. Property data on-disk path layout
+
+The on-disk path for property data now includes the group name:
+
+- **Before (0.9.x):** `<data-dir>/property/data/shard-<id>/...`
+- **After (0.10.x):** `<data-dir>/property/data/<group>/shard-<id>/...`
+
+OAP stores UI templates, profiling task metadata and similar items in the BanyanDB `property` group
+(see the `property` block in [bydb.yml](../setup/backend/storages/banyandb.md#configuration)).
+Existing data at the old path is **not** migrated automatically. Operators with persisted property data
+should either:
+
+- accept that the existing property contents will be re-created by OAP after the upgrade
+  (UI templates, async profiler tasks, etc. are re-initialized), or
+- follow the upstream [Upgrading to 0.10](https://skywalking.apache.org/docs/skywalking-banyandb/latest/operation/upgrade/)
+  procedure for any data you need to preserve.
+
+### 2. Node discovery default changed to `none`
+
+The default BanyanDB node discovery mode changed from `etcd` to `none`. **Standalone deployments are unaffected**
+because they do not use node discovery.
+
+For **cluster deployments** (the multi-`liaison`/`data` setup that OAP connects to via the `targets` list in
+[bydb.yml](../setup/backend/storages/banyandb.md#configuration)), every BanyanDB node must now be started
+with an explicit discovery mode, e.g.:
+
+```shell
+banyand data --node-discovery-mode=etcd      # previous default
+banyand data --node-discovery-mode=dns       # Kubernetes-friendly
+banyand data --node-discovery-mode=file      # static configuration
+```
+
+Without this flag, cluster nodes will not discover each other and OAP write/query traffic to the cluster will fail.
+See the upstream [Node Discovery](https://skywalking.apache.org/docs/skywalking-banyandb/latest/operation/node-discovery/)
+guide for the full list of modes and flags.
+
+### 3. Windows binaries no longer shipped
+
+BanyanDB 0.10.0 releases no longer ship Windows binaries or Docker images. SkyWalking deployments running BanyanDB
+on Windows must build BanyanDB from source. Linux and macOS deployments are unaffected.
+
+## Behavioral changes worth knowing
+
+### Property background repair on by default
+
+BanyanDB 0.10.0 enables the property background repair mechanism by default. This automatically repairs inconsistent
+property data across nodes via a gossip protocol. No SkyWalking-side configuration change is required.
+The mechanism can be tuned/disabled via BanyanDB-side flags such as `--property-repair-enabled`,
+`--property-repair-cron` and `--property-repair-history-days`. See the upstream
+[Property Repair](https://skywalking.apache.org/docs/skywalking-banyandb/latest/operation/property-repair/) guide.
+
+### Stream element IDs
+
+BanyanDB 0.10.0 generates `element_id` server-side when omitted, and deduplicates stream query results by
+`element_id`. SkyWalking writes (logs, segments, browser error logs, etc.) continue to work without changes;
+the change reduces duplicate rows that can otherwise appear under retry or replay scenarios.
+
+### Distributed measure aggregation
+
+For cluster deployments, BanyanDB 0.10.0 pushes measure aggregation work down to data nodes (map) and reduces
+results on the liaison (reduce). SkyWalking metric queries benefit transparently. No OAP configuration change
+is required, but cluster operators may observe shifted CPU/memory profiles between liaison and data nodes.
+
+### Query/storage efficiency
+
+- Bloom filters are no longer used for dictionary-encoded tags; an O(1) dictionary lookup is used instead.
+- Tags referenced only in `WHERE` conditions no longer need to be present in the projection list.
+
+These are transparent to OAP but may shift query latency for power users who issue ad-hoc queries directly
+against BanyanDB via `bydbctl` or BydbQL.
+
+## See also
+
+- BanyanDB-side configuration: [Storage BanyanDB](../setup/backend/storages/banyandb.md)
+- Data lifecycle: [Data Lifecycle Stages (Hot/Warm/Cold)](stages.md), [Progressive TTL](ttl.md)
+- Self observability: [BanyanDB self observability dashboard](dashboards-banyandb.md)
+- Upstream: [BanyanDB 0.10.0 release notes](https://github.com/apache/skywalking-banyandb/releases/tag/v0.10.0)

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -49,6 +49,7 @@
 * Update LAL documentation with `sourceAttribute()` function and `layer: auto` mode.
 * Add iOS app monitoring setup documentation.
 * Add WeChat / Alipay Mini Program monitoring setup documentation, plus a client-side-monitoring section in the security guide covering public-internet ingress (OTLP + `/v3/segments`) for mobile / browser / mini-program SDKs.
+* Add `Upgrading to BanyanDB 0.10.0` operator guide covering the property on-disk path layout change, the node discovery default switch to `none` for clusters, dropped Windows binaries, property repair on by default, server-generated stream `element_id`, distributed measure aggregation, and the Bloom-filter / criteria-projection storage tweaks. Also document the missing `pprofTaskQueryMaxSize` field in the BanyanDB storage page (partial #13777).
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/issues?q=milestone:10.5.0)
 

--- a/docs/en/setup/backend/storages/banyandb.md
+++ b/docs/en/setup/backend/storages/banyandb.md
@@ -15,6 +15,8 @@ If the BanyanDB server API version is not compatible with the OAP server, the OA
 org.apache.skywalking.oap.server.library.module.ModuleStartException: Incompatible BanyanDB server API version...
 ```
 
+> Upgrading from BanyanDB 0.9.x to 0.10.x? See [Upgrading to BanyanDB 0.10.0](../../../banyandb/upgrade-0.10.md) for breaking changes (property on-disk path, node discovery default) and behavioral changes that affect SkyWalking deployments.
+
 ### Configuration
 In the `application.yml` file, select the BanyanDB storage provider:
 
@@ -56,6 +58,8 @@ global:
   # The batch size for querying profile data.
   profileDataQueryBatchSize: ${SW_STORAGE_BANYANDB_QUERY_PROFILE_DATA_BATCH_SIZE:100}
   asyncProfilerTaskQueryMaxSize: ${SW_STORAGE_BANYANDB_ASYNC_PROFILER_TASK_QUERY_MAX_SIZE:200}
+  # The maximum number of pprof task queries in a request.
+  pprofTaskQueryMaxSize: ${SW_STORAGE_BANYANDB_PPROF_TASK_QUERY_MAX_SIZE:200}
   user: ${SW_STORAGE_BANYANDB_USER:""}
   password: ${SW_STORAGE_BANYANDB_PASSWORD:""}
   # If the BanyanDB server is configured with TLS, configure the TLS cert file path and enable TLS connection.

--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -228,6 +228,8 @@ catalog:
             path: "/en/banyandb/stages"
           - name: "BanyanDB self observability dashboard"
             path: "/en/banyandb/dashboards-banyandb"
+          - name: "Upgrading to BanyanDB 0.10.0"
+            path: "/en/banyandb/upgrade-0.10"
       - name: "Tracing"
         catalog:
           - name: "Trace Sampling"


### PR DESCRIPTION
## Why

#13777 tracks completing user/operator documentation for BanyanDB 0.10.0. The release shipped a number of breaking and behavioral changes that affect SkyWalking OAP operators, but the SkyWalking-side docs still describe the 0.9 world. This is a first-pass slice that covers the operator-facing essentials so deployments upgrading from 0.9.x to 0.10.x have a single page to land on.

## What

- **New page** `docs/en/banyandb/upgrade-0.10.md` ("Upgrading to BanyanDB 0.10.0") under the existing **BanyanDB Exclusive Setup** menu section, covering:
  - Compatibility (OAP defaults to API `0.10`, error if mismatched).
  - Breaking: property on-disk path now `<data-dir>/property/data/<group>/shard-<id>/...`.
  - Breaking: node discovery default changed from `etcd` to `none`. Cluster deployments must explicitly set a discovery mode.
  - Breaking: Windows binaries / Docker images dropped.
  - Behavioral: property background repair on by default; server-side `element_id` for streams; distributed measure aggregation map/reduce; Bloom-filter / criteria-projection storage tweaks.
  - Cross-links to the upstream BanyanDB `Upgrading to 0.10`, `Node Discovery` and `Property Repair` guides plus the existing SkyWalking BanyanDB pages.
- `docs/en/setup/backend/storages/banyandb.md`:
  - Add the missing `pprofTaskQueryMaxSize` config field (already in the live `oap-server/server-starter/src/main/resources/bydb.yml` since 0.10 but not in the docs sample).
  - Add a one-line pointer to the new upgrade page near the compatibility note.
- `docs/menu.yml`: link the new page under "BanyanDB Exclusive Setup".
- `docs/en/changes/changes.md`: 10.5.0 Documentation entry.

## Tested

- [x] All link targets verified (`/en/banyandb/upgrade-0.10`, upstream BanyanDB pages).
- [x] Diff is additive only (110 additions, 0 deletions).
- [x] DCO sign-off included.

## Scope note

Per the issue, the full 0.10 documentation refresh is large. This PR intentionally scopes to the operator/upgrade essentials. Items left for follow-up (still tracked under #13777):

- MCP setup and security guidance.
- BydbQL surfaces: property sorted queries, group deletion (`bydbctl --force`/`--dry-run`/`--data-only`).
- FODC / KTM (eBPF I/O) operator pointers.
- Snapshot minimum-age retention semantics, liaison sync + series metadata, schema property + `has-meta-role` flag.
- `bydbctl` dump / `smeta` inspection workflow.

These are mostly upstream BanyanDB concerns and benefit from being covered in the BanyanDB repo first; SkyWalking-side pointers can follow once those land.