### PR TITLE
Improve downsampling documentation

### DIFF
--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -291,5 +291,6 @@
 * Update LAL documentation with `sourceAttribute()` function and `layer: auto` mode.
 * Add iOS app monitoring setup documentation.
 * Add WeChat / Alipay Mini Program monitoring setup documentation, plus a client-side-monitoring section in the security guide covering public-internet ingress (OTLP + `/v3/segments`) for mobile / browser / mini-program SDKs.
+* Improve downsampling documentation
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/issues?q=milestone:11.0.0)

--- a/docs/en/concepts-and-designs/mal.md
+++ b/docs/en/concepts-and-designs/mal.md
@@ -303,14 +303,14 @@ MAL should instruct meter-system on how to downsample for metrics. It doesn't on
 
 Down sampling function is called `downsampling` in MAL, and it accepts the following types:
 
-- `AVG`: Calculates the average value of the samples within the time window.
-- `SUM`: Calculates the total sum of the samples within the time window.
-- `LATEST`: Selects the most recent sample value within the time window.
+- `AVG`: Calculates the average value of the samples.
+- `SUM`: Calculates the total sum of the samples.
+- `LATEST`: Selects the most recent sample value.
 - `SUM_PER_MIN`: Calculates the sum of the samples specifically per minute.
-- `MIN`: Selects the minimum sample value within the time window.
-- `MAX`: Selects the maximum sample value within the time window.
-- `MEAN`: Calculates the mathematical mean of all sample values within the downsampling window.
-- `COUNT`: Computes the total number of metric data points or events recorded within the downsampling window.
+- `MIN`: Selects the minimum sample value.
+- `MAX`: Selects the maximum sample value.
+- `MEAN`: Calculates the mathematical mean of all sample values.
+- `COUNT`: Computes the total number of metric data points or events recorded.
 
 The default type is `AVG`.
 

--- a/docs/en/concepts-and-designs/mal.md
+++ b/docs/en/concepts-and-designs/mal.md
@@ -303,14 +303,14 @@ MAL should instruct meter-system on how to downsample for metrics. It doesn't on
 
 Down sampling function is called `downsampling` in MAL, and it accepts the following types:
 
- - AVG
- - SUM
- - LATEST
- - SUM_PER_MIN
- - MIN
- - MAX
- - MEAN (TODO)
- - COUNT (TODO)
+- `AVG`: Calculates the average value of the samples within the time window.
+- `SUM`: Calculates the total sum of the samples within the time window.
+- `LATEST`: Selects the most recent sample value within the time window.
+- `SUM_PER_MIN`: Calculates the sum of the samples specifically per minute.
+- `MIN`: Selects the minimum sample value within the time window.
+- `MAX`: Selects the maximum sample value within the time window.
+- `MEAN`: Calculates the mathematical mean of all sample values within the downsampling window.
+- `COUNT`: Computes the total number of metric data points or events recorded within the downsampling window.
 
 The default type is `AVG`.
 


### PR DESCRIPTION
Document MAL downsampling operations by adding descriptions for MEAN and COUNT, and clarify the behavior of existing downsampling types.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).
