### PR TITLE
Use imports instead of inline fully-qualified names in the DSL compilers

### DIFF
--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALBlockCodegen.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALBlockCodegen.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.skywalking.oap.server.core.analysis.Layer;
 import org.apache.skywalking.oap.server.core.dsl.DslJavaSourceText;
+import java.lang.reflect.Method;
 
 /**
  * Code generation for LAL block-level structures: {@code extractor},
@@ -250,7 +251,7 @@ final class LALBlockCodegen {
             final LALClassGenerator.GenCtx genCtx) {
         final String[] candidates =
             FIELD_TYPE_SETTER_CANDIDATES[field.getFieldType().ordinal()];
-        java.lang.reflect.Method setter = null;
+        Method setter = null;
         for (final String candidate : candidates) {
             setter = findSetter(genCtx.outputType, candidate);
             if (setter != null) {
@@ -482,7 +483,7 @@ final class LALBlockCodegen {
         }
 
         // Compile-time validation: verify the setter exists on the output type
-        final java.lang.reflect.Method setter = findSetter(genCtx.outputType, setterName);
+        final Method setter = findSetter(genCtx.outputType, setterName);
         if (setter == null) {
             throw new IllegalArgumentException(
                 "Output type " + genCtx.outputType.getName()
@@ -507,11 +508,11 @@ final class LALBlockCodegen {
         sb.append(");\n");
     }
 
-    private static java.lang.reflect.Method findSetter(
+    private static Method findSetter(
             final Class<?> clazz, final String setterName) {
         Class<?> c = clazz;
         while (c != null && c != Object.class) {
-            for (final java.lang.reflect.Method m : c.getDeclaredMethods()) {
+            for (final Method m : c.getDeclaredMethods()) {
                 if (m.getName().equals(setterName)
                         && m.getParameterCount() == 1) {
                     return m;

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGenerator.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALClassGenerator.java
@@ -40,6 +40,7 @@ import org.apache.skywalking.oap.server.core.dsl.debug.DSLDebugCodegenSwitch;
 import org.apache.skywalking.oap.server.core.source.LogBuilder;
 import org.apache.skywalking.oap.log.analyzer.v2.dsl.LalExpression;
 import org.apache.skywalking.oap.server.core.dsl.DslJavaSourceText;
+import javassist.CtField;
 
 /**
  * Generates {@link LalExpression} implementation classes from
@@ -305,7 +306,7 @@ public final class LALClassGenerator {
      * {@code if (this.debug.isGateOn()) LALDebug.captureXxx(this.debug, ...)} call sites
      * that read the field directly.
      */
