### PR TITLE
Correct Horizon UI setup docs (Docker Hub image, port 8081, horizon.yaml config)

### DIFF
--- a/docs/en/academy/diagnose-service-mesh-network-performance-with-ebpf.md
+++ b/docs/en/academy/diagnose-service-mesh-network-performance-with-ebpf.md
@@ -199,7 +199,7 @@ helm -n istio-system install skywalking skywalking \
  --set elasticsearch.minimumMasterNodes=1 \
  --set elasticsearch.imageTag=7.5.1 \
  --set oap.replicas=1 \
- --set ui.image.repository=ghcr.io/apache/skywalking-horizon-ui \
+ --set ui.image.repository=apache/skywalking-ui \
  --set ui.image.tag=latest \
  --set oap.image.tag=9.2.0 \
  --set oap.envoy.als.enabled=true \

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -46,8 +46,10 @@
   or pushed the UI image. The official UI is now
   [**Horizon UI**](https://github.com/apache/skywalking-horizon-ui), a SkyWalking
   sub-project that **releases independently** of the OAP backend on its own
-  schedule, with container images published to
-  [`ghcr.io/apache/skywalking-horizon-ui`](https://github.com/apache/skywalking-horizon-ui/pkgs/container/skywalking-horizon-ui).
+  schedule, with released container images on Docker Hub at
+  [`apache/skywalking-ui`](https://hub.docker.com/r/apache/skywalking-ui)
+  (tags `latest` / `horizon-<version>`; per-commit development images live on
+  `ghcr.io/apache/skywalking-horizon-ui`).
   There is no 1:1 mapping between OAP versions and Horizon UI versions —
   operators pin the UI image tag in their deployment and upgrade the two
   on separate cadences.
@@ -66,8 +68,10 @@
   `UIMenuManagementService`, `UIMenuManagementDAO`, `UIMenu`, `MenuItem`,
   and the storage impls are all removed; Horizon UI owns the menu
   client-side and uses `listServices(layer:...)` for dynamic "layer has
-  services" gating. Upgrade path: replace `skywalking/ui:<tag>` with
-  `ghcr.io/apache/skywalking-horizon-ui:<tag>` in your deployment, expose
+  services" gating. Upgrade path: replace `skywalking/ui:<tag>` with the
+  Horizon UI image `apache/skywalking-ui:latest` (or a `horizon-<version>`
+  tag — pick a version per Horizon UI's OAP-compatibility notes, OAP `11.0+`
+  is supported) in your deployment, expose
   port `17128` from the OAP container, and migrate any scripts that
   called the legacy GraphQL UI mutations to the REST endpoints under
   [UI Management API](../setup/backend/admin-api/ui-management.md). All

--- a/docs/en/guides/How-to-release.md
+++ b/docs/en/guides/How-to-release.md
@@ -131,8 +131,9 @@ make docker.push
 
 > Note: this repository no longer builds the UI Docker image. The official
 > web UI ships from [`apache/skywalking-horizon-ui`](https://github.com/apache/skywalking-horizon-ui),
-> which has its own release cadence and publishes images independently
-> under `ghcr.io/apache/skywalking-horizon-ui`. The OAP release described
+> which has its own release cadence and publishes images independently:
+> released images to Docker Hub `apache/skywalking-ui`, per-commit development
+> images to `ghcr.io/apache/skywalking-horizon-ui`. The OAP release described
 > above is independent of any Horizon UI release — they advance on
 > separate schedules and are matched at deploy time, not at release time.
 

--- a/docs/en/setup/backend/backend-telemetry.md
+++ b/docs/en/setup/backend/backend-telemetry.md
@@ -68,8 +68,8 @@ Set this up following these steps:
                --set elasticsearch.minimumMasterNodes=1 \
                --set elasticsearch.imageTag=7.5.1 \
                --set oap.replicas=2 \
-               --set ui.image.repository=ghcr.io/apache/skywalking-horizon-ui \
-               --set ui.image.tag=$TAG \
+               --set ui.image.repository=apache/skywalking-ui \
+               --set ui.image.tag=latest \
                --set oap.image.tag=$TAG \
                --set oap.image.repository=$HUB/skywalking-oap \
                --set oap.storageType=elasticsearch \

--- a/docs/en/setup/backend/ui-setup.md
+++ b/docs/en/setup/backend/ui-setup.md
@@ -4,36 +4,63 @@ The SkyWalking web UI ships from a dedicated project,
 [apache/skywalking-horizon-ui](https://github.com/apache/skywalking-horizon-ui).
 This OAP distribution does not bundle a UI.
 
-Horizon UI **releases independently** of the OAP backend. The two projects
-advance on separate schedules, are matched at deploy time (not at release
-time), and the OAP `x.y.z` tag has no implied Horizon UI counterpart. Pin
-the UI image tag explicitly in your deployment.
+Horizon UI **releases independently** of the OAP backend, on its own
+schedule. This repository is **not bound to any specific Horizon UI
+version** — backend compatibility is Horizon UI's responsibility, and it
+supports OAP from `11.0` onward. Don't lock the UI to an OAP `x.y.z` tag;
+pick the UI version following
+[Horizon UI's OAP-compatibility notes](https://skywalking.apache.org/docs/skywalking-horizon-ui/next/compatibility/oap-version/).
 
 ## Run Horizon UI with Docker
 
-Container images are published to
-[`ghcr.io/apache/skywalking-horizon-ui`](https://github.com/apache/skywalking-horizon-ui/pkgs/container/skywalking-horizon-ui).
-Operators pin to a commit SHA for reproducibility, or use `latest` for tracking.
+Released images are published to Docker Hub at
+[`apache/skywalking-ui`](https://hub.docker.com/r/apache/skywalking-ui) —
+use the `latest` tag, or a `horizon-<version>` tag for a reproducible
+deploy. Per-commit development images are pushed to
+[`ghcr.io/apache/skywalking-horizon-ui`](https://github.com/apache/skywalking-horizon-ui/pkgs/container/skywalking-horizon-ui)
+and are for testing the development branch, not production.
+
+Horizon UI is configured through a mounted `horizon.yaml` file (not
+environment variables). The OAP wiring it needs is the query host and the
+admin host; the Zipkin host is only required if a layer uses Zipkin
+traces:
 
 ```shell
 docker run --name skywalking-ui --restart always -d \
-  -p 8080:8080 \
-  -e SW_OAP_ADDRESS=http://oap:12800 \
-  -e SW_ADMIN_ADDRESS=http://oap:17128 \
-  -e SW_ZIPKIN_ADDRESS=http://oap:9412 \
-  ghcr.io/apache/skywalking-horizon-ui:latest
+  -p 8081:8081 \
+  -v "$PWD/horizon.yaml:/app/horizon.yaml:ro" \
+  apache/skywalking-ui:latest
 ```
 
-### Environment variables
+A minimal `horizon.yaml` pointed at your OAP cluster:
 
-| Variable | Default | Description |
-|---|---|---|
-| `SW_OAP_ADDRESS` | `http://127.0.0.1:12800` | OAP public GraphQL / REST surface — read-side queries (services, metrics, traces, logs, alarms, MQE). |
-| `SW_ADMIN_ADDRESS` | `http://127.0.0.1:17128` | OAP admin host — `/ui-management/templates/*` (dashboard templates; menu is owned by Horizon UI client-side), `/status/*`, `/inspect/*`, `/dsl-debugging/*`, `/runtime/rule/*`. |
-| `SW_ZIPKIN_ADDRESS` | `http://127.0.0.1:9412` | OAP Zipkin v2 query endpoint, for trace ingestion paths that target the Zipkin compatibility layer. |
+```yaml
+oap:
+  queryUrl: http://oap:12800        # GraphQL / query surface
+  adminUrl: http://oap:17128        # admin host (runtime-rule, inspect, dsl-debugging, status)
+  zipkinUrl: http://oap:9412/zipkin # only if a layer uses Zipkin traces
+```
 
-## Building UI assets
+There is no default account — you must configure at least one login
+(local users or LDAP) before anyone can sign in. Authentication, RBAC,
+sessions, the full `horizon.yaml` reference, and the container layout are
+all covered in the Horizon UI docs; don't expect this page to mirror
+them.
 
-The Horizon UI repository owns its own build, release, and CI workflow. To
-contribute dashboards, menus, widgets, or i18n, see the
-[Horizon UI contributing guide](https://github.com/apache/skywalking-horizon-ui#contributing).
+## What Horizon UI provides
+
+Beyond the application itself, Horizon UI ships the entire visualization
+layer that the OAP backend no longer seeds: the default dashboard
+configurations for every supported layer, several cross-cutting overview
+and 3D infrastructure-map setups, i18n translations, and the sidebar
+menu. Operators customize these in the UI's admin pages.
+
+## Documentation
+
+Horizon UI's documentation is the source of truth and tracks the UI
+release, not this backend. Start here:
+
+* [Horizon UI documentation](https://skywalking.apache.org/docs/skywalking-horizon-ui/next/readme/)
+* [Container image & deployment](https://skywalking.apache.org/docs/skywalking-horizon-ui/next/setup/container-image/)
+* [`horizon.yaml` reference](https://skywalking.apache.org/docs/skywalking-horizon-ui/next/setup/horizon-yaml/)
+* [OAP connection](https://skywalking.apache.org/docs/skywalking-horizon-ui/next/setup/oap/)

--- a/docs/en/ui/README.md
+++ b/docs/en/ui/README.md
@@ -34,9 +34,12 @@ Each area lives in the
 ## Bundled UI templates
 
 The OAP backend does **not** seed dashboard JSONs at boot anymore.
-Horizon UI owns the bundled template set — layer dashboards, overview
-templates, and alert views — and ships them in its own image. See
-[apache/skywalking-horizon-ui · apps/bff/src/bundled_templates](https://github.com/apache/skywalking-horizon-ui/tree/main/apps/bff/src/bundled_templates).
+Horizon UI owns and ships the entire bundled set in its own image: the
+default dashboard configurations for every supported layer, several
+cross-cutting overview and 3D infrastructure-map setups, the sidebar
+menu, and i18n translations. Operators customize these in the UI's admin
+pages; see the
+[Horizon UI documentation](https://skywalking.apache.org/docs/skywalking-horizon-ui/next/readme/).
 
 ## Editing dashboards from the UI
 


### PR DESCRIPTION
### Fix incorrect Horizon UI setup documentation
- [ ] Add a unit test to verify that the fix works. (N/A — documentation only)
- [x] Explain briefly why the bug exists and how to fix it.

The Horizon UI setup docs predated Horizon UI's settled configuration surface and were factually wrong on three counts:

1. **Registry** — they pointed operators at the GHCR dev registry for production. Released images are mirrored to Docker Hub `apache/skywalking-ui` (tags `latest` / `horizon-<version>`); `ghcr.io/apache/skywalking-horizon-ui` is per-commit/dev only.
2. **Port** — the `docker run` example used `8080`. Horizon UI's BFF binds **8081** (`EXPOSE 8081`).
3. **Configuration** — they documented `SW_OAP_ADDRESS` / `SW_ADMIN_ADDRESS` / `SW_ZIPKIN_ADDRESS` environment variables that **Horizon UI does not read**. It is configured via a mounted `horizon.yaml` (`oap.queryUrl` / `oap.adminUrl` / `oap.zipkinUrl`), so the old example could not have worked.

This PR corrects those and applies the same registry/version policy across the docs:

- `setup/backend/ui-setup.md` — rewritten: Docker Hub image, port 8081, `horizon.yaml` config, no-default-login note, **no Horizon UI version lock** (OAP `11.0+` supported; compatibility is Horizon UI's responsibility), high-level "what Horizon provides", and links to the Horizon UI website docs only.
- `ui/README.md` — drop the source-code link; describe the bundled set (default per-layer dashboard configs, overview / 3D infra-map setups, sidebar menu, i18n) at a high level.
- `changes/changes.md` — fix the 11.0.0 breaking-change entry's registry + upgrade-path references; unlock the version.
- `setup/backend/backend-telemetry.md` + `academy/diagnose-service-mesh-network-performance-with-ebpf.md` — Helm `ui.image.repository=apache/skywalking-ui`, decouple the UI tag from the OAP `$TAG`.
- `guides/How-to-release.md` — distinguish Docker Hub (releases) from GHCR (per-commit dev).

Verified against the Horizon UI source (`apache/skywalking-horizon-ui`, incl. `publish-image.yaml`, `horizon.example.yaml`, `docs/`) and the `skywalking-helm` chart (`ui-svc.yaml`: Service port `80` → targetPort `8081`, and `values.yaml` which documents the same registry policy).

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md). (Documentation correction — no new functional change to log; this PR corrects an existing 11.0.0 entry.)