### PR TITLE
Fix BanyanDB property merge-latency unit (nanoseconds, not seconds)

### DIFF
--- a/oap-server/server-starter/src/main/resources/otel-rules/banyandb/banyandb-endpoint.yaml
+++ b/oap-server/server-starter/src/main/resources/otel-rules/banyandb/banyandb-endpoint.yaml
@@ -132,10 +132,14 @@ metricsRules:
   # rate(merge_started) in ms. banyandb_property_inverted_index_total_merge_started carries
   # type=file/mem; .sum() collapses it (file is the on-disk merge). Property merge IS applicable,
   # unlike the _total_written-based write_rate which property never emits.
+  # UNIT: property's merge-latency gauge is the bluge inverted-index ZapTime, accumulated in
+  # NANOSECONDS (uint64(time.Since(...)), bluge index/merge.go) -- NOT seconds like the tst
+  # merge_file_latency rules (banyand/measure/merger.go incTotalMergeLatency(elapsed.Seconds())).
+  # So convert ns -> ms with /1000000, NOT the *1000 (s->ms) used by the tst latency rules.
   - name: property_index_merge_rate
     exp: banyandb_property_inverted_index_total_merge_started.sum(['cluster', 'group']).rate('PT1M') * 60
   - name: property_index_merge_latency
-    exp: banyandb_property_inverted_index_total_merge_latency.sum(['cluster', 'group']).rate('PT1M').safeDiv(banyandb_property_inverted_index_total_merge_started.sum(['cluster', 'group']).rate('PT1M')) * 1000
+    exp: banyandb_property_inverted_index_total_merge_latency.sum(['cluster', 'group']).rate('PT1M').safeDiv(banyandb_property_inverted_index_total_merge_started.sum(['cluster', 'group']).rate('PT1M')) / 1000000
 
   # ---- Series write rate (per data-model type) ----
   # inverted-index updates/s for the group (series-write proxy). NOTE: *_inverted_index_total_updates


### PR DESCRIPTION
### Fix `meter_banyandb_endpoint_property_index_merge_latency` over-reporting by 1,000,000×

- [ ] Add a unit test to verify that the fix works. — The MAL test asserts entities (not metric *values*) and the boot-check asserts the rule compiles; the value-correctness here is established by the BanyanDB **source unit** (see below), which a rule unit test can't assert. Boot-check (`DSLClassGeneratorTest`) green.
- [x] Explain briefly why the bug exists and how to fix it.

**Why:** `property_index_merge_latency` converted its source with `* 1000` (seconds → ms), like the `*_tst_total_merge_latency` rules. But `banyandb_property_inverted_index_total_merge_latency` is **not** in seconds — it's bluge's inverted-index `ZapTime`, set directly from `float64(TotFileMergeZapTime)` (`pkg/index/inverted/metrics.go:151,156`), which bluge computes as `uint64(time.Since(...))` (`index/merge.go`) — a raw `time.Duration` in **nanoseconds**, never `.Seconds()`. So the rule over-reported merge latency by **1e6**.

**Fix:** convert ns → ms with `/ 1000000` (one line + a source-cited comment).

**Scope check:** I audited *every* BanyanDB latency rule across the three `banyandb-*.yaml` files against the source. All others are correct — every other family records `.Seconds()`; the histogram `*_latency_p99` rules get an implicit seconds → ms from MAL's `histogram()` default `SECONDS` bucket unit (`le * toMillis(1)`), so they correctly omit `*1000`; the `safeDiv * 1000` rules (query / merge-file latency) match their seconds source. **`property_index_merge_latency` was the only mismatch.**

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md). — N/A: `property_index_merge_latency` is part of the **unreleased** SWIP-15 so11y rules (11.0.0, merged in #13905, not yet released), so the bug never shipped; covered by that entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)