-    private void emitDebugHolderMembers(final CtClass ctClass) throws javassist.CannotCompileException {
+    private void emitDebugHolderMembers(final CtClass ctClass) throws CannotCompileException {
         if (!DSLDebugCodegenSwitch.isInjectionEnabled()) {
             // Injection off — fall back to the LalExpression.debugHolder() default
             // (null), no GateHolder field, no probe call sites.
@@ -314,7 +315,7 @@ public final class LALClassGenerator {
         final String escapedContent = DslJavaSourceText.toLiteral(content);
         // Per-rule capture binding — instance field, lowercase per Java
         // convention (it's a final but not a static-final constant).
-        ctClass.addField(javassist.CtField.make(
+        ctClass.addField(CtField.make(
             "public final " + LALCodegenHelper.GATE_HOLDER_FQCN + " debug = new "
                 + LALCodegenHelper.GATE_HOLDER_FQCN + "(\"" + escapedContent + "\");",
             ctClass));

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALDefCodegen.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALDefCodegen.java
@@ -18,6 +18,7 @@
 package org.apache.skywalking.oap.log.analyzer.v2.compiler;
 
 import java.util.List;
+import java.lang.reflect.Method;
 
 /**
  * Code generation for LAL {@code def} local variable declarations and
@@ -260,7 +261,7 @@ final class LALDefCodegen {
                 final String methodName = ms.getName();
 
                 // Resolve method on currentType via reflection
-                final java.lang.reflect.Method method =
+                final Method method =
                     resolveMethod(currentType, methodName, ms.getArguments());
                 if (method == null) {
                     throw new IllegalArgumentException(
@@ -299,7 +300,7 @@ final class LALDefCodegen {
                 final String getterName = "get"
                     + Character.toUpperCase(fieldName.charAt(0))
                     + fieldName.substring(1);
-                java.lang.reflect.Method getter = null;
+                Method getter = null;
                 try {
                     getter = currentType.getMethod(getterName);
                 } catch (NoSuchMethodException e) {
@@ -337,7 +338,7 @@ final class LALDefCodegen {
             } else if (seg instanceof LALScriptModel.IndexSegment) {
                 final int index = ((LALScriptModel.IndexSegment) seg).getIndex();
                 // Try get(int) method (e.g., JsonArray.get(int))
-                java.lang.reflect.Method getMethod = null;
+                Method getMethod = null;
                 try {
                     getMethod = currentType.getMethod("get", int.class);
                 } catch (NoSuchMethodException e) {
@@ -367,7 +368,7 @@ final class LALDefCodegen {
      * For methods with String arguments (like JsonObject.get(String)),
      * prioritizes exact match by parameter types.
      */
-    private static java.lang.reflect.Method resolveMethod(
+    private static Method resolveMethod(
             final Class<?> type, final String name,
             final List<LALScriptModel.FunctionArg> args) {
         final int argCount = args != null ? args.size() : 0;
@@ -392,7 +393,7 @@ final class LALDefCodegen {
             }
         }
         // Fallback: find by name and arg count
-        for (final java.lang.reflect.Method m : type.getMethods()) {
+        for (final Method m : type.getMethods()) {
             if (m.getName().equals(name)
                     && m.getParameterCount() == argCount) {
                 return m;

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALValueCodegen.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/compiler/LALValueCodegen.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.skywalking.oap.server.core.source.LogMetadata;
 import org.apache.skywalking.oap.server.core.dsl.DslJavaSourceText;
+import java.lang.reflect.Method;
 
 /**
  * Code generation for LAL expression evaluation: value access, conditions,
@@ -1113,7 +1114,7 @@ final class LALValueCodegen {
             final String getterName = "get" + Character.toUpperCase(field.charAt(0))
                 + field.substring(1);
 
-            final java.lang.reflect.Method getter;
+            final Method getter;
             try {
                 getter = currentType.getMethod(getterName);
             } catch (NoSuchMethodException e) {

--- a/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/provider/log/listener/LogFilterListener.java
+++ b/oap-server/analyzer/log-analyzer/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/provider/log/listener/LogFilterListener.java
@@ -48,6 +48,7 @@ import org.apache.skywalking.oap.server.core.source.LogMetadata;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.module.ModuleStartException;
 import org.apache.skywalking.oap.server.library.module.Service;
+import javassist.ClassPool;
 
 /**
  * Runtime listener that executes compiled LAL rules against incoming log data.
@@ -284,7 +285,7 @@ public class LogFilterListener implements LogAnalysisListener {
          * {@code RuleClassLoader} it creates on every compile.
          */
         public CompiledLAL compile(final LALConfig c,
-                                   final javassist.ClassPool pool,
+                                   final ClassPool pool,
                                    final ClassLoader targetClassLoader) throws ModuleStartException {
             final boolean isAuto = LALConfig.LAYER_AUTO.equalsIgnoreCase(c.getLayer());
             final Layer layer = isAuto ? null : Layer.nameOf(c.getLayer());

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/Analyzer.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/Analyzer.java
@@ -73,6 +73,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
+import javassist.ClassPool;
 
 /**
  * Analyzer analyses DSL expression with input samples, then to generate meter-system metrics.
@@ -155,7 +156,7 @@ public class Analyzer {
                                  final String expression,
                                  final MeterSystem meterSystem,
                                  final DslSourceRef sourceRef,
-                                 final javassist.ClassPool pool,
+                                 final ClassPool pool,
                                  final ClassLoader targetClassLoader) {
         final Analyzer analyzer = prepare(
             metricName, filter, expression, meterSystem, sourceRef, pool, targetClassLoader);
@@ -179,7 +180,7 @@ public class Analyzer {
                                     final String expression,
                                     final MeterSystem meterSystem,
                                     final DslSourceRef sourceRef,
-                                    final javassist.ClassPool pool,
+                                    final ClassPool pool,
                                     final ClassLoader targetClassLoader) {
         // Static boot / default path: create-if-absent. Runtime-rule on-demand apply passes
         // withSchemaChange() via the explicit-opt overload.
@@ -197,7 +198,7 @@ public class Analyzer {
                                     final String expression,
                                     final MeterSystem meterSystem,
                                     final DslSourceRef sourceRef,
-                                    final javassist.ClassPool pool,
+                                    final ClassPool pool,
                                     final ClassLoader targetClassLoader,
                                     final StorageManipulationOpt storageOpt) {
         Expression e = DSL.parse(metricName, expression, sourceRef, pool, targetClassLoader);
@@ -239,7 +240,7 @@ public class Analyzer {
     private int[] percentiles;
 
     /** Per-file Javassist pool for runtime-rule hot-update, null on startup path. */
-    private javassist.ClassPool pool;
+    private ClassPool pool;
     /** Per-file target classloader for runtime-rule hot-update, null on startup path. */
     private ClassLoader targetClassLoader;
     /**

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/MetricConvert.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/MetricConvert.java
@@ -42,6 +42,7 @@ import org.apache.skywalking.oap.server.core.dsl.debug.GateHolder;
 import org.apache.skywalking.oap.server.core.storage.model.StorageManipulationOpt;
 
 import static java.util.stream.Collectors.toList;
+import javassist.ClassPool;
 
 /**
  * MetricConvert converts {@link SampleFamily} collection to meter-system metrics, then store them to backend storage.
@@ -89,7 +90,7 @@ public class MetricConvert {
     }
 
     public MetricConvert(final MetricRuleConfig rule, final MeterSystem service,
-                         final javassist.ClassPool pool,
+                         final ClassPool pool,
                          final ClassLoader targetClassLoader) {
         this(rule, service, pool, targetClassLoader,
              StorageManipulationOpt.schemaCreateIfAbsent());
@@ -106,7 +107,7 @@ public class MetricConvert {
      *                   peer-node passes withoutSchemaChange to skip server DDL
      */
     public MetricConvert(final MetricRuleConfig rule, final MeterSystem service,
-                         final javassist.ClassPool pool,
+                         final ClassPool pool,
                          final ClassLoader targetClassLoader,
                          final StorageManipulationOpt storageOpt) {
         Preconditions.checkState(!Strings.isNullOrEmpty(rule.getMetricPrefix()));
@@ -244,7 +245,7 @@ public class MetricConvert {
                            final String exp,
                            final MeterSystem service,
                            final DslSourceRef sourceRef,
-                           final javassist.ClassPool pool,
+                           final ClassPool pool,
                            final ClassLoader targetClassLoader) {
         return Analyzer.build(
             metricsName,
@@ -274,7 +275,7 @@ public class MetricConvert {
                               final String exp,
                               final MeterSystem service,
                               final DslSourceRef sourceRef,
-                              final javassist.ClassPool pool,
+                              final ClassPool pool,
                               final ClassLoader targetClassLoader,
                               final StorageManipulationOpt storageOpt) {
         return Analyzer.prepare(
@@ -290,7 +291,7 @@ public class MetricConvert {
     }
 
     private static FilterExpression buildFilter(final MetricRuleConfig rule,
-                                                final javassist.ClassPool pool,
+                                                final ClassPool pool,
                                                 final ClassLoader targetClassLoader) {
         final String filterText = rule.getFilter();
         if (Strings.isNullOrEmpty(filterText)) {

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/MALBytecodeHelper.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/MALBytecodeHelper.java
@@ -32,6 +32,7 @@ import javassist.bytecode.ConstPool;
 import javassist.bytecode.CodeAttribute;
 import javassist.bytecode.MethodInfo;
 import lombok.extern.slf4j.Slf4j;
+import javassist.bytecode.CodeIterator;
 
 /**
  * Javassist bytecode utilities for MAL-generated classes.
@@ -193,7 +194,7 @@ final class MALBytecodeHelper {
             int boundary = 0;
             boolean nextIsNewLine = true;
 
-            final javassist.bytecode.CodeIterator ci = code.iterator();
+            final CodeIterator ci = code.iterator();
             while (ci.hasNext()) {
                 final int pc = ci.next();
                 if (nextIsNewLine) {

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/MALClassGenerator.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/MALClassGenerator.java
@@ -36,6 +36,9 @@ import org.apache.skywalking.oap.meter.analyzer.v2.dsl.ExpressionMetadata;
 import org.apache.skywalking.oap.meter.analyzer.v2.dsl.MalExpression;
 import org.apache.skywalking.oap.meter.analyzer.v2.dsl.MalFilter;
 import org.apache.skywalking.oap.server.core.dsl.DslJavaSourceText;
+import javassist.CtField;
+import javassist.CtMethod;
+import javassist.LoaderClassPath;
 
 /**
  * Public API for compiling MAL expressions into {@link MalExpression} implementation classes.
@@ -80,7 +83,7 @@ public final class MALClassGenerator {
     private static ClassPool createClassPool() {
         final ClassPool pool = new ClassPool(true);
         pool.appendClassPath(
-            new javassist.LoaderClassPath(
+            new LoaderClassPath(
                 Thread.currentThread().getContextClassLoader()));
         return pool;
     }
@@ -207,7 +210,7 @@ public final class MALClassGenerator {
         final List<String> params = closure.getParams();
         final String paramName = params.isEmpty() ? "it" : params.get(0);
 
-        final javassist.CtMethod testMethod =
+        final CtMethod testMethod =
             CtNewMethod.make(filterBody, ctClass);
         ctClass.addMethod(testMethod);
         DslGeneratedFileWriter.addLocalVariableTable(testMethod, className,
@@ -292,7 +295,7 @@ public final class MALClassGenerator {
         }
 
         for (int i = 0; i < closures.size(); i++) {
-            ctClass.addField(javassist.CtField.make(
+            ctClass.addField(CtField.make(
                 "public static final " + closureInterfaceTypes.get(i) + " "
                     + closureFieldNames.get(i) + ";", ctClass));
         }
@@ -336,7 +339,7 @@ public final class MALClassGenerator {
         }
 
         // 5. Add methods and bytecode attributes
-        final javassist.CtMethod runMethod =
+        final CtMethod runMethod =
             CtNewMethod.make(runBody, ctClass);
         ctClass.addMethod(runMethod);
         bytecodeHelper.addRunLocalVariableTable(
@@ -350,7 +353,7 @@ public final class MALClassGenerator {
             MalGeneratedSourceLines.statementLinesOf(runBody),
             DslGeneratedFileWriter.lineOfMethod(expressionSource, "run"));
 
-        final javassist.CtMethod metaMethod =
+        final CtMethod metaMethod =
             CtNewMethod.make(metadataBody, ctClass);
         ctClass.addMethod(metaMethod);
         DslGeneratedFileWriter.addLocalVariableTable(metaMethod, className,
@@ -415,7 +418,7 @@ public final class MALClassGenerator {
      * call sites that read the field directly. The constructor arg is the
      * configured {@link #content}, escaped as a Java string literal.
      */
-    private void emitDebugHolderMembers(final CtClass ctClass) throws javassist.CannotCompileException {
+    private void emitDebugHolderMembers(final CtClass ctClass) throws CannotCompileException {
         if (!org.apache.skywalking.oap.server.core.dsl.debug.DSLDebugCodegenSwitch.isInjectionEnabled()) {
             // Injection off — generated class inherits MalExpression.debugHolder()'s
             // default null return, no GateHolder field is emitted, and the captureXxx
@@ -427,7 +430,7 @@ public final class MALClassGenerator {
         final String escapedContent = DslJavaSourceText.toLiteral(content);
         // Per-rule capture binding — instance field, lowercase per Java
         // convention (it's a final but not a static-final constant).
-        ctClass.addField(javassist.CtField.make(
+        ctClass.addField(CtField.make(
             "public final " + holderFqcn + " debug = new " + holderFqcn
                 + "(\"" + escapedContent + "\");",
             ctClass));

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/MALClosureCodegen.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/MALClosureCodegen.java
@@ -25,6 +25,7 @@ import javassist.CtNewConstructor;
 import javassist.CtNewMethod;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.server.core.dsl.DslJavaSourceText;
+import javassist.CtMethod;
 
 /**
  * Generates closure classes for MAL expressions using Javassist bytecode generation.
@@ -625,7 +626,7 @@ final class MALClosureCodegen {
         if (log.isDebugEnabled()) {
             log.debug("Companion class [{}] apply():\n{}", companionName, methodBody);
         }
-        final javassist.CtMethod m = CtNewMethod.make(methodBody, companion);
+        final CtMethod m = CtNewMethod.make(methodBody, companion);
         companion.addMethod(m);
         addCompanionLocalVariableTable(m, info);
         // A companion is its own class file, so it carries its own coordinates: its own .java and
@@ -717,7 +718,7 @@ final class MALClosureCodegen {
         return sb.toString();
     }
 
-    private void addCompanionLocalVariableTable(final javassist.CtMethod m,
+    private void addCompanionLocalVariableTable(final CtMethod m,
                                                 final ClosureInfo info) {
         final List<String> params = info.closure.getParams();
         if (MALCodegenHelper.FOR_EACH_FUNCTION_TYPE.equals(info.interfaceType)) {

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/MALCodegenHelper.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/MALCodegenHelper.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.skywalking.oap.server.core.dsl.debug.DSLDebugCodegenSwitch;
 import org.apache.skywalking.oap.server.core.dsl.DslJavaSourceText;
+import java.lang.reflect.Method;
 
 /**
  * Static utility methods and constants shared across MAL code generation classes.
@@ -231,7 +232,7 @@ final class MALCodegenHelper {
         if (lastMethodName == null) {
             return false;
         }
-        for (final java.lang.reflect.Method m : String.class.getMethods()) {
+        for (final Method m : String.class.getMethods()) {
             if (m.getName().equals(lastMethodName)
                     && m.getReturnType() == boolean.class) {
                 return true;

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/rt/MalExtensionRegistry.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/compiler/rt/MalExtensionRegistry.java
@@ -28,6 +28,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.oap.meter.analyzer.v2.dsl.SampleFamily;
 import org.apache.skywalking.oap.meter.analyzer.v2.spi.MALContextFunction;
 import org.apache.skywalking.oap.meter.analyzer.v2.spi.MalFunctionExtension;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
 
 /**
  * Compile-time registry for MAL extension functions discovered via SPI.
@@ -92,12 +95,12 @@ public final class MalExtensionRegistry {
             final Class<?>[] extraParamTypes = new Class<?>[paramTypes.length - 1];
             System.arraycopy(paramTypes, 1, extraParamTypes, 0, extraParamTypes.length);
             // Validate List params use List<String> (the only List type MAL supports)
-            final java.lang.reflect.Type[] genericTypes = m.getGenericParameterTypes();
+            final Type[] genericTypes = m.getGenericParameterTypes();
             for (int i = 1; i < genericTypes.length; i++) {
-                if (java.util.List.class.isAssignableFrom(extraParamTypes[i - 1])
-                        && genericTypes[i] instanceof java.lang.reflect.ParameterizedType) {
-                    final java.lang.reflect.Type elementType =
-                        ((java.lang.reflect.ParameterizedType) genericTypes[i])
+                if (List.class.isAssignableFrom(extraParamTypes[i - 1])
+                        && genericTypes[i] instanceof ParameterizedType) {
+                    final Type elementType =
+                        ((ParameterizedType) genericTypes[i])
                             .getActualTypeArguments()[0];
                     if (!String.class.equals(elementType)) {
                         throw new IllegalArgumentException(

--- a/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/prometheus/rule/Rules.java
+++ b/oap-server/analyzer/meter-analyzer/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/prometheus/rule/Rules.java
@@ -44,6 +44,7 @@ import org.apache.skywalking.oap.server.library.util.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
+import java.util.Objects;
 
 /**
  * Rules is factory to instance {@link Rule} from a local file.
@@ -143,7 +144,7 @@ public class Rules {
 
         return merged.entrySet().stream()
             .map(e -> parseRule(path, e.getKey(), diskPaths.get(e.getKey()), e.getValue()))
-            .filter(java.util.Objects::nonNull)
+            .filter(Objects::nonNull)
             .collect(Collectors.toList());
     }
 

--- a/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/v2/generator/OALClassGeneratorV2.java
+++ b/oap-server/oal-rt/src/main/java/org/apache/skywalking/oal/v2/generator/OALClassGeneratorV2.java
@@ -471,7 +471,7 @@ public class OALClassGeneratorV2 {
                     // stamped with {ruleName, sourceLine} at instance-init time
                     // — the dsl-debugging records carry a structured per-rule
                     // envelope alongside the verbatim dsl source.
-                    dispatcherClass.addField(javassist.CtField.make(
+                    dispatcherClass.addField(CtField.make(
                         "public final " + holderFqcn + " debug_" + metric.getTableName()
                             + " = " + holderFqcn + ".withMetadata(\""
                             + perMetricContent + "\", \""

--- a/oap-server/oal-rt/src/main/resources/code-templates-v2/CLAUDE.md
+++ b/oap-server/oal-rt/src/main/resources/code-templates-v2/CLAUDE.md
@@ -1,0 +1,13 @@
+# OAL code templates — always fully qualify
+
+These `.ftl` files render **generated Java source**, compiled by Javassist, not javac.
+
+**Javassist's compiler has no `import` statement.** It resolves a simple class name only against
+`ClassPool.importedPackages`, which holds `java.lang` and nothing else. So every class named here
+must be fully qualified — `java.util.Map`, `org.apache.skywalking...GateHolder`, all of it.
+
+Shortening one to look tidier still renders, still compiles the surrounding Java, and then fails at
+runtime when the rule is compiled. The project's "no inline fully-qualified class names" rule is
+about hand-written Java and does not apply to this directory.
+
+Same rule for FQCNs inside codegen string literals in the MAL / LAL / Hierarchy generators.


### PR DESCRIPTION
### Use imports instead of inline fully-qualified names in the DSL compilers

`CLAUDE.md` bans fully-qualified class names written inline where an import would do, and names the
exact form found here:

> *Field declarations, method signatures, local variables, and generic type arguments should always
> use the imported short name — `private RemoteClientManager rcm;`, not
> `private org.apache.skywalking...RemoteClientManager rcm;`*

`Analyzer.java:242` was literally `private javassist.ClassPool pool;`. 44 sites across 14 files in
the four DSL modules: parameter and field types, locals, `throws` clauses, static calls, a class
literal and a method reference.

#### The part that needed care

**Every site changed is a name the compiler resolves. Nothing resolved at runtime was touched.**

That distinction is the whole risk. Javassist's compiler has no `import` statement — it resolves a
simple class name only against `ClassPool.importedPackages`, which holds `java.lang` and nothing
else. A fully-qualified name inside generated source is therefore mandatory, and shortening one
still compiles as Java, then fails when the rule is compiled. The same applies to anything handed
to `Class.forName`.

So this PR deliberately did **not** touch:

- FQCNs inside codegen string literals (MAL/LAL/Hierarchy generators)
- anything under `code-templates-v2/*.ftl`
- names resolved reflectively

The transform rewrote only lines containing no quote character. That is sufficient rather than
merely convenient: a Java string literal cannot span lines under JDK 11, so a line with no quote
cannot be inside one. Verified after the fact — `git diff` shows no changed line contains a quote,
and no `.ftl` is modified.

Simple-name collisions and in-file shadowing were checked before any import was added. There were
none, so no site had to be left qualified for ambiguity.

#### Documentation

Adds a short `CLAUDE.md` to `code-templates-v2/`. The rule already exists in the root `CLAUDE.md`,
but the templates are the weakest spot: they are not Java, so a reader editing one has no reason to
consult a Java style rule, and "tidying" an FQCN there breaks the OAP only at rule-compile time.

- [x] Explain briefly why the bug exists and how to fix it.
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.

No changelog entry: no behaviour change, no user-visible surface.
