### PR TITLE
Add 3D Infrastructure Map demo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ microservices, cloud native and container-based architectures.
 * AI Power Enabled
   * Machine Learning (ML) and Artificial Intelligence (AI) analyze observability data to identify patterns and enhance capabilities, such as recognizing HTTP URI patterns and automatically calculating metric baselines for intelligent alerting, improving anomaly detection.
 
-<img src="https://skywalking.apache.org/images/home/architecture.svg?t=20220516"/>
-
 # Live Demo
+
+[<img src="https://skywalking.apache.org/images/home/horizon-3d-map.png" alt="SkyWalking 3D Infrastructure Map"/>](https://skywalking.apache.org/3d-map-app/#/3d/map)
+
+- Explore the [SkyWalking 3D Infrastructure Map interactive demo](https://skywalking.apache.org/3d-map-app/#/3d/map), a 3D visualization of the service topology powered by [Horizon UI](https://github.com/apache/skywalking-horizon-ui).
 - Find the [SkyWalking live demo with native UI and Grafana](https://skywalking.apache.org/#demo), and [screenshots](https://skywalking.apache.org/#arch) on our website.
 - Follow the [showcase](https://skywalking.apache.org/docs/skywalking-showcase/next/readme/) to set up a preview deployment quickly.
 


### PR DESCRIPTION
### Surface the SkyWalking 3D Infrastructure Map demo on the README

Adds the 3D Infrastructure Map (powered by [Horizon UI](https://github.com/apache/skywalking-horizon-ui)) to the README's **Live Demo** section:

- A clickable screenshot (`horizon-3d-map.png`) linking to the hosted interactive demo at https://skywalking.apache.org/3d-map-app/#/3d/map
- A Live Demo bullet describing it as a 3D visualization of the service topology

Documentation/website link only — no functional, code, or schema change.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md). N/A — README front-page demo link only, no user-facing OAP change.