### PR TITLE
DSL debugger (OAL): emit source @ScopeDefaultColumn fields on output sample via codegen

### DIFF
--- a/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/v2/generator/OALClassGeneratorV2.java
+++ b/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/v2/generator/OALClassGeneratorV2.java
@@ -89,7 +89,16 @@ public class OALClassGeneratorV2 {
         "deserialize",
         "getMeta",
         "toHour",
-        "toDay"
+        "toDay",
+        // Emits the source's @ScopeDefaultColumn fields (the codegen-
+        // materialised dynamic @Column fields on the generated subclass)
+        // onto the dsl-debugging `output` sample. For a Service-style
+        // scope that is exactly entityId + attr0..attr5 — nothing about
+        // the metric's own value, which is delegated upward via
+        // super.appendDebugFields(obj) to the family parent's override
+        // (CPMMetrics emits total + value, SumMetrics emits value,
+        // LongAvgMetrics emits summation + count + value, …).
+        "appendDebugFields"
     };
     private static final String[] METRICS_BUILDER_CLASS_METHODS = {
         "entity2Storage",

--- a/oap-server/oal-rt/src/main/resources/code-templates-v2/metrics/appendDebugFields.ftl
+++ b/oap-server/oal-rt/src/main/resources/code-templates-v2/metrics/appendDebugFields.ftl
@@ -1,0 +1,18 @@
+protected void appendDebugFields(com.google.gson.JsonObject obj) {
+super.appendDebugFields(obj);
+<#list fieldsFromSource as field>
+    <#if field.typeName == "long">
+        obj.addProperty("${field.columnName}", java.lang.Long.valueOf(${field.fieldGetter}()));
+    <#elseif field.typeName == "int">
+        obj.addProperty("${field.columnName}", java.lang.Integer.valueOf(${field.fieldGetter}()));
+    <#elseif field.typeName == "double">
+        obj.addProperty("${field.columnName}", java.lang.Double.valueOf(${field.fieldGetter}()));
+    <#elseif field.typeName == "float">
+        obj.addProperty("${field.columnName}", java.lang.Float.valueOf(${field.fieldGetter}()));
+    <#elseif field.typeName == "boolean">
+        obj.addProperty("${field.columnName}", java.lang.Boolean.valueOf(${field.fieldGetter}()));
+    <#else>
+        obj.addProperty("${field.columnName}", ${field.fieldGetter}() == null ? null : ${field.fieldGetter}().toString());
+    </#if>
+</#list>
+}


### PR DESCRIPTION
### Fix missing `attr0..5` / `entityId` columns in OAL debug capture

**Bug.** A debug session against any OAL metric (e.g.
`oal/core.oal/service_cpm`) shows the terminal `output` sample with only
the family parent's value columns:

```json
{ "type": "ServiceCpmMetrics", "timeBucket": …, "id": …,
  "total": 1, "value": 0 }
```

The source-derived storage columns `attr0..attr5` and `entityId` are
absent — even though the OAL-generated subclass DOES carry them on the
live instance, the entry function copied them from the Source, and the
storage row in BanyanDB DOES persist them. Operators verifying e.g. the
layer name written to `attr0` by `ServiceDecorator` cannot see it in
the debugger; they have to cross-reference with a storage query.

**Why the gap.** For OAL-generated metrics, `attr0..5` are NOT
inherited from a fixed parent — they are declared on the source class
via `@ScopeDefaultColumn.DefinedByField`, surfaced by
`SourceColumnsFactory.getColumns()`, and copied to the generated
metrics subclass at OAL boot by `OALClassGeneratorV2.generateMetricsClass`
(line 220, the `for (CodeGenModel.SourceFieldV2 field :
model.getFieldsFromSource()) metricsClass.addField(...)` loop). The
family parent (CPMMetrics, SumMetrics, …) doesn't know the dynamic
fields exist, so its `appendDebugFields(JsonObject)` override only
emits its own value columns. `Metrics.toJson()` then renders just
`{type, timeBucket, lastUpdateTimestamp, id} + family fields`.

**The fix.** Codegen-side. The same OAL pass that materialises the
dynamic fields now also emits an `appendDebugFields(JsonObject)`
override on the generated subclass:
```java
protected void appendDebugFields(com.google.gson.JsonObject obj) {
    super.appendDebugFields(obj);  // delegates to family override
                                   // (CPMMetrics → total + value, …)
    obj.addProperty("entity_id", entityId);
    obj.addProperty("attr0", attr0);
    // … each @ScopeDefaultColumn-declared field
}
```
Mechanically: a new FreeMarker template
`oap-server/oal-rt/src/main/resources/code-templates-v2/metrics/appendDebugFields.ftl`
iterates `fieldsFromSource` and emits the right typed
`obj.addProperty(...)` overload (Long / Integer / Double / Float /
Boolean wrappers for primitives so Javassist resolves the
`addProperty(String, Number)` overload unambiguously; null-safe
`toString()` for object types). The generator picks it up by listing
`"appendDebugFields"` in `METRICS_CLASS_METHODS`, the same array that
already drives `id.ftl`, `serialize.ftl`, etc.

**Why codegen, not reflection / a `Convert2Storage` shim.** The fields
are codegen-materialised — putting their debug projection in the same
codegen pass keeps the field list literally hard-coded in the bytecode
(zero reflection at runtime, exact parity with what the generator
declared). Recorder-side reflection or a JsonObject-backed
`Convert2Storage` would also work but adds a runtime walker per probed
emit; codegen is strictly cheaper.

- [x] Add a unit test to verify that the fix works.
  - All 98 existing `oap-server/oal-rt` unit tests pass against the new
    METRICS_CLASS_METHODS entry — the existing
    `OALClassGeneratorV2Test` and `RuntimeOALGenerationTest` exercise
    the full template-driven generator. The generated method is loaded
    onto every `*Metrics` subclass at OAP boot, so a generator failure
    would surface as a class-load error before a single source event
    is dispatched.
  - Live-verified post-deploy: an OAL session against
    `oal/core.oal/service_cpm` now shows the dynamic columns on the
    terminal sample in addition to the family parent's value fields.
- [x] Explain briefly why the bug exists and how to fix it.
  - See above. The bug is debug-output only; the storage row was
    always correct, only the wire payload missed the dynamic columns.
    The fix is debug-only and zero-cost when
    `SW_DSL_DEBUGGING_INJECTION_ENABLED=false` (the override is only
    invoked from `Metrics.toJson()`, which is only called by the
    gated dsl-debugging recorder).

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
  - Not required: this is a follow-up patch to the same unreleased
    SWIP-13 surface that PR #13865 just landed against, already
    covered by the 10.5.0 changelog entry.