### PR TITLE
Point the APISIX guide at the deployed rules file and document the service.name trap

### DIFF
--- a/docs/en/setup/backend/backend-apisix-monitoring.md
+++ b/docs/en/setup/backend/backend-apisix-monitoring.md
@@ -40,6 +40,8 @@ receivers:
 
 Keep `job_name: apisix-monitoring` unless you also update the APISIX MAL filter in OAP. If `skywalking_service` is absent or blank, the MAL rule uses `APISIX`, resulting in the default service name `APISIX::APISIX`.
 
+Do **not** use the OpenTelemetry `service.name` resource attribute to name the service. The Collector's Prometheus receiver converts the Prometheus `job` label into `service.name`, and the SkyWalking OpenTelemetry receiver maps `service.name` back to `job_name` — the very label the APISIX MAL rule filters on. Setting `service.name` therefore changes the filter key rather than the service name, and the rule stops matching, so no APISIX metrics are produced. `skywalking_service` exists precisely because `service.name` is already taken.
+
 #### Supported metrics
 
 | Monitoring Panel | Unit | Metric Name | Catalog | Description | Data Source |
@@ -72,6 +74,8 @@ For Dashboard widget semantics and display units, see the Horizon UI [APISIX Das
 
 ### Customizations
 
-The APISIX metric definitions and expressions are in [`oap-server/server-starter/src/main/resources/otel-rules/apisix.yaml`](../../../../oap-server/server-starter/src/main/resources/otel-rules/apisix.yaml).
+The APISIX metric definitions and expressions are in `/config/otel-rules/apisix.yaml` of your OAP installation. In the source tree the same file is [`oap-server/server-starter/src/main/resources/otel-rules/apisix.yaml`](../../../../oap-server/server-starter/src/main/resources/otel-rules/apisix.yaml).
+
+Each metric name in the table above is the rule's `metricPrefix` (`meter_apisix`) joined to the `name` of its entry in that file — the entry named `sv_http_requests` produces `meter_apisix_sv_http_requests`.
 
 The Horizon UI bundled APISIX Dashboard is maintained in the [`apache/skywalking-horizon-ui`](https://github.com/apache/skywalking-horizon-ui) repository; the OAP backend no longer hosts the UI Dashboard JSON.


### PR DESCRIPTION
### Fix two gaps left in the APISIX monitoring guide after #13976

- [x] Add a unit test to verify that the fix works. (Not applicable — documentation only. Every claim was verified against the source; see below.)
- [x] Explain briefly why the bug exists and how to fix it.

#### 1. Customization pointed at the source tree, not the deployed file

#13976 replaced `` `/config/otel-rules/apisix.yaml` `` with a repo-relative link into `oap-server/server-starter/src/main/resources/`. An operator customizing an installation edits the deployed copy — `apm-dist/src/main/assembly/binary.xml:71` packages `otel-rules/**` into `config/` — and every other monitoring guide that names its rules file uses the deployed path (`vm.yaml`, `windows.yaml`, the three `nginx-*.yaml`). No doc links into the source tree.

The deployed path is named first, with the source link kept alongside for contributors.

#### 2. The `service.name` trap was undocumented

Nothing explained why a custom `skywalking_service` label exists when OpenTelemetry already has a standard attribute for service identity. The reason is that the standard one is already taken:

- the Collector's Prometheus receiver converts the Prometheus `job` label into the `service.name` resource attribute;
- `OpenTelemetryMetricRequestProcessor` maps `service.name` back to `job_name` (`FALLBACK_LABEL_MAPPINGS`, line 103);
- the APISIX MAL rule filters on exactly that label — `filter: "{ tags -> tags.job_name == 'apisix-monitoring' }"` (`apisix.yaml:31`).

So setting `service.name` to name an APISIX service changes the **filter key** rather than the service name. The rule stops matching and no APISIX metrics are produced — silently, with nothing in the docs to explain it. Reaching for the OTel-idiomatic attribute is the obvious move, which makes this worth stating explicitly.

#### Also

One line recording that each metric name in the table is the rule's `metricPrefix` (`meter_apisix`) joined to its entry's `name`, so a reader who opens `apisix.yaml` can connect `sv_http_requests` to `meter_apisix_sv_http_requests`.

#### No changelog entry

This corrects #13976, which is itself unreleased in 11.0.0. That PR's existing `#### Documentation` entry already tells the release reader the APISIX guide was corrected; a second line for a fix to an unreleased change would only add noise.

#### Verification

- `apm-dist/src/main/assembly/binary.xml:71` includes `otel-rules/**`, confirming the deployed `config/otel-rules/` path
- `OpenTelemetryMetricRequestProcessor.java:103` — `.put("service.name", "job_name")`
- `otel-rules/apisix.yaml:31` — the `job_name` filter; `:34` — `metricPrefix: meter_apisix`
- the relative link to the source file resolves
- `license-eye header check` → 0 invalid across 4998 files

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. (Not applicable.)
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking/blob/master/docs/en/changes/changes.md). (Deliberately not updated — see above.)