### PR TITLE
Fix broken CLI link in backend-health-check doc

### DIFF
--- a/docs/en/setup/backend/backend-health-check.md
+++ b/docs/en/setup/backend/backend-health-check.md
@@ -67,4 +67,31 @@ You may use the [grpc-health-probe](https://github.com/grpc-ecosystem/grpc-healt
 health of OAP gRPC services.
 
 ## CLI tool
-Please follow the [CLI doc](https://github.com/apache/skywalking-cli#checkhealth) to get the health status score directly through the `checkhealth` command.
+
+The `swctl` CLI ships a `health` subcommand that runs the GraphQL `checkHealth`
+query (and, by default, the gRPC `HealthCheck` service) and exits with a
+non-zero status when the OAP is unhealthy.
+
+```bash
+# Plain gRPC
+swctl --base-url=http://OAP:12800/graphql health
+
+# OAP gRPC with TLS (cert verification is intentionally skipped)
+swctl --base-url=http://OAP:12800/graphql health --grpcTLS=true
+```
+
+### Reading the response
+
+A healthy OAP returns the same `score: 0` envelope shown in the GraphQL
+section above and the process exits 0. A failing run prints the GraphQL /
+gRPC error and exits non-zero — straightforward to wire into a shell readiness
+loop:
+
+```bash
+if swctl --base-url=http://OAP:12800/graphql health >/dev/null 2>&1; then
+  echo "OAP healthy"
+else
+  echo "OAP not healthy"
+  exit 1
+fi
+```


### PR DESCRIPTION
### Fix broken CLI link in backend-health-check doc

The \`## CLI tool\` section links to \`https://github.com/apache/skywalking-cli#checkhealth\`, but:

1. **The anchor doesn't exist** — \`grep -i checkhealth\` against the CLI README returns nothing.
2. **The command isn't even named \`checkhealth\`** — the actual command is \`swctl health\` (Name field at \`internal/commands/healthcheck/healthcheck.go:30\`), documented only in \`--help\` text.

Operators following the link land on the README, find nothing about a \`checkhealth\` command, and don't realise they need \`swctl health\`.

This PR replaces the broken link with self-contained documentation: the canonical \`swctl health\` invocation (plain + TLS) and a shell snippet showing how to wire the exit status into a readiness loop. No source-code links.

- [x] Add a unit test to verify that the fix works. *(N/A — doc-only change)*
- [x] Explain briefly why the bug exists and how to fix it. *(see above)*
- [x] Update the [\`CHANGES\` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md). *(N/A — internal doc fix, not a user-facing feature change)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)