### PR TITLE
Push Duration parameter down to storage layer in trace detail queries

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -41,6 +41,7 @@
 * Fix: potential unexpected current directory inclusion in Docker OAP classpath.
 * MAL: add `safeDiv(divisor)` on `SampleFamily` that yields `0` when the divisor is `0` instead of `Infinity`/`NaN`. Replace `/` with `safeDiv(...)` in Envoy AI Gateway latency-average rules so `sum / count * 1000` no longer produces dropped or out-of-range samples when a counter is zero in a window.
 * Fix: `envoy-ai-gateway` metrics rules, make the metrics value return `0` when the divisor is `0`.
+* Push the `Duration` parameter down to the storage layer in trace detail query DAOs. `JDBCTraceQueryDAO`, `JDBCSpanAttachedEventQueryDAO`, `JDBCZipkinQueryDAO`, `TraceQueryEsDAO`, and `SpanAttachedEventEsDAO` previously accepted `@Nullable Duration` but ignored it: JDBC scanned every shard table within TTL and Elasticsearch did not apply a `time_bucket` range filter. Both backends now narrow to the trace's time window when duration is provided (preserving prior behavior when null). BanyanDB already handled this correctly.
 
 #### UI
 * Add mobile menu icon and i18n labels for the iOS layer.

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/SpanAttachedEventEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/SpanAttachedEventEsDAO.java
@@ -69,8 +69,13 @@ public class SpanAttachedEventEsDAO extends EsDAO implements ISpanAttachedEventQ
         if (IndexController.LogicIndicesRegister.isMergedTable(SWSpanAttachedEventRecord.INDEX_NAME)) {
             query.must(Query.term(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME, SWSpanAttachedEventRecord.INDEX_NAME));
         }
-        final SearchBuilder search = Search.builder().query(query).size(scrollingBatchSize);
         query.must(Query.terms(SWSpanAttachedEventRecord.RELATED_TRACE_ID, traceIds));
+        if (duration != null) {
+            query.must(Query.range(SWSpanAttachedEventRecord.TIME_BUCKET)
+                .gte(duration.getStartTimeBucketInSec())
+                .lte(duration.getEndTimeBucketInSec()));
+        }
+        final SearchBuilder search = Search.builder().query(query).size(scrollingBatchSize);
         search.sort(SWSpanAttachedEventRecord.START_TIME_SECOND, Sort.Order.ASC);
         search.sort(SWSpanAttachedEventRecord.START_TIME_NANOS, Sort.Order.ASC);
 
@@ -92,8 +97,13 @@ public class SpanAttachedEventEsDAO extends EsDAO implements ISpanAttachedEventQ
         if (IndexController.LogicIndicesRegister.isMergedTable(SpanAttachedEventRecord.INDEX_NAME)) {
             query.must(Query.term(IndexController.LogicIndicesRegister.RECORD_TABLE_NAME, SpanAttachedEventRecord.INDEX_NAME));
         }
-        final SearchBuilder search = Search.builder().query(query).size(scrollingBatchSize);
         query.must(Query.terms(SpanAttachedEventRecord.RELATED_TRACE_ID, traceIds));
