### PR TITLE
Support Elasticsearch 9.x as storage

### DIFF
--- a/.github/workflows/skywalking.yaml
+++ b/.github/workflows/skywalking.yaml
@@ -377,6 +377,9 @@ jobs:
           - name: Storage ES 8.18.8
             config: test/e2e-v2/cases/storage/es/e2e.yaml
             env: ES_VERSION=8.18.8
+          - name: Storage ES 9.3.0
+            config: test/e2e-v2/cases/storage/es/e2e.yaml
+            env: ES_VERSION=9.3.0
           - name: Storage OpenSearch 2.4.0
             config: test/e2e-v2/cases/storage/opensearch/e2e.yaml
             env: OPENSEARCH_VERSION=2.4.0

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -255,6 +255,7 @@
   admin-host only" entry above for the public REST retirement.
 
 #### OAP Server
+* Support Elasticsearch 9.x as storage.
 * Add Node.js runtime metrics via the Node.js agent **`MeterReportService`** pipeline (`meter_instance_nodejs_*`, 1s collect/report). OAP analyzes raw meters through `nodejs-runtime.yaml`. Node.js E2E asserts six `meter_instance_nodejs_*` metrics (`test/e2e-v2/cases/nodejs/e2e.yaml`).
 * Add PHP runtime PHM meter analyzer (`php-runtime.yaml`) for SkyWalking PHP agent process
   metrics (CPU, memory, virtual memory, thread count, open file descriptors sampled from

--- a/docs/en/setup/backend/storages/elasticsearch.md
+++ b/docs/en/setup/backend/storages/elasticsearch.md
@@ -37,7 +37,7 @@ SkyWalking rebuilds the ElasticSearch client on top of ElasticSearch REST API an
 correct request formats according to the server-side version, hence you don't need to download different binaries
 and don't need to configure different storage selectors for different ElasticSearch server-side versions anymore.
 
-For now, SkyWalking supports ElasticSearch 7.x, ElasticSearch 8.x, and OpenSearch 1.x, their
+For now, SkyWalking supports ElasticSearch 7.x, ElasticSearch 8.x, ElasticSearch 9.x, and OpenSearch 1.x, their
 configurations are as follows:
 
 _Notice, ElasticSearch 6 worked and is not promised due to end of life officially._

--- a/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/ElasticSearchVersion.java
+++ b/oap-server/server-library/library-elasticsearch-client/src/main/java/org/apache/skywalking/library/elasticsearch/ElasticSearchVersion.java
@@ -64,7 +64,7 @@ public final class ElasticSearchVersion {
                 }
                 return;
             }
-            if (major == 8) {
+            if (major >= 8) { // 8.x, 9.x and later: typeless docs + composable index templates
                 requestFactory = new V81RequestFactory(this);
                 codec = V78Codec.INSTANCE;
                 return;

--- a/oap-server/server-library/library-elasticsearch-client/src/test/java/org/apache/skywalking/library/elasticsearch/ElasticSearchIT.java
+++ b/oap-server/server-library/library-elasticsearch-client/src/test/java/org/apache/skywalking/library/elasticsearch/ElasticSearchIT.java
@@ -91,6 +91,13 @@ public class ElasticSearchIT {
                     .withEnv("xpack.security.enabled", "false")
             },
             {
+                "ElasticSearch 9.3.0",
+                new ElasticsearchContainer(
+                    DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+                                   .withTag("9.3.0"))
+                    .withEnv("xpack.security.enabled", "false")
+            },
+            {
                 "OpenSearch 1.0.0",
                 new ElasticsearchContainer(
                     DockerImageName.parse("opensearchproject/opensearch")


### PR DESCRIPTION
### Fix the issue

Adds support for running SkyWalking OAP against **Elasticsearch 9.x** as storage.

### Why

The in-tree ES client (`library-elasticsearch-client`) selects its request factory / codec per server version in `ElasticSearchVersion`. The ceiling was `major == 8`, so any server reporting major version 9 fell through to `UnsupportedOperationException("Unsupported version")` and OAP refused to start against an Elasticsearch 9 cluster.

ES 9 keeps the same REST surface the ES 8 path already relies on — typeless document writes (`POST /{index}/_update/{id}`) and composable index templates (`PUT /_index_template/{name}`) — so no new factory or codec is needed; the version gate just needs to admit major >= 8. This mirrors how OpenSearch is already handled version-agnostically.

### What changed

- `ElasticSearchVersion`: `if (major == 8)` → `if (major >= 8)` for the ElasticSearch distribution (8.x, 9.x and later use the existing typeless-doc + composable-template path).
- `ElasticSearchIT`: add an `ElasticSearch 9.3.0` parameter (all IT methods run against a real ES 9 container).
- CI `skywalking.yaml`: add a `Storage ES 9.3.0` e2e case alongside the existing `8.18.8`.
- Docs: storage doc supported-versions line now lists ElasticSearch 9.x; changelog entry added.

Verified locally against a real `elasticsearch:9.3.0` container: version detection, composable index template, typeless index/get/update/delete, and search all behave as expected.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md).