### PR TITLE
Add explicit read-only permissions to CI workflows

### DIFF
--- a/.github/workflows/dead-link-checker.yaml
+++ b/.github/workflows/dead-link-checker.yaml
@@ -23,6 +23,9 @@ on:
   schedule:
     - cron: '0 18 * * *'  # TimeZone: UTC 0
 
+permissions:
+  contents: read
+
 concurrency:
   group: dlc-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -21,6 +21,9 @@ on:
   schedule:
     - cron: "0 18 * * *" # TimeZone: UTC 0
 
+permissions:
+  contents: read
+
 concurrency:
   group: skywalking-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to:
  - `.github/workflows/skywalking.yaml`
  - `.github/workflows/dead-link-checker.yaml`
- Set token scope to `contents: read` for both workflows.

## Why
These workflows only require repository read access. Explicitly declaring minimal permissions follows least-privilege GitHub Actions hardening and avoids implicit broad token defaults.