### PR TITLE
docs: list Java 25 in OAP backend runtime requirement

### DIFF
--- a/docs/en/setup/backend/backend-setup.md
+++ b/docs/en/setup/backend/backend-setup.md
@@ -14,7 +14,7 @@ SkyWalking's backend distribution package consists of the following parts:
 
 ## Requirements and default settings
 
-Requirement: **Java 11/17/21**.
+Requirement: **Java 11, 17, 21, or 25**. The OAP is compiled for Java 11 (the minimum runtime), so the binary distribution runs on any of these. Official Docker images publish `-java11` / `-java17` / `-java21` tag variants; the default (unsuffixed) image tag is built on Java 25 (`eclipse-temurin:25-jre`).
 
 You should set up the database ready before starting the backend. We recommend to use BanyanDB.
 If you want to use other databases, please read the [storage document](backend-storage.md).


### PR DESCRIPTION
### Fix stale JRE requirement in backend setup docs

- [x] Explain briefly why the doc is wrong and how it is fixed.

`docs/en/setup/backend/backend-setup.md` stated the runtime requirement as **Java 11/17/21**, which is stale: since 10.4.0 the **default (unsuffixed) OAP Docker image is built on `eclipse-temurin:25-jre`** (`docs/.../changes-10.4.0.md`, `docker/oap/Dockerfile`), the release publisher pushes `-java11` / `-java17` / `-java21` variants plus the default Java-25 tag (`.github/workflows/publish-docker.yaml`), and CI builds/tests on 11/17/21/25 (`.github/workflows/skywalking.yaml`).

Updated the requirement to **"Java 11, 17, 21, or 25"** and noted that the default Docker image tag is Java 25 while `-java11/-java17/-java21` variants are also published. Java 11 remains the compile target / minimum runtime (`pom.xml` `maven.compiler.release=11`).

Docs-only accuracy fix; no code change. The JDK 25 support itself was already logged in the 10.4.0 changelog, so no new `CHANGES` entry is added.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)