+        if (duration != null) {
+            query.must(Query.range(SpanAttachedEventRecord.TIME_BUCKET)
+                .gte(duration.getStartTimeBucketInSec())
+                .lte(duration.getEndTimeBucketInSec()));
+        }
+        final SearchBuilder search = Search.builder().query(query).size(scrollingBatchSize);
         search.sort(SpanAttachedEventRecord.START_TIME_SECOND, Sort.Order.ASC);
         search.sort(SpanAttachedEventRecord.START_TIME_NANOS, Sort.Order.ASC);
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TraceQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TraceQueryEsDAO.java
@@ -183,10 +183,13 @@ public class TraceQueryEsDAO extends EsDAO implements ITraceQueryDAO {
         final String index =
             IndexController.LogicIndicesRegister.getPhysicalTableName(SegmentRecord.INDEX_NAME);
 
-        final SearchBuilder search =
-            Search.builder()
-                  .query(Query.term(SegmentRecord.TRACE_ID, traceId))
-                  .size(segmentQueryMaxSize);
+        final BoolQueryBuilder query = Query.bool().must(Query.term(SegmentRecord.TRACE_ID, traceId));
+        if (duration != null) {
+            query.must(Query.range(SegmentRecord.TIME_BUCKET)
+                .gte(duration.getStartTimeBucketInSec())
+                .lte(duration.getEndTimeBucketInSec()));
+        }
+        final SearchBuilder search = Search.builder().query(query).size(segmentQueryMaxSize);
 
         SearchParams searchParams = new SearchParams();
         RoutingUtils.addRoutingValueToSearchParam(searchParams, traceId);
@@ -201,10 +204,13 @@ public class TraceQueryEsDAO extends EsDAO implements ITraceQueryDAO {
         final String index =
             IndexController.LogicIndicesRegister.getPhysicalTableName(SegmentRecord.INDEX_NAME);
 
-        final SearchBuilder search =
-            Search.builder()
-                .query(Query.terms(SegmentRecord.SEGMENT_ID, segmentIdList))
-                .size(segmentQueryMaxSize);
+        final BoolQueryBuilder query = Query.bool().must(Query.terms(SegmentRecord.SEGMENT_ID, segmentIdList));
+        if (duration != null) {
+            query.must(Query.range(SegmentRecord.TIME_BUCKET)
+                .gte(duration.getStartTimeBucketInSec())
+                .lte(duration.getEndTimeBucketInSec()));
+        }
+        final SearchBuilder search = Search.builder().query(query).size(segmentQueryMaxSize);
 
         SearchParams searchParams = new SearchParams();
         final SearchResponse response = getClient().search(index, search.build(), searchParams);
@@ -217,10 +223,15 @@ public class TraceQueryEsDAO extends EsDAO implements ITraceQueryDAO {
         final String index =
             IndexController.LogicIndicesRegister.getPhysicalTableName(SegmentRecord.INDEX_NAME);
 
-        final SearchBuilder search =
-            Search.builder()
-                .query(Query.bool().must(Query.terms(SegmentRecord.TRACE_ID, traceIdList)).must(Query.terms(SegmentRecord.SERVICE_INSTANCE_ID, instanceIdList)))
-                .size(segmentQueryMaxSize);
+        final BoolQueryBuilder query = Query.bool()
+            .must(Query.terms(SegmentRecord.TRACE_ID, traceIdList))
+            .must(Query.terms(SegmentRecord.SERVICE_INSTANCE_ID, instanceIdList));
+        if (duration != null) {
+            query.must(Query.range(SegmentRecord.TIME_BUCKET)
+                .gte(duration.getStartTimeBucketInSec())
+                .lte(duration.getEndTimeBucketInSec()));
+        }
+        final SearchBuilder search = Search.builder().query(query).size(segmentQueryMaxSize);
 
         SearchParams searchParams = new SearchParams();
         final SearchResponse response = getClient().search(index, search.build(), searchParams);

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/SpanAttachedEventEsDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/SpanAttachedEventEsDAOTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.skywalking.library.elasticsearch.requests.search.Search;
+import org.apache.skywalking.library.elasticsearch.requests.search.SearchParams;
+import org.apache.skywalking.library.elasticsearch.response.search.SearchResponse;
+import org.apache.skywalking.oap.server.core.analysis.manual.spanattach.SWSpanAttachedEventRecord;
+import org.apache.skywalking.oap.server.core.analysis.manual.spanattach.SpanAttachedEventRecord;
+import org.apache.skywalking.oap.server.core.query.enumeration.Step;
+import org.apache.skywalking.oap.server.core.query.input.Duration;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.StorageModuleElasticsearchConfig;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SpanAttachedEventEsDAOTest {
+
+    @Mock
+    private ElasticSearchClient client;
+
+    private SpanAttachedEventEsDAO dao;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        final StorageModuleElasticsearchConfig config = new StorageModuleElasticsearchConfig();
+        config.setProfileDataQueryBatchSize(100);
+        dao = new SpanAttachedEventEsDAO(client, config);
+    }
+
+    @Test
+    void querySWSpanAttachedEvents_withDuration_shouldAddTimeBucketRangeFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class), any(SearchParams.class)))
+            .thenReturn(new SearchResponse());
+
+        dao.querySWSpanAttachedEvents(Collections.singletonList("trace-1"), buildDuration());
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture(), any(SearchParams.class));
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(SWSpanAttachedEventRecord.TIME_BUCKET);
+        assertThat(json).contains(SWSpanAttachedEventRecord.RELATED_TRACE_ID);
+    }
+
+    @Test
+    void querySWSpanAttachedEvents_withNullDuration_shouldNotAddTimeBucketRangeFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class), any(SearchParams.class)))
+            .thenReturn(new SearchResponse());
+
+        dao.querySWSpanAttachedEvents(Collections.singletonList("trace-1"), null);
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture(), any(SearchParams.class));
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).doesNotContain(SWSpanAttachedEventRecord.TIME_BUCKET);
+    }
+
+    @Test
+    void queryZKSpanAttachedEvents_withDuration_shouldAddTimeBucketRangeFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class), any(SearchParams.class)))
+            .thenReturn(new SearchResponse());
+
+        dao.queryZKSpanAttachedEvents(Collections.singletonList("trace-1"), buildDuration());
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture(), any(SearchParams.class));
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(SpanAttachedEventRecord.TIME_BUCKET);
+        assertThat(json).contains(SpanAttachedEventRecord.RELATED_TRACE_ID);
+    }
+
+    @Test
+    void queryZKSpanAttachedEvents_withNullDuration_shouldNotAddTimeBucketRangeFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class), any(SearchParams.class)))
+            .thenReturn(new SearchResponse());
+
+        dao.queryZKSpanAttachedEvents(Collections.singletonList("trace-1"), null);
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture(), any(SearchParams.class));
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).doesNotContain(SpanAttachedEventRecord.TIME_BUCKET);
+    }
+
+    private static Duration buildDuration() {
+        final Duration duration = new Duration();
+        duration.setStart(new DateTime(2026, 4, 28, 14, 0).toString("yyyy-MM-dd HHmm"));
+        duration.setEnd(new DateTime(2026, 4, 28, 14, 30).toString("yyyy-MM-dd HHmm"));
+        duration.setStep(Step.MINUTE);
+        return duration;
+    }
+}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TraceQueryEsDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TraceQueryEsDAOTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.skywalking.library.elasticsearch.requests.search.Search;
+import org.apache.skywalking.library.elasticsearch.requests.search.SearchParams;
+import org.apache.skywalking.library.elasticsearch.response.search.SearchResponse;
+import org.apache.skywalking.oap.server.core.analysis.manual.segment.SegmentRecord;
+import org.apache.skywalking.oap.server.core.query.enumeration.Step;
+import org.apache.skywalking.oap.server.core.query.input.Duration;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TraceQueryEsDAOTest {
+
+    @Mock
+    private ElasticSearchClient client;
+
+    private TraceQueryEsDAO dao;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        dao = new TraceQueryEsDAO(client, 100);
+    }
+
+    @Test
+    void queryByTraceId_withDuration_shouldAddTimeBucketRangeFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class), any(SearchParams.class)))
+            .thenReturn(new SearchResponse());
+
+        dao.queryByTraceId("trace-abc", buildDuration());
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture(), any(SearchParams.class));
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(SegmentRecord.TIME_BUCKET);
+        assertThat(json).contains(SegmentRecord.TRACE_ID);
+    }
+
+    @Test
+    void queryByTraceId_withNullDuration_shouldNotAddTimeBucketRangeFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class), any(SearchParams.class)))
+            .thenReturn(new SearchResponse());
+
+        dao.queryByTraceId("trace-abc", null);
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture(), any(SearchParams.class));
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).doesNotContain(SegmentRecord.TIME_BUCKET);
+    }
+
+    @Test
+    void queryBySegmentIdList_withDuration_shouldAddTimeBucketRangeFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class), any(SearchParams.class)))
+            .thenReturn(new SearchResponse());
+
+        dao.queryBySegmentIdList(Arrays.asList("seg-1", "seg-2"), buildDuration());
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture(), any(SearchParams.class));
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(SegmentRecord.TIME_BUCKET);
+        assertThat(json).contains(SegmentRecord.SEGMENT_ID);
+    }
+
+    @Test
+    void queryByTraceIdWithInstanceId_withDuration_shouldAddTimeBucketRangeFilter() throws Exception {
+        when(client.search(anyString(), any(Search.class), any(SearchParams.class)))
+            .thenReturn(new SearchResponse());
+
+        dao.queryByTraceIdWithInstanceId(
+            Collections.singletonList("trace-1"),
+            Collections.singletonList("instance-1"),
+            buildDuration()
+        );
+
+        final ArgumentCaptor<Search> searchCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(client).search(anyString(), searchCaptor.capture(), any(SearchParams.class));
+
+        final String json = objectMapper.writeValueAsString(searchCaptor.getValue());
+        assertThat(json).contains(SegmentRecord.TIME_BUCKET);
+        assertThat(json).contains(SegmentRecord.TRACE_ID);
+        assertThat(json).contains(SegmentRecord.SERVICE_INSTANCE_ID);
+    }
+
+    private static Duration buildDuration() {
+        final Duration duration = new Duration();
+        duration.setStart(new DateTime(2026, 4, 28, 14, 0).toString("yyyy-MM-dd HHmm"));
+        duration.setEnd(new DateTime(2026, 4, 28, 14, 30).toString("yyyy-MM-dd HHmm"));
+        duration.setStep(Step.MINUTE);
+        return duration;
+    }
+}

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCSpanAttachedEventQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCSpanAttachedEventQueryDAO.java
@@ -47,11 +47,19 @@ public class JDBCSpanAttachedEventQueryDAO implements ISpanAttachedEventQueryDAO
     @Override
     @SneakyThrows
     public List<SpanAttachedEventRecord> queryZKSpanAttachedEvents(List<String> traceIds, @Nullable Duration duration) {
-        final var tables = tableHelper.getTablesWithinTTL(SpanAttachedEventRecord.INDEX_NAME);
+        long startSecondTB = 0;
+        long endSecondTB = 0;
+        if (duration != null) {
+            startSecondTB = duration.getStartTimeBucketInSec();
+            endSecondTB = duration.getEndTimeBucketInSec();
+        }
+        final var tables = startSecondTB > 0 && endSecondTB > 0 ?
+            tableHelper.getTablesForRead(SpanAttachedEventRecord.INDEX_NAME, startSecondTB, endSecondTB) :
+            tableHelper.getTablesWithinTTL(SpanAttachedEventRecord.INDEX_NAME);
         final var results = new ArrayList<SpanAttachedEventRecord>();
 
         for (String table : tables) {
-            final var sqlAndParameters = buildZKSQL(traceIds, table);
+            final var sqlAndParameters = buildZKSQL(traceIds, table, startSecondTB, endSecondTB);
 
             jdbcClient.executeQuery(
                 sqlAndParameters.sql(),
@@ -87,11 +95,19 @@ public class JDBCSpanAttachedEventQueryDAO implements ISpanAttachedEventQueryDAO
     @Override
     @SneakyThrows
     public List<SWSpanAttachedEventRecord> querySWSpanAttachedEvents(List<String> traceIds, @Nullable Duration duration) {
-        final var tables = tableHelper.getTablesWithinTTL(SWSpanAttachedEventRecord.INDEX_NAME);
+        long startSecondTB = 0;
+        long endSecondTB = 0;
+        if (duration != null) {
+            startSecondTB = duration.getStartTimeBucketInSec();
+            endSecondTB = duration.getEndTimeBucketInSec();
+        }
+        final var tables = startSecondTB > 0 && endSecondTB > 0 ?
+            tableHelper.getTablesForRead(SWSpanAttachedEventRecord.INDEX_NAME, startSecondTB, endSecondTB) :
+            tableHelper.getTablesWithinTTL(SWSpanAttachedEventRecord.INDEX_NAME);
         final var results = new ArrayList<SWSpanAttachedEventRecord>();
 
         for (String table : tables) {
-            final var sqlAndParameters = buildSWSQL(traceIds, table);
+            final var sqlAndParameters = buildSWSQL(traceIds, table, startSecondTB, endSecondTB);
 
             jdbcClient.executeQuery(
                     sqlAndParameters.sql(),
@@ -124,9 +140,9 @@ public class JDBCSpanAttachedEventQueryDAO implements ISpanAttachedEventQueryDAO
                 .collect(toList());
     }
 
-    private static SQLAndParameters buildZKSQL(List<String> traceIds, String table) {
+    private static SQLAndParameters buildZKSQL(List<String> traceIds, String table, long startSecondTB, long endSecondTB) {
         final var sql = new StringBuilder("select * from " + table + " where ");
-        final var parameters = new ArrayList<>(traceIds.size() + 1);
+        final var parameters = new ArrayList<>(traceIds.size() + 3);
 
         sql.append(JDBCTableInstaller.TABLE_COLUMN).append(" = ? ");
         parameters.add(SpanAttachedEventRecord.INDEX_NAME);
@@ -140,15 +156,22 @@ public class JDBCSpanAttachedEventQueryDAO implements ISpanAttachedEventQueryDAO
         );
         parameters.addAll(traceIds);
 
+        if (startSecondTB != 0 && endSecondTB != 0) {
+            sql.append(" and ").append(SpanAttachedEventRecord.TIME_BUCKET).append(" >= ?");
+            parameters.add(startSecondTB);
+            sql.append(" and ").append(SpanAttachedEventRecord.TIME_BUCKET).append(" <= ?");
+            parameters.add(endSecondTB);
+        }
+
         sql.append(" order by ").append(SpanAttachedEventRecord.START_TIME_SECOND)
            .append(",").append(SpanAttachedEventRecord.START_TIME_NANOS).append(" ASC ");
 
         return new SQLAndParameters(sql.toString(), parameters);
     }
 
-    private static SQLAndParameters buildSWSQL(List<String> traceIds, String table) {
+    private static SQLAndParameters buildSWSQL(List<String> traceIds, String table, long startSecondTB, long endSecondTB) {
         final var sql = new StringBuilder("select * from " + table + " where ");
-        final var parameters = new ArrayList<>(traceIds.size() + 1);
+        final var parameters = new ArrayList<>(traceIds.size() + 3);
 
         sql.append(JDBCTableInstaller.TABLE_COLUMN).append(" = ? ");
         parameters.add(SWSpanAttachedEventRecord.INDEX_NAME);
@@ -161,6 +184,13 @@ public class JDBCSpanAttachedEventQueryDAO implements ISpanAttachedEventQueryDAO
                         .collect(joining(",", "(", ")"))
         );
         parameters.addAll(traceIds);
+
+        if (startSecondTB != 0 && endSecondTB != 0) {
+            sql.append(" and ").append(SWSpanAttachedEventRecord.TIME_BUCKET).append(" >= ?");
+            parameters.add(startSecondTB);
+            sql.append(" and ").append(SWSpanAttachedEventRecord.TIME_BUCKET).append(" <= ?");
+            parameters.add(endSecondTB);
+        }
 
         sql.append(" order by ").append(SWSpanAttachedEventRecord.START_TIME_SECOND)
                 .append(",").append(SWSpanAttachedEventRecord.START_TIME_NANOS).append(" ASC ");

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCTraceQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCTraceQueryDAO.java
@@ -234,19 +234,39 @@ public class JDBCTraceQueryDAO implements ITraceQueryDAO {
     @Override
     @SneakyThrows
     public List<SegmentRecord> queryByTraceId(String traceId, @Nullable Duration duration) throws IOException {
-        final var tables = tableHelper.getTablesWithinTTL(SegmentRecord.INDEX_NAME);
+        long startSecondTB = 0;
+        long endSecondTB = 0;
+        if (nonNull(duration)) {
+            startSecondTB = duration.getStartTimeBucketInSec();
+            endSecondTB = duration.getEndTimeBucketInSec();
+        }
+        final var tables = startSecondTB > 0 && endSecondTB > 0 ?
+            tableHelper.getTablesForRead(SegmentRecord.INDEX_NAME, startSecondTB, endSecondTB) :
+            tableHelper.getTablesWithinTTL(SegmentRecord.INDEX_NAME);
         final var segmentRecords = new ArrayList<SegmentRecord>();
 
         for (String table : tables) {
-            jdbcClient.executeQuery(
+            final var sql = new StringBuilder(
                 DETAIL_SELECT_QUERY + " from " + table + " where " +
                     JDBCTableInstaller.TABLE_COLUMN + " = ? and " +
-                    SegmentRecord.TRACE_ID + " = ?",
+                    SegmentRecord.TRACE_ID + " = ?");
+            final var parameters = new ArrayList<>();
+            parameters.add(SegmentRecord.INDEX_NAME);
+            parameters.add(traceId);
+            if (startSecondTB != 0 && endSecondTB != 0) {
+                sql.append(" and ").append(SegmentRecord.TIME_BUCKET).append(" >= ?");
+                parameters.add(startSecondTB);
+                sql.append(" and ").append(SegmentRecord.TIME_BUCKET).append(" <= ?");
+                parameters.add(endSecondTB);
+            }
+
+            jdbcClient.executeQuery(
+                sql.toString(),
                 resultSet -> {
                     segmentRecords.addAll(buildRecords(resultSet));
                     return null;
                 },
-                SegmentRecord.INDEX_NAME, traceId
+                parameters.toArray()
             );
         }
         return segmentRecords;
@@ -255,23 +275,40 @@ public class JDBCTraceQueryDAO implements ITraceQueryDAO {
     @SneakyThrows
     @Override
     public List<SegmentRecord> queryBySegmentIdList(List<String> segmentIdList, @Nullable Duration duration) throws IOException {
-        final var tables = tableHelper.getTablesWithinTTL(SegmentRecord.INDEX_NAME);
+        long startSecondTB = 0;
+        long endSecondTB = 0;
+        if (nonNull(duration)) {
+            startSecondTB = duration.getStartTimeBucketInSec();
+            endSecondTB = duration.getEndTimeBucketInSec();
+        }
+        final var tables = startSecondTB > 0 && endSecondTB > 0 ?
+            tableHelper.getTablesForRead(SegmentRecord.INDEX_NAME, startSecondTB, endSecondTB) :
+            tableHelper.getTablesWithinTTL(SegmentRecord.INDEX_NAME);
         final var segmentRecords = new ArrayList<SegmentRecord>();
-        final ArrayList<String> conditions = new ArrayList<>();
-        conditions.add(SegmentRecord.INDEX_NAME);
-        conditions.addAll(segmentIdList);
 
         for (String table : tables) {
-            jdbcClient.executeQuery(
+            final var sql = new StringBuilder(
                 DETAIL_SELECT_QUERY + " from " + table + " where " +
                     JDBCTableInstaller.TABLE_COLUMN + " = ? and " +
                     SegmentRecord.SEGMENT_ID + " in " +
-                    segmentIdList.stream().map(it -> "?").collect(Collectors.joining(",", "(", ")")),
+                    segmentIdList.stream().map(it -> "?").collect(Collectors.joining(",", "(", ")")));
+            final var parameters = new ArrayList<>();
+            parameters.add(SegmentRecord.INDEX_NAME);
+            parameters.addAll(segmentIdList);
+            if (startSecondTB != 0 && endSecondTB != 0) {
+                sql.append(" and ").append(SegmentRecord.TIME_BUCKET).append(" >= ?");
+                parameters.add(startSecondTB);
+                sql.append(" and ").append(SegmentRecord.TIME_BUCKET).append(" <= ?");
+                parameters.add(endSecondTB);
+            }
+
+            jdbcClient.executeQuery(
+                sql.toString(),
                 resultSet -> {
                     segmentRecords.addAll(buildRecords(resultSet));
                     return null;
                 },
-                conditions.toArray()
+                parameters.toArray()
             );
         }
         return segmentRecords;
@@ -280,26 +317,43 @@ public class JDBCTraceQueryDAO implements ITraceQueryDAO {
     @SneakyThrows
     @Override
     public List<SegmentRecord> queryByTraceIdWithInstanceId(List<String> traceIdList, List<String> instanceIdList, @Nullable Duration duration) throws IOException {
-        final var tables = tableHelper.getTablesWithinTTL(SegmentRecord.INDEX_NAME);
+        long startSecondTB = 0;
+        long endSecondTB = 0;
+        if (nonNull(duration)) {
+            startSecondTB = duration.getStartTimeBucketInSec();
+            endSecondTB = duration.getEndTimeBucketInSec();
+        }
+        final var tables = startSecondTB > 0 && endSecondTB > 0 ?
+            tableHelper.getTablesForRead(SegmentRecord.INDEX_NAME, startSecondTB, endSecondTB) :
+            tableHelper.getTablesWithinTTL(SegmentRecord.INDEX_NAME);
         final var segmentRecords = new ArrayList<SegmentRecord>();
-        final ArrayList<String> conditions = new ArrayList<>();
-        conditions.add(SegmentRecord.INDEX_NAME);
-        conditions.addAll(traceIdList);
-        conditions.addAll(instanceIdList);
 
         for (String table : tables) {
-            jdbcClient.executeQuery(
+            final var sql = new StringBuilder(
                 DETAIL_SELECT_QUERY + " from " + table + " where " +
                     JDBCTableInstaller.TABLE_COLUMN + " = ? and " +
                     SegmentRecord.TRACE_ID + " in " +
                     traceIdList.stream().map(it -> "?").collect(Collectors.joining(",", "(", ") and ")) +
                     SegmentRecord.SERVICE_INSTANCE_ID + " in " +
-                    instanceIdList.stream().map(it -> "?").collect(Collectors.joining(",", "(", ")")),
+                    instanceIdList.stream().map(it -> "?").collect(Collectors.joining(",", "(", ")")));
+            final var parameters = new ArrayList<>();
+            parameters.add(SegmentRecord.INDEX_NAME);
+            parameters.addAll(traceIdList);
+            parameters.addAll(instanceIdList);
+            if (startSecondTB != 0 && endSecondTB != 0) {
+                sql.append(" and ").append(SegmentRecord.TIME_BUCKET).append(" >= ?");
+                parameters.add(startSecondTB);
+                sql.append(" and ").append(SegmentRecord.TIME_BUCKET).append(" <= ?");
+                parameters.add(endSecondTB);
+            }
+
+            jdbcClient.executeQuery(
+                sql.toString(),
                 resultSet -> {
                     segmentRecords.addAll(buildRecords(resultSet));
                     return null;
                 },
-                conditions.toArray()
+                parameters.toArray()
             );
         }
         return segmentRecords;

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCZipkinQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCZipkinQueryDAO.java
@@ -150,18 +150,32 @@ public class JDBCZipkinQueryDAO implements IZipkinQueryDAO {
     @Override
     @SneakyThrows
     public List<Span> getTrace(final String traceId, @Nullable final Duration duration) {
-        final var tables = tableHelper.getTablesWithinTTL(ZipkinSpanRecord.INDEX_NAME);
+        long startSecondTB = 0;
+        long endSecondTB = 0;
+        if (duration != null) {
+            startSecondTB = duration.getStartTimeBucketInSec();
+            endSecondTB = duration.getEndTimeBucketInSec();
+        }
+        final var tables = startSecondTB > 0 && endSecondTB > 0 ?
+            tableHelper.getTablesForRead(ZipkinSpanRecord.INDEX_NAME, startSecondTB, endSecondTB) :
+            tableHelper.getTablesWithinTTL(ZipkinSpanRecord.INDEX_NAME);
         final var trace = new ArrayList<Span>();
 
         for (String table : tables) {
             StringBuilder sql = new StringBuilder();
-            List<Object> condition = new ArrayList<>(1);
+            List<Object> condition = new ArrayList<>(4);
             sql.append("select * from ").append(table);
             sql.append(" where ");
             sql.append(JDBCTableInstaller.TABLE_COLUMN).append(" = ?");
             condition.add(ZipkinSpanRecord.INDEX_NAME);
             sql.append(" and ").append(ZipkinSpanRecord.TRACE_ID).append(" = ?");
             condition.add(traceId);
+            if (startSecondTB != 0 && endSecondTB != 0) {
+                sql.append(" and ").append(ZipkinSpanRecord.TIME_BUCKET).append(" >= ?");
+                condition.add(startSecondTB);
+                sql.append(" and ").append(ZipkinSpanRecord.TIME_BUCKET).append(" <= ?");
+                condition.add(endSecondTB);
+            }
             h2Client.executeQuery(sql.toString(), resultSet -> {
                 while (resultSet.next()) {
                     trace.add(buildSpan(resultSet));

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCSpanAttachedEventQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCSpanAttachedEventQueryDAOTest.java
@@ -20,6 +20,8 @@ package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
 
 import org.apache.skywalking.oap.server.core.analysis.manual.spanattach.SWSpanAttachedEventRecord;
 import org.apache.skywalking.oap.server.core.analysis.manual.spanattach.SpanAttachedEventRecord;
+import org.apache.skywalking.oap.server.core.query.input.Duration;
+import org.apache.skywalking.oap.server.core.query.enumeration.Step;
 import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
 import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
 import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
@@ -31,6 +33,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import org.joda.time.DateTime;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,7 +42,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
@@ -107,5 +113,63 @@ class JDBCSpanAttachedEventQueryDAOTest {
 
         assertThat(capturedSql.get()).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
         assertThat(capturedSql.get()).contains(SWSpanAttachedEventRecord.RELATED_TRACE_ID + " in (?,?,?)");
+    }
+
+    @Test
+    void queryZKSpanAttachedEvents_withDuration_shouldUseTablesForReadAndAddTimeBucketFilter() throws Exception {
+        when(tableHelper.getTablesForRead(eq(SpanAttachedEventRecord.INDEX_NAME), anyLong(), anyLong()))
+            .thenReturn(Collections.singletonList("span_attached_event_record_20260428"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryZKSpanAttachedEvents(Arrays.asList("trace-1"), buildDuration());
+
+        assertThat(capturedSql.get()).contains(SpanAttachedEventRecord.TIME_BUCKET + " >= ?");
+        assertThat(capturedSql.get()).contains(SpanAttachedEventRecord.TIME_BUCKET + " <= ?");
+    }
+
+    @Test
+    void queryZKSpanAttachedEvents_withNullDuration_shouldFallBackToTablesWithinTTL() throws Exception {
+        when(tableHelper.getTablesWithinTTL(SpanAttachedEventRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("span_attached_event"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryZKSpanAttachedEvents(Arrays.asList("trace-1"), null);
+
+        assertThat(capturedSql.get()).doesNotContain(SpanAttachedEventRecord.TIME_BUCKET + " >= ?");
+    }
+
+    @Test
+    void querySWSpanAttachedEvents_withDuration_shouldUseTablesForReadAndAddTimeBucketFilter() throws Exception {
+        when(tableHelper.getTablesForRead(eq(SWSpanAttachedEventRecord.INDEX_NAME), anyLong(), anyLong()))
+            .thenReturn(Collections.singletonList("sw_span_attached_event_record_20260428"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.querySWSpanAttachedEvents(Arrays.asList("trace-1"), buildDuration());
+
+        assertThat(capturedSql.get()).contains(SWSpanAttachedEventRecord.TIME_BUCKET + " >= ?");
+        assertThat(capturedSql.get()).contains(SWSpanAttachedEventRecord.TIME_BUCKET + " <= ?");
+    }
+
+    private static Duration buildDuration() {
+        final Duration duration = new Duration();
+        duration.setStart(new DateTime(2026, 4, 28, 14, 0).toString("yyyy-MM-dd HHmm"));
+        duration.setEnd(new DateTime(2026, 4, 28, 14, 30).toString("yyyy-MM-dd HHmm"));
+        duration.setStep(Step.MINUTE);
+        return duration;
     }
 }

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCTraceQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCTraceQueryDAOTest.java
@@ -19,10 +19,13 @@
 package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
 
 import org.apache.skywalking.oap.server.core.analysis.manual.segment.SegmentRecord;
+import org.apache.skywalking.oap.server.core.query.enumeration.Step;
+import org.apache.skywalking.oap.server.core.query.input.Duration;
 import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
 import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,7 +40,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
@@ -145,6 +150,87 @@ class JDBCTraceQueryDAOTest {
         final String sql = capturedSql.get();
         assertThat(sql).contains(SegmentRecord.TRACE_ID + " in (?)");
         assertThat(sql).contains(" and " + SegmentRecord.SERVICE_INSTANCE_ID + " in (?)");
+    }
+
+    @Test
+    void queryByTraceId_withDuration_shouldUseTablesForReadAndAddTimeBucketFilter() throws Exception {
+        when(tableHelper.getTablesForRead(eq(SegmentRecord.INDEX_NAME), anyLong(), anyLong()))
+            .thenReturn(Collections.singletonList(TABLE));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return Collections.emptyList();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryByTraceId("trace-abc", buildDuration());
+
+        final String sql = capturedSql.get();
+        assertThat(sql).contains(SegmentRecord.TIME_BUCKET + " >= ?");
+        assertThat(sql).contains(SegmentRecord.TIME_BUCKET + " <= ?");
+    }
+
+    @Test
+    void queryBySegmentIdList_withDuration_shouldUseTablesForReadAndAddTimeBucketFilter() throws Exception {
+        when(tableHelper.getTablesForRead(eq(SegmentRecord.INDEX_NAME), anyLong(), anyLong()))
+            .thenReturn(Collections.singletonList(TABLE));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return Collections.emptyList();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryBySegmentIdList(Arrays.asList("seg-1", "seg-2"), buildDuration());
+
+        final String sql = capturedSql.get();
+        assertThat(sql).contains(SegmentRecord.TIME_BUCKET + " >= ?");
+        assertThat(sql).contains(SegmentRecord.TIME_BUCKET + " <= ?");
+    }
+
+    @Test
+    void queryByTraceIdWithInstanceId_withDuration_shouldUseTablesForReadAndAddTimeBucketFilter() throws Exception {
+        when(tableHelper.getTablesForRead(eq(SegmentRecord.INDEX_NAME), anyLong(), anyLong()))
+            .thenReturn(Collections.singletonList(TABLE));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return Collections.emptyList();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryByTraceIdWithInstanceId(
+            Arrays.asList("trace-1"), Arrays.asList("instance-1"), buildDuration()
+        );
+
+        final String sql = capturedSql.get();
+        assertThat(sql).contains(SegmentRecord.TIME_BUCKET + " >= ?");
+        assertThat(sql).contains(SegmentRecord.TIME_BUCKET + " <= ?");
+    }
+
+    @Test
+    void queryByTraceId_withNullDuration_shouldFallBackToTablesWithinTTL() throws Exception {
+        when(tableHelper.getTablesWithinTTL(SegmentRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList(TABLE));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return Collections.emptyList();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.queryByTraceId("trace-abc", null);
+
+        final String sql = capturedSql.get();
+        assertThat(sql).doesNotContain(SegmentRecord.TIME_BUCKET + " >= ?");
+    }
+
+    private static Duration buildDuration() {
+        final Duration duration = new Duration();
+        duration.setStart(new DateTime(2026, 4, 28, 14, 0).toString("yyyy-MM-dd HHmm"));
+        duration.setEnd(new DateTime(2026, 4, 28, 14, 30).toString("yyyy-MM-dd HHmm"));
+        duration.setStep(Step.MINUTE);
+        return duration;
     }
 
     private long countOccurrences(final String text, final String pattern) {

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCZipkinQueryDAOTest.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/test/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/common/dao/JDBCZipkinQueryDAOTest.java
@@ -18,10 +18,13 @@
 
 package org.apache.skywalking.oap.server.storage.plugin.jdbc.common.dao;
 
+import org.apache.skywalking.oap.server.core.query.enumeration.Step;
+import org.apache.skywalking.oap.server.core.query.input.Duration;
 import org.apache.skywalking.oap.server.core.zipkin.ZipkinSpanRecord;
 import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
 import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCTableInstaller;
 import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +42,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
@@ -107,5 +112,49 @@ class JDBCZipkinQueryDAOTest {
         final String sql = capturedSql.get();
         assertThat(sql).contains(JDBCTableInstaller.TABLE_COLUMN + " = ?");
         assertThat(sql).contains(ZipkinSpanRecord.TRACE_ID + " in (?)");
+    }
+
+    @Test
+    void getTrace_withDuration_shouldUseTablesForReadAndAddTimeBucketFilter() throws Exception {
+        when(tableHelper.getTablesForRead(eq(ZipkinSpanRecord.INDEX_NAME), anyLong(), anyLong()))
+            .thenReturn(Collections.singletonList("zipkin_span_record_20260428"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTrace("trace-abc", buildDuration());
+
+        final String sql = capturedSql.get();
+        assertThat(sql).contains(ZipkinSpanRecord.TRACE_ID + " = ?");
+        assertThat(sql).contains(ZipkinSpanRecord.TIME_BUCKET + " >= ?");
+        assertThat(sql).contains(ZipkinSpanRecord.TIME_BUCKET + " <= ?");
+    }
+
+    @Test
+    void getTrace_withNullDuration_shouldFallBackToTablesWithinTTL() throws Exception {
+        when(tableHelper.getTablesWithinTTL(ZipkinSpanRecord.INDEX_NAME))
+            .thenReturn(Collections.singletonList("zipkin_span_record"));
+
+        final AtomicReference<String> capturedSql = new AtomicReference<>();
+        doAnswer(invocation -> {
+            capturedSql.set(invocation.getArgument(0));
+            return new ArrayList<>();
+        }).when(jdbcClient).executeQuery(anyString(), any(), any(Object[].class));
+
+        dao.getTrace("trace-abc", null);
+
+        final String sql = capturedSql.get();
+        assertThat(sql).doesNotContain(ZipkinSpanRecord.TIME_BUCKET + " >= ?");
+    }
+
+    private static Duration buildDuration() {
+        final Duration duration = new Duration();
+        duration.setStart(new DateTime(2026, 4, 28, 14, 0).toString("yyyy-MM-dd HHmm"));
+        duration.setEnd(new DateTime(2026, 4, 28, 14, 30).toString("yyyy-MM-dd HHmm"));
+        duration.setStep(Step.MINUTE);
+        return duration;
     }
 }


### PR DESCRIPTION
## What

Several trace detail query DAOs accept a `@Nullable Duration` parameter but ignore it. This PR pushes the parameter down to the storage layer so that:

- **JDBC**: shard pruning via `TableHelper.getTablesForRead` (instead of scanning all TTL shards) + a `time_bucket` `WHERE` filter inside the generated SQL.
- **Elasticsearch**: a `Query.range(TIME_BUCKET)` filter on the search request.

When `duration` is `null`, both backends fall back to the prior behavior, so this is fully backward-compatible.

### Affected (JDBC)
- `JDBCTraceQueryDAO`: `queryByTraceId`, `queryBySegmentIdList`, `queryByTraceIdWithInstanceId`
- `JDBCSpanAttachedEventQueryDAO`: `queryZKSpanAttachedEvents`, `querySWSpanAttachedEvents`
- `JDBCZipkinQueryDAO`: `getTrace`

### Affected (Elasticsearch)
- `TraceQueryEsDAO`: `queryByTraceId`, `queryBySegmentIdList`, `queryByTraceIdWithInstanceId`
- `SpanAttachedEventEsDAO`: `querySWSpanAttachedEvents`, `queryZKSpanAttachedEvents`

## Why

This is a **storage-side plumbing fix**. Several DAO implementations accept `@Nullable Duration` in their interface signatures but drop the parameter, leaving JDBC scanning every shard table within TTL and Elasticsearch missing the `time_bucket` range filter. `BanyanDB` already handles this correctly via `getTimestampRange(duration)`, so this change brings JDBC and ES in line.

### Who carries non-null `duration` to these DAOs today

- ✅ **`SkyWalkingTraceQLApiHandler.queryTraceImpl`** (`traceql-plugin`) — builds a `Duration` from the request `start`/`end` and calls `traceQueryService.queryTrace(traceId, duration)`. Tempo/Grafana clients querying via the SkyWalking TraceQL endpoint with JDBC/ES storage benefit immediately.
- ✅ **`queryTraceFromColdStage`** GraphQL field — BanyanDB-tier feature, but the storage-side null check is now correct on JDBC/ES too.
- ✅ Third-party GraphQL clients that explicitly pass the optional `duration` variable to `queryTrace`.

### Who does **not** carry duration today

- ❌ The default SkyWalking UI's `TraceSpans` fragment sends `queryTrace(traceId)` without a `duration` variable (the `trace.graphqls:200` comment codifies that as "only for BanyanDB"). On JDBC/ES with the default UI this PR's new code takes the null-fallback path — same behavior as before.
- ❌ Zipkin's `getTraceById` API has no time-range argument, so it always passes `null`.

Updating the GraphQL schema comment + the default UI fragment so the GraphQL hot path also carries `duration` on JDBC/ES is a follow-up I'd rather not bundle in this storage-side PR (it touches the `skywalking-ui` submodule + the schema). This PR establishes the storage-side capability so that the schema/UI change is purely additive when it lands.

## Pattern

The fix follows the existing pattern in the same project:
- `JDBCTraceQueryDAO.queryBasicTraces` (the conditional `getTablesForRead` / `getTablesWithinTTL` ternary + `time_bucket` `WHERE` filter)
- `JDBCBrowserLogQueryDAO.queryBrowserErrorLogs` (same pattern)
- `TraceQueryEsDAO.queryBasicTraces` (the `Query.range(TIME_BUCKET)` filter)
- `BanyanDBSpanAttachedEventQueryDAO.queryZK/SWSpanAttachedEvents` (`getTimestampRange(duration)`)

## Test plan

- [x] New / extended unit tests:
  - `JDBCTraceQueryDAOTest`: 4 new cases covering all three methods with non-null duration + a null-duration fallback case
  - `JDBCSpanAttachedEventQueryDAOTest`: 3 new cases (ZK with duration, SW with duration, ZK with null fallback)
  - `JDBCZipkinQueryDAOTest`: 2 new cases (`getTrace` with duration + null fallback)
  - `TraceQueryEsDAOTest` (new): 4 cases covering all three methods, with + without duration
  - `SpanAttachedEventEsDAOTest` (new): 4 cases covering both methods, with + without duration
- [x] All tests in `storage-jdbc-hikaricp-plugin` and `storage-elasticsearch-plugin` pass (40+ tests)
- [x] `mvn checkstyle:check` clean for both modules