### PR TITLE
Let Spring Boot manage logback (matched) to clear logback-core CVE alerts

### DIFF
--- a/test/e2e-v2/java-test-service/e2e-service-provider/pom.xml
+++ b/test/e2e-v2/java-test-service/e2e-service-provider/pom.xml
@@ -35,7 +35,6 @@
 
     <properties>
         <log4j2.version>2.25.4</log4j2.version>
-        <logback.version>1.2.13</logback.version>
     </properties>
 
     <dependencies>
@@ -75,20 +74,14 @@
             <version>${log4j2.version}</version>
         </dependency>
         <dependency>
+            <!-- No explicit version: let spring-boot-dependencies manage BOTH
+                 logback-classic and logback-core to the same version so they never
+                 mismatch. A classic newer than the managed core makes logback-classic's
+                 ThrowableProxy call OptionHelper.isNotEmtpy() (absent in the older core),
+                 throwing NoSuchMethodError when logging an exception. Java 8 / Spring
+                 Boot 2.x keeps this on the logback 1.2.x line. -->
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-        </dependency>
-        <dependency>
-            <!-- Pin logback-core to the same version as logback-classic. Spring Boot's
-                 dependency management otherwise holds logback-core at an older version
-                 (1.2.6), and logback-classic 1.2.13's ThrowableProxy calls
-                 OptionHelper.isNotEmtpy() which only exists in the matching core, so
-                 logging any exception throws NoSuchMethodError and kills the request
-                 thread. -->
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.skywalking</groupId>


### PR DESCRIPTION
### Fix the logback-core CVE alerts surfaced by #13915

Follow-up to #13915. After #13915 added an explicit `logback-core` 1.2.13 dependency to `e2e-service-provider` (to fix the lua-hang `NoSuchMethodError`), Dependabot started flagging `logback-core` — **4 alerts**, all patched only in logback 1.3.x/1.5.x which require **SLF4J 2.0 / Spring Boot 3 / Java 17**, unreachable on this **Java 8 / Spring Boot 2.5** test fixture.

**Root of the whole thing:** #13913 pinned `logback-classic` to 1.2.13 while Spring Boot kept `logback-core` at 1.2.6. The mismatch is what made `logback-classic`'s `ThrowableProxy` call `OptionHelper.isNotEmtpy()` (absent in the older core) → `NoSuchMethodError` → dead Tomcat thread → the lua e2e hang.

**Fix:** drop the explicit logback pins (both the classic `${logback.version}` and #13915's `logback-core` dep) and let `spring-boot-dependencies` manage **both** to the same version (1.2.6).
- **Matched** classic+core can never trigger the `NoSuchMethodError` → the lua fix is preserved.
- A **BOM-managed (not declared)** `logback-core` is not flagged by Dependabot (as the same 1.2.6 wasn't, pre-#13915) → the 4 alerts clear, without shipping a *declared* vulnerable dependency.

Verified locally: the provider jar now bundles `logback-classic-1.2.6` + `logback-core-1.2.6` (matched), and the poms contain no explicit logback version pin.

- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md) — N/A, test-fixture only.