### PR TITLE
Fix docker-compose quickstart for Horizon UI and OAP healthcheck

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -77,6 +77,7 @@ docker compose --profile banyandb up
 such as the Docker image registry and tags.
 
 After the services are up and running, you can send telemetry data to
-`localhost:11800` and access the Horizon UI at <http://localhost:8080>. The OAP
-admin host is exposed on `localhost:17128` (UI templates, runtime-rule hot
-update, DSL debugging, status, inspect).
+`localhost:11800` and access the Horizon UI at <http://localhost:8080>
+(default login `admin` / `admin`, configured in [docker/horizon.yaml](./horizon.yaml)).
+The OAP admin host is exposed on `localhost:17128` (UI templates, runtime-rule
+hot update, DSL debugging, status, inspect).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,11 +67,15 @@ services:
     networks:
       - demo
     healthcheck:
-      test: [ "CMD-SHELL", "curl http://localhost:12800/internal/l7check" ]
-      interval: 30s
+      # The OAP image (eclipse-temurin JRE) ships bash but no curl/wget/nc,
+      # so probe the query port with bash's built-in /dev/tcp instead.
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/12800" ]
+      interval: 15s
       timeout: 10s
-      retries: 3
-      start_period: 10s
+      retries: 10
+      # OAP can take 60-120s to boot (BanyanDB schema install); don't count
+      # failures against the retry budget during that window.
+      start_period: 90s
     environment: &oap-env
       SW_HEALTH_CHECKER: default
       SW_TELEMETRY: prometheus
@@ -111,13 +115,15 @@ services:
     image: ${UI_IMAGE:-ghcr.io/apache/skywalking-horizon-ui:latest}
     container_name: ui
     ports:
-      - "8080:8080"
+      # Horizon listens on 8081 inside the container (HORIZON_SERVER_PORT).
+      - "8080:8081"
     networks:
       - demo
-    environment:
-      SW_OAP_ADDRESS: http://oap:12800
-      SW_ADMIN_ADDRESS: http://oap:17128
-      SW_ZIPKIN_ADDRESS: http://oap:9412
+    volumes:
+      # Backend URLs (OAP query/admin/zipkin) and login users come ONLY from
+      # this file; there are no env vars for them. The image's HORIZON_CONFIG
+      # default points here.
+      - ./horizon.yaml:/app/horizon.yaml:ro
 
 networks:
   demo:

--- a/docker/horizon.yaml
+++ b/docker/horizon.yaml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Horizon UI config for the docker-compose quickstart. The image reads its
+# backend wiring and login users ONLY from this file (mounted at the image's
+# HORIZON_CONFIG path) — there are no env vars for the OAP URLs.
+
+server:
+  # Bind all interfaces. The default example config ships host: 127.0.0.1,
+  # which binds container-loopback only and 503s from the host side.
+  host: 0.0.0.0
+  port: 8081
+
+oap:
+  # Point at the `oap` service on the compose network, not 127.0.0.1.
+  queryUrl: http://oap:12800
+  adminUrl: http://oap:17128
+  zipkinUrl: http://oap:9412/zipkin
+
+# Demo login: admin / admin. Change before exposing this beyond localhost.
+# rbac defaults to enabled with the admin role granting `*`.
+auth:
+  backend: local
+  local:
+    users:
+      - username: admin
+        passwordHash: "$argon2id$v=19$m=65536,t=3,p=4$joV9AVlyLS3pqq4mLrYokQ$pJLkTKrz9/LzEH6YaFljdz9k8dyBiryjwSB26Diiz9U"
+        roles: [admin]

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -303,5 +303,6 @@
 * Add iOS app monitoring setup documentation.
 * Add WeChat / Alipay Mini Program monitoring setup documentation, plus a client-side-monitoring section in the security guide covering public-internet ingress (OTLP + `/v3/segments`) for mobile / browser / mini-program SDKs.
 * Improve downsampling documentation
+* Fix the docker-compose quickstart: OAP healthcheck no longer calls `curl` (absent from the JRE image) and probes the query port via bash `/dev/tcp`; the Horizon UI service maps the correct container port (8081) and mounts a `horizon.yaml` (binding `0.0.0.0`, OAP URLs, demo `admin`/`admin` login) instead of non-existent `SW_*_ADDRESS` env vars.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/issues?q=milestone:11.0.0)


### PR DESCRIPTION
### Fix docker-compose quickstart issues reported in #13896

The docker-compose quickstart had three problems that surfaced when a user tried the Horizon UI with a mounted `horizon.yaml`:

1. **OAP healthcheck used `curl`**, which isn't present in the `eclipse-temurin` JRE image — the healthcheck never ran. Replaced with bash's built-in `/dev/tcp` port probe (no extra binary), and widened `start_period` to `90s` so BanyanDB schema install during boot doesn't consume the retry budget.
2. **Horizon UI port mapping was wrong** — Horizon listens on `8081` inside the container, but compose mapped `8080:8080`. Fixed to `8080:8081`.
3. **Horizon backend wiring used non-existent env vars** (`SW_OAP_ADDRESS` / `SW_ADMIN_ADDRESS` / `SW_ZIPKIN_ADDRESS`). The image reads OAP URLs and login users **only** from its config file. Now mounts a new `docker/horizon.yaml` with `server.host: 0.0.0.0` (the upstream example ships `127.0.0.1`, which binds container-loopback only and 503s from the host — the original report), OAP query/admin/zipkin URLs pointed at the compose `oap` service, and a demo `admin`/`admin` local login.

- [x] Explain briefly why the bug exists and how to fix it.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #13896.